### PR TITLE
fix(ssh,tests): harden ssh argv handling + drop env-var race in mocks

### DIFF
--- a/src/app/patch.rs
+++ b/src/app/patch.rs
@@ -505,6 +505,15 @@ impl Orchestrator {
 
             // 1. Confirm the node went down at least once. The `/nodes`
             //    list reflects cluster-level liveness.
+            //
+            // We intentionally swallow API errors here: this loop is
+            // designed to outlast a reboot, so transient TCP/TLS
+            // failures while the cluster is reconverging are EXPECTED.
+            // An empty list ⇒ no `node_entry` ⇒ `online = false`,
+            // which is exactly the signal the rest of the loop reads
+            // ("treat unreachable as offline, keep polling"). A bubbled
+            // error here would abort the whole upgrade orchestration on
+            // the first dropped packet — bug, not safety.
             let nodes = self.api.get_nodes().await.unwrap_or_default();
             let node_entry = nodes.iter().find(|n| n.node == node);
             let online =

--- a/src/app/preflight.rs
+++ b/src/app/preflight.rs
@@ -874,7 +874,10 @@ tcp   0      0      :::443                  :::*                    LISTEN
     //   4. an empty backup list yields Ok(None)
 
     async fn mock_pxclient(server: &wiremock::MockServer) -> crate::api::PxClient {
-        std::env::set_var("PROXXX_TOKEN_SECRET", "fake-secret");
+        // Pass the secret via the cli_secret parameter (resolver priority
+        // #1) rather than std::env::set_var. Env vars are process-global
+        // and cargo runs unit tests in parallel — set_var here would race
+        // with any concurrently-running test that reads PROXXX_TOKEN_SECRET.
         let cfg = crate::config::ProfileConfig {
             url: server.uri(),
             user: "root@pam".into(),
@@ -891,7 +894,9 @@ tcp   0      0      :::443                  :::*                    LISTEN
             pbs: None,
             alerts: None,
         };
-        crate::api::PxClient::new(cfg, None).await.expect("client")
+        crate::api::PxClient::new(cfg, Some("fake-secret"))
+            .await
+            .expect("client")
     }
 
     #[tokio::test]

--- a/src/cli/init_wizard.rs
+++ b/src/cli/init_wizard.rs
@@ -790,6 +790,16 @@ fn api_host_only(url: &str) -> Option<String> {
 
 fn probe_ssh(user: &str, host: &str, key_path: &str) -> Result<String> {
     use std::process::Command;
+    // Refuse hostile/typo'd destinations BEFORE shelling out, so the
+    // wizard fails fast with a clear message instead of OpenSSH's
+    // cryptic "command-line option not recognised" (CWE-88).
+    if let Err(why) = crate::config::validate_ssh_destination(user, host) {
+        anyhow::bail!("refusing to ssh: {why}");
+    }
+    // `--` ends option processing before `user@host`: defense-in-depth
+    // so a host string starting with `-` can't be parsed as a flag
+    // (CWE-88). The remote command must come AFTER the destination —
+    // openssh keeps it as a positional even past `--`.
     let out = Command::new("ssh")
         .args([
             "-o",
@@ -802,6 +812,7 @@ fn probe_ssh(user: &str, host: &str, key_path: &str) -> Result<String> {
             "LogLevel=ERROR",
             "-i",
             key_path,
+            "--",
             &format!("{user}@{host}"),
             "uname -a",
         ])

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4141,6 +4141,21 @@ async fn execute_ssh(
             }
         }
     };
+    // Last-line-of-defense validation BEFORE we spawn ssh. The config
+    // and QGA paths above can each yield a target, but a tampered TOML
+    // or a hostile QGA reply could still smuggle a leading `-` or an
+    // embedded `@`. Refuse here with a paste-ready diagnostic instead
+    // of relying solely on the `--` separator below (CWE-88).
+    if let Err(why) = crate::config::validate_ssh_destination(&target.user, &target.host) {
+        anyhow::bail!(
+            "refusing to ssh: {why}\n\
+             source: {source}\n\
+             target: user={:?} host={:?}\n\
+             Edit [ssh] / [ssh.guests.\"{vmid}\"] in config.toml to fix.",
+            target.user,
+            target.host,
+        );
+    }
     eprintln!(
         "\x1b[2m[ssh] resolved {}@{}:{} (source: {source})\x1b[0m",
         target.user, target.host, target.port
@@ -4149,12 +4164,18 @@ async fn execute_ssh(
     // Spawn the system `ssh`. Sharing stdin/stdout/stderr with the
     // parent gives a true terminal handoff — no extra PTY layer, no
     // double key forwarding. The child inherits TERM, LANG, etc.
+    //
+    // The `--` separator before `user@host` is defense-in-depth against
+    // argv injection: a misconfigured/poisoned `host` starting with `-`
+    // (e.g. `-oProxyCommand=…`) would otherwise be parsed by ssh as a
+    // flag. POSIX `--` ends option processing.
     let mut cmd_builder = std::process::Command::new("ssh");
     cmd_builder
         .arg("-i")
         .arg(&target.key_path)
         .arg("-p")
         .arg(target.port.to_string())
+        .arg("--")
         .arg(format!("{}@{}", target.user, target.host));
     if let Some(c) = cmd {
         cmd_builder.arg(c);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -390,6 +390,88 @@ pub struct ResolvedGuestSsh {
     pub key_path: std::path::PathBuf,
 }
 
+/// Reject SSH user/host strings that would be parsed by `ssh(1)` as
+/// flags or that would smuggle a different destination through the
+/// `user@host` positional. Defense-in-depth even with `--`: the
+/// `--`-separator stops flag parsing in the binary, but a leading `-`
+/// in `host` or `@` in `user` still indicates a config that's been
+/// tampered with or fat-fingered, and "ssh -- -oProxyCommand=…" is
+/// unsafe on shells that auto-complete around `--` (CWE-88).
+///
+/// Returns `Err(reason)` so callers can surface an actionable message.
+pub fn validate_ssh_destination(user: &str, host: &str) -> std::result::Result<(), String> {
+    if user.is_empty() {
+        return Err("ssh user is empty".into());
+    }
+    if host.is_empty() {
+        return Err("ssh host is empty".into());
+    }
+    // Leading `-` would be parsed as a flag if the destination ever
+    // ends up before `--` (e.g. via a future call site that forgets
+    // the separator). Refuse at the source.
+    if user.starts_with('-') {
+        return Err(format!("ssh user starts with '-': {user:?}"));
+    }
+    if host.starts_with('-') {
+        return Err(format!("ssh host starts with '-': {host:?}"));
+    }
+    // `@` in the user collapses `user@host` parsing — ssh keeps the
+    // last `@` as the separator, so `user="a@b", host="c"` becomes
+    // destination `b@c` and silently changes target.
+    if user.contains('@') {
+        return Err(format!("ssh user contains '@': {user:?}"));
+    }
+    // Whitespace and NUL would survive into argv but break shell
+    // composition for the few internal callers that quote into
+    // log/diagnostic strings.
+    let bad = |c: char| c.is_whitespace() || c == '\0';
+    if user.contains(bad) {
+        return Err(format!("ssh user contains whitespace/NUL: {user:?}"));
+    }
+    if host.contains(bad) {
+        return Err(format!("ssh host contains whitespace/NUL: {host:?}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod ssh_validation_tests {
+    use super::validate_ssh_destination;
+
+    #[test]
+    fn accepts_normal_destination() {
+        assert!(validate_ssh_destination("root", "10.0.0.1").is_ok());
+        assert!(validate_ssh_destination("ops", "pve.lab").is_ok());
+    }
+
+    #[test]
+    fn rejects_leading_dash_host() {
+        assert!(validate_ssh_destination("root", "-oProxyCommand=evil").is_err());
+    }
+
+    #[test]
+    fn rejects_leading_dash_user() {
+        assert!(validate_ssh_destination("-l", "host").is_err());
+    }
+
+    #[test]
+    fn rejects_at_in_user() {
+        assert!(validate_ssh_destination("user@other", "host").is_err());
+    }
+
+    #[test]
+    fn rejects_whitespace_or_nul() {
+        assert!(validate_ssh_destination("ro ot", "h").is_err());
+        assert!(validate_ssh_destination("root", "h\0ost").is_err());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_ssh_destination("", "host").is_err());
+        assert!(validate_ssh_destination("user", "").is_err());
+    }
+}
+
 impl SshConfig {
     /// Look up a guest's connection target by VMID, applying parent fallbacks.
     /// Returns `None` if the guest isn't configured AND there's no auto-discovery

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -27,9 +27,13 @@ mod tests {
     }
 
     async fn mock_client(server: &MockServer) -> PxClient {
-        // Use a token-auth profile pointing at the mock server. Token
-        // secret comes from env so we don't read filesystem keychain.
-        std::env::set_var("PROXXX_TOKEN_SECRET", "fake-secret");
+        // Pass the secret via the cli_secret parameter (resolver priority
+        // #1) instead of `std::env::set_var`. Env vars are process-global
+        // and cargo runs integration tests in parallel — set_var would
+        // race with any other test reading PROXXX_TOKEN_SECRET. The token
+        // also stays out of the keychain code path because cli_secret
+        // short-circuits the resolver before it consults env / file /
+        // keychain.
         let cfg = ProfileConfig {
             url: server.uri(),
             user: "root@pam".into(),
@@ -46,7 +50,9 @@ mod tests {
             pbs: None,
             alerts: None,
         };
-        PxClient::new(cfg, None).await.expect("client builds")
+        PxClient::new(cfg, Some("fake-secret"))
+            .await
+            .expect("client builds")
     }
 
     // ── Bug #1: LXC routing ─────────────────────────────────

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -111,9 +111,14 @@ impl E2eEnv {
     /// fallback in E2E to keep the test deterministic).
     pub async fn build_client(&self) -> Result<Arc<PxClient>> {
         // We construct a `ProfileConfig` directly rather than going
-        // through the TOML loader — the env IS the source of truth
-        // for E2E and we don't want to touch ~/.config/proxxx.
-        std::env::set_var("PROXXX_TOKEN_SECRET", &self.token_secret);
+        // through the TOML loader — the E2E env IS the source of truth
+        // and we don't want to touch ~/.config/proxxx.
+        //
+        // The token secret is passed via cli_secret (resolver priority
+        // #1) instead of being injected through PROXXX_TOKEN_SECRET. The
+        // env-var path is process-global; with concurrent test binaries
+        // sharing a parent shell environment, a stale set_var can leak
+        // into a sibling suite that legitimately wants the env empty.
         let cfg = proxxx::config::ProfileConfig {
             url: self.api_url.clone(),
             user: self.user.clone(),
@@ -130,7 +135,7 @@ impl E2eEnv {
             pbs: None,
             alerts: None,
         };
-        let client = PxClient::new(cfg, None)
+        let client = PxClient::new(cfg, Some(&self.token_secret))
             .await
             .context("PxClient::new from E2E env")?;
         Ok(Arc::new(client))

--- a/tests/rbac_e2e.rs
+++ b/tests/rbac_e2e.rs
@@ -60,7 +60,10 @@ use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 /// flows into the configured profile so the client picks the right auth
 /// header shape (token-auth uses the user as the principal).
 async fn persona_client(server: &MockServer, user: &str) -> PxClient {
-    std::env::set_var("PROXXX_TOKEN_SECRET", "fake-secret");
+    // Pass the secret as cli_secret (resolver priority #1) instead of
+    // mutating PROXXX_TOKEN_SECRET. Env state is process-global and
+    // cargo runs integration tests in parallel — set_var would race
+    // with any test that observes the env var.
     let cfg = ProfileConfig {
         url: server.uri(),
         user: user.into(),
@@ -77,7 +80,9 @@ async fn persona_client(server: &MockServer, user: &str) -> PxClient {
         pbs: None,
         alerts: None,
     };
-    PxClient::new(cfg, None).await.expect("client builds")
+    PxClient::new(cfg, Some("fake-secret"))
+        .await
+        .expect("client builds")
 }
 
 /// Stock 403 response in PVE's standard envelope.

--- a/tests/rbac_live.rs
+++ b/tests/rbac_live.rs
@@ -84,9 +84,12 @@ impl RbacEnv {
     }
 
     async fn client_for(&self, user: &str, secret: &str) -> Result<Arc<PxClient>> {
-        // Per-test secret injection via env var. Each test runs serial,
-        // so the env doesn't race; PxClient reads it once at build.
-        std::env::set_var("PROXXX_TOKEN_SECRET", secret);
+        // Pass the secret as cli_secret (resolver priority #1). The
+        // serial annotation already removes intra-suite race risk, but
+        // avoiding set_var also keeps env state clean for tests in
+        // OTHER suites that share the same cargo-test process — and
+        // means a hot-loop test no longer hands the secret to siblings
+        // through process-global state.
         let cfg = ProfileConfig {
             url: self.api_url.clone(),
             user: user.into(),
@@ -103,7 +106,7 @@ impl RbacEnv {
             pbs: None,
             alerts: None,
         };
-        Ok(Arc::new(PxClient::new(cfg, None).await?))
+        Ok(Arc::new(PxClient::new(cfg, Some(secret)).await?))
     }
 
     async fn operator(&self) -> Result<Arc<PxClient>> {


### PR DESCRIPTION
## Summary

- **ssh argv injection (CWE-88)** — \`execute_ssh\` ([src/cli/mod.rs](src/cli/mod.rs)) and \`probe_ssh\` ([src/cli/init_wizard.rs](src/cli/init_wizard.rs)) now refuse destinations with a leading \`-\`, embedded \`@\` in user, whitespace, NUL, or empty strings, and append a POSIX \`--\` separator before \`user@host\`. Shared validator \`config::validate_ssh_destination\` covers both sites + 6 unit tests.
- **Test env-var race** — replaced \`std::env::set_var(\"PROXXX_TOKEN_SECRET\", …)\` in 5 test-mock builders ([src/app/preflight.rs](src/app/preflight.rs), [tests/api_test.rs](tests/api_test.rs), [tests/common/mod.rs](tests/common/mod.rs), [tests/rbac_e2e.rs](tests/rbac_e2e.rs), [tests/rbac_live.rs](tests/rbac_live.rs)) with the \`cli_secret\` parameter (resolver priority #1). Removes the only parallel-test data race in the suite.
- **Clarify intentional error swallow** — \`wait_for_reboot\` poll loop in [src/app/patch.rs](src/app/patch.rs): \`unwrap_or_default()\` is correct (transient API errors during reboot should re-poll, not abort), but read as a bug. Comment explains.

## Test plan

- [x] \`cargo build --all-targets\` clean
- [x] \`cargo clippy --all-targets\` zero warnings
- [x] \`cargo test --lib\` — 293/293 pass
- [x] \`cargo test --tests\` — 17 integration suites pass; 16 ignored are live-cluster / live-SSH gated
- [ ] CI gate (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)