### PR TITLE
ci: explicit permissions — fix OpenSSF Scorecard TokenPermissions alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ on:
     # commit time.
     - cron: "17 4 * * *"
 
+# Minimal top-level permissions — satisfy OpenSSF Scorecard TokenPermissions.
+# Individual jobs that need write access declare it explicitly below.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,10 @@ on:
 #                         pins the issuer + workflow path so a leaked
 #                         cert from another repo can't validate against
 #                         our bundles.
+# Minimal top-level permissions — satisfy OpenSSF Scorecard TokenPermissions.
+# contents:write and id-token:write are scoped to the jobs that need them.
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   # ──────────────────────────────────────────────────────────
@@ -190,6 +191,9 @@ jobs:
     name: Publish GitHub release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create GitHub release + upload assets
+      id-token: write   # sigstore OIDC keyless signing
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 


### PR DESCRIPTION
## Summary

- `ci.yml`: add top-level `permissions: contents: read` (all jobs are read-only)
- `release.yml`: drop top-level `contents: write` + `id-token: write` to read-only default; scope write permissions to the `release` job only

Closes 2 of 11 OpenSSF Scorecard `TokenPermissions` alerts in the code-scanning dashboard.

The remaining 9 alerts (`PinnedDependencies` on live test scripts, `BranchProtection`, `SAST`, etc.) are either false positives or require external configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)