### PR TITLE
docs(home): homepage audit — fix stale facts, CTAs, badge, image stretch

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -56,25 +56,6 @@
   align-items: flex-start;
 }
 
-.VPHero .name {
-  display: inline-block;
-  font-family: var(--vp-font-family-mono);
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1.4;
-  letter-spacing: 0;
-  color: var(--vp-c-text-2);
-  background: var(--vp-c-bg-soft);
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 5px;
-  padding: 5px 10px;
-  margin: 0 0 28px 0;
-}
-.VPHero .name::before {
-  content: '◆ ';
-  color: var(--vp-c-brand-1);
-  margin-right: 2px;
-}
 
 .VPHero .text {
   font-size: 64px;
@@ -127,6 +108,7 @@
   border: 1px solid var(--vp-c-divider);
   max-width: 100%;
   height: auto;
+  object-fit: contain;
   /* Multi-layer ambient shadow + brand-tinted ring (light tone). */
   box-shadow:
     0 1px 2px rgba(15, 23, 42, 0.04),

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,6 @@
 layout: home
 
 hero:
-  name: proxxx
   text: Terminal cockpit for Proxmox VE & PBS.
   tagline: A Rust TUI and CLI that talks to real Proxmox clusters. REST against PVE and PBS, SSH for the rest. No agent on the cluster.
   # Animated SVG slideshow mirroring the README hero (assets/demo.svg).
@@ -15,10 +14,10 @@ hero:
     alt: proxxx animated demo — a destructive command refused by the pre-flight risk gate, approved via Telegram HITL, then executed
   actions:
     - theme: brand
-      text: Get started
+      text: Install in 60 s
       link: /guide/installation
     - theme: alt
-      text: Quick start
+      text: 5-min quickstart
       link: /guide/quick-start
     - theme: alt
       text: GitHub
@@ -32,7 +31,7 @@ features:
   - title: Six-stage commit gate, no skip flags
     details: cargo fmt, cargo clippy --all-targets at deny tier, cargo audit against a pinned advisory policy, the full test suite, 87 read-only probes against a live cluster, and a full mutation lifecycle covering LXC, cluster-level CRUD, QEMU, and opt-in QGA agent-required round-trips. Every commit on main passes locally and in CI.
   - title: Pre-flight risk gate plus HITL
-    details: 11 risk variants — running, locked, HA-managed, tagged prod, listening on service, no recent backup — refuse destructive operations on guests that look like production unless overridden explicitly. Above that, a real Telegram round-trip with deny-on-timeout for any op marked destructive by policy.
+    details: 11 risk variants — running, long-uptime, locked, HA-managed, tagged prod, active net traffic, listening on service, many snapshots, backup age warning, no backup found, deep-check skipped — refuse destructive operations on guests that look like production unless overridden explicitly. Above that, a real Telegram round-trip with deny-on-timeout for any op marked destructive by policy.
 ---
 
 <script setup>
@@ -95,7 +94,7 @@ onMounted(() => {
 
 <div class="status-row">
   <span><span class="ok">●</span> <strong>main</strong> · gate green</span>
-  <span><strong>v0.1.7</strong></span>
+  <span><strong>v0.1.26</strong></span>
   <span><strong>full mutation lifecycle</strong> · LXC + cluster + QEMU + QGA</span>
   <span><strong>0</strong> system deps · rustls only</span>
   <span><strong>MIT</strong></span>


### PR DESCRIPTION
## Summary

- **Remove `◆ proxxx` badge** from hero (`name:` field + CSS rule)
- **Fix image stretch** — add `object-fit: contain` to `.VPHero img`
- **Better CTAs** — "Get started" → "Install in 60 s", "Quick start" → "5-min quickstart"
- **Version fix** — status row was showing `v0.1.7`, now `v0.1.26`
- **KLOC update** — `~28/~5` → `~44/~14` (verified with `wc -l`)
- **Risk variants** — HITL card listed 6/11; now lists all 11
- **"A taste"** — add `snapshot rollback` (landed in v0.1.24)

## Test plan

- [ ] `npm run dev` in `docs/` — verify hero has no badge chip
- [ ] Hero image renders without stretch on desktop and mobile
- [ ] CTA buttons show "Install in 60 s" and "5-min quickstart"
- [ ] Status row shows `v0.1.26`
- [ ] Feature card HITL lists all 11 risk variants
- [ ] "By the numbers" table shows ~44 KLOC / ~14 KLOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)