### PR TITLE
feat(clone): cloud-init customization at clone time + MCP clone_with_cloudinit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ SemVer contract:
 - **MCP tool `create_guest`** (tool #23) — LLM-callable guest creation for both
   QEMU and LXC; node, type, name, memory, cores, storage, disk_size, template/iso,
   bridge. Registry SHA-256 updated; counter 22→23.
+- **Real-time event stream** — `proxxx events stream` polls cluster task
+  queues and prints new task starts/completions as they appear (STARTED /
+  DONE / FAIL). Supports `--node`, `--type`, `--vmid` filters, `--interval`
+  (default 2 s), and `--format json` for NDJSON piping. Shows currently-running
+  tasks at startup; `--no-existing` skips the snapshot.
+- **MCP tool `list_cluster_events`** (tool #24) — returns recent cluster-wide
+  task events with elapsed time; `limit` (default 50) and `running_only` params.
 - **Config hot-reload** — `SIGHUP` atomically swaps the live config in the
   `alerts watch`, `mcp serve`, and `mcp serve-http` daemons. After `kill -HUP
   $(pgrep proxxx)`, the next tick/request picks up new `[[alerts]]` rules,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ SemVer contract:
   (`"Parameter 'guest_id': expected integer, got \"abc\""`) rather than
   silently misrouting the value.
 - **EU & compliance section** in README — NIS2/ISO 27001/GDPR alignment table.
+- **Cloud-init clone** — `proxxx clone <src> --cloud-init-user <file.toml>`
+  parses a TOML profile (ciuser, cipassword, sshkey/sshkey_file, ipconfig0,
+  searchdomain, nameserver), waits for the clone task to land, then applies
+  the cloud-init fields and regenerates the drive. Canonical IaC pattern in
+  one command — no more clone → set → regen dance.
+- **MCP tool `clone_with_cloudinit`** (tool #25) — same flow callable by LLMs
+  with inline params (no file). QEMU-only; LXC is rejected explicitly.
+  Registry SHA-256 updated; counter 24→25.
 
 ## [0.1.27] — 2026-05-14
 

--- a/src/cli/events.rs
+++ b/src/cli/events.rs
@@ -1,0 +1,268 @@
+// Real-time cluster event stream.
+//
+// Polls `/cluster/tasks` (or `/nodes/{node}/tasks` when --node is set) at a
+// configurable interval and emits events for:
+//   - RUNNING  — tasks already in progress when the stream starts (shown once
+//                at startup unless --no-existing is passed)
+//   - START    — a new task appeared since the last poll
+//   - DONE     — a previously running task completed with exitstatus "OK"
+//   - FAIL     — a previously running task completed with a non-OK status
+//   - FINISH   — same as DONE/FAIL when the task appeared already completed
+//                (started + finished between two polls)
+//
+// PVE has no native server-sent-events or WebSocket task feed, so this is
+// a pull-poll stream.  2 s default interval gives sub-4 s visibility on
+// fast task completions without hammering the API.
+
+use anyhow::Result;
+use clap::Subcommand;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::api::types::TaskInfo;
+use crate::api::{ProxmoxGateway, PxClient};
+
+#[derive(Debug, Subcommand)]
+pub enum EventsCommand {
+    /// Stream cluster task events in real-time.
+    ///
+    /// Shows a live feed of task starts and completions across all nodes
+    /// (or one node with --node). Press Ctrl-C or send SIGTERM to stop.
+    ///
+    /// Examples:
+    ///   proxxx events stream
+    ///   proxxx events stream --node pve1 --type qmmigrate
+    ///   proxxx events stream --format json | jq 'select(.event=="FAIL")'
+    Stream {
+        /// Poll interval in seconds (default 2, minimum 1)
+        #[arg(long, default_value_t = 2)]
+        interval: u64,
+        /// Watch only this node (default: all nodes)
+        #[arg(long)]
+        node: Option<String>,
+        /// Filter by task type substring (e.g. qmstart, qmstop, qmmigrate,
+        /// vzdump, qmclone). Case-insensitive.
+        #[arg(long, value_name = "TYPE")]
+        r#type: Option<String>,
+        /// Filter by guest VMID
+        #[arg(long)]
+        vmid: Option<u32>,
+        /// Do not print currently-running tasks at startup
+        #[arg(long)]
+        no_existing: bool,
+        /// Output format: text (default) or json (NDJSON, one object per line)
+        #[arg(long, default_value = "text")]
+        format: String,
+    },
+}
+
+pub async fn execute_events(client: &Arc<PxClient>, action: EventsCommand) -> Result<(Value, i32)> {
+    match action {
+        EventsCommand::Stream {
+            interval,
+            node,
+            r#type,
+            vmid,
+            no_existing,
+            format,
+        } => {
+            let interval = interval.max(1);
+            let is_json = format.trim().eq_ignore_ascii_case("json");
+
+            // Initial poll — build the "seen" baseline without emitting
+            // events for tasks that were already completed.
+            let initial = fetch_tasks(client, node.as_deref(), vmid, r#type.as_deref()).await?;
+            let mut seen: HashMap<String, TaskInfo> = HashMap::new();
+
+            if !is_json {
+                eprintln!(
+                    "Streaming cluster events (Ctrl-C to stop, interval {}s)...",
+                    interval
+                );
+            }
+
+            // Show currently-running tasks as the initial snapshot.
+            if !no_existing {
+                let running: Vec<&TaskInfo> =
+                    initial.iter().filter(|t| t.endtime.is_none()).collect();
+                if !running.is_empty() {
+                    if !is_json {
+                        let sep = "─".repeat(72);
+                        eprintln!("{sep}");
+                    }
+                    for task in &running {
+                        emit_event("RUNNING", task, None, is_json);
+                    }
+                    if !is_json {
+                        let sep = "─".repeat(72);
+                        eprintln!("{sep}");
+                    }
+                }
+            }
+
+            for task in initial {
+                seen.insert(task.upid.clone(), task);
+            }
+
+            // Stream loop — emit deltas on each poll.
+            loop {
+                tokio::select! {
+                    biased;
+                    () = crate::util::shutdown::wait_for_shutdown_signal() => {
+                        if !is_json {
+                            eprintln!("\nstream stopped");
+                        }
+                        break;
+                    }
+                    () = tokio::time::sleep(std::time::Duration::from_secs(interval)) => {}
+                }
+
+                let current =
+                    match fetch_tasks(client, node.as_deref(), vmid, r#type.as_deref()).await {
+                        Ok(t) => t,
+                        Err(e) => {
+                            tracing::warn!("events stream: poll failed: {e:#}");
+                            continue;
+                        }
+                    };
+
+                for task in &current {
+                    match seen.get(&task.upid) {
+                        None => {
+                            // Task wasn't in the last snapshot.
+                            let elapsed = elapsed_secs(task);
+                            if task.endtime.is_none() {
+                                emit_event("START", task, None, is_json);
+                            } else {
+                                // Fast task: started and finished between polls.
+                                let label = outcome_label(task);
+                                emit_event(label, task, elapsed, is_json);
+                            }
+                        }
+                        Some(old) => {
+                            // Known task: emit if it just completed.
+                            if old.endtime.is_none() && task.endtime.is_some() {
+                                let elapsed =
+                                    task.endtime.map(|e| e.saturating_sub(task.starttime));
+                                let label = outcome_label(task);
+                                emit_event(label, task, elapsed, is_json);
+                            }
+                        }
+                    }
+                    seen.insert(task.upid.clone(), task.clone());
+                }
+            }
+
+            Ok((serde_json::json!({"status": "stream stopped"}), 0))
+        }
+    }
+}
+
+/// Fetch tasks, applying node/vmid/type filters.
+async fn fetch_tasks(
+    client: &PxClient,
+    node: Option<&str>,
+    vmid_filter: Option<u32>,
+    type_filter: Option<&str>,
+) -> Result<Vec<TaskInfo>> {
+    let mut tasks = if let Some(n) = node {
+        client.list_node_tasks(n, Some(200)).await?
+    } else {
+        client.get_cluster_tasks().await?
+    };
+
+    if let Some(v) = vmid_filter {
+        let id_str = v.to_string();
+        tasks.retain(|t| t.id == id_str);
+    }
+    if let Some(tp) = type_filter {
+        let tp_lower = tp.to_ascii_lowercase();
+        tasks.retain(|t| t.task_type.to_ascii_lowercase().contains(&tp_lower));
+    }
+    Ok(tasks)
+}
+
+/// Elapsed seconds for a completed task.
+fn elapsed_secs(task: &TaskInfo) -> Option<u64> {
+    task.endtime
+        .map(|e| e.saturating_sub(task.starttime))
+        .filter(|_| task.starttime > 0)
+}
+
+/// "DONE" for OK, "FAIL" for anything else.
+fn outcome_label(task: &TaskInfo) -> &'static str {
+    match task.status.as_deref() {
+        None | Some("OK") => "DONE",
+        _ => "FAIL",
+    }
+}
+
+fn emit_event(kind: &str, task: &TaskInfo, elapsed: Option<u64>, json: bool) {
+    if json {
+        let obj = serde_json::json!({
+            "event":    kind,
+            "upid":     task.upid,
+            "node":     task.node,
+            "type":     task.task_type,
+            "id":       task.id,
+            "user":     task.user,
+            "status":   task.status,
+            "starttime":task.starttime,
+            "endtime":  task.endtime,
+            "elapsed_secs": elapsed,
+        });
+        println!("{obj}");
+    } else {
+        let ts = fmt_ts(task.starttime);
+        let elapsed_str = elapsed.map(|s| format!("  [{s}s]")).unwrap_or_default();
+        let status_str = match task.status.as_deref() {
+            None | Some("OK") => String::new(),
+            Some(s) => format!("  {s}"),
+        };
+        let id_part = if task.id.is_empty() {
+            String::new()
+        } else {
+            format!("  vmid={}", task.id)
+        };
+        println!(
+            "{ts}  {kind:<8}  {node:<14}  {ty:<22}{id}{status}{elapsed}",
+            node = task.node,
+            ty = task.task_type,
+            id = id_part,
+            status = status_str,
+            elapsed = elapsed_str,
+        );
+    }
+}
+
+fn fmt_ts(unix: u64) -> String {
+    // Format as ISO-8601 without pulling in chrono — good enough for a log line.
+    // Days since epoch via Euclidean division, then hour/min/sec.
+    if unix == 0 {
+        return "                   ".to_string(); // placeholder width
+    }
+    let secs = unix % 60;
+    let mins = (unix / 60) % 60;
+    let hours = (unix / 3600) % 24;
+    let days = unix / 86400; // days since 1970-01-01
+
+    // Compute calendar date from days-since-epoch (no leap-second handling).
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{mins:02}:{secs:02}Z")
+}
+
+fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
+    // Algorithm from Henry Warren "Hacker's Delight" §12-3, adjusted for u64.
+    days += 719468; // shift epoch to 0000-03-01
+    let era = days / 146097;
+    let doe = days % 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 mod access;
 mod audit_cmd;
 mod cluster;
-mod common;
+pub mod common;
 mod console;
 mod ct;
 mod doctor;
@@ -17,7 +17,7 @@ mod monitoring;
 mod node;
 mod patch;
 mod storage;
-mod vm;
+pub mod vm;
 
 pub use audit_cmd::AuditAction;
 
@@ -300,6 +300,13 @@ pub enum Command {
         /// Description for the new guest.
         #[arg(long)]
         description: Option<String>,
+        /// Cloud-init customization TOML file. Applied (and the
+        /// cloud-init drive regenerated) after the clone task
+        /// completes. QEMU-only. Supported keys: ciuser,
+        /// cipassword, sshkey, sshkey_file, ipconfig0,
+        /// searchdomain, nameserver.
+        #[arg(long, value_name = "FILE")]
+        cloud_init_user: Option<std::path::PathBuf>,
     },
     /// Manage snapshots
     Snapshot {
@@ -1229,6 +1236,7 @@ pub async fn execute(
             full,
             snapname,
             description,
+            cloud_init_user,
         } => {
             let (src_node, gt) = find_guest(&client, src_vmid).await?;
             // Auto-fetch newid only when the user didn't pin one — saves
@@ -1238,6 +1246,16 @@ pub async fn execute(
                 Some(n) => n,
                 None => client.next_free_vmid().await?,
             };
+            // Parse profile up-front so a malformed file fails before
+            // we burn the clone task.
+            let profile = match &cloud_init_user {
+                Some(p) => Some(vm::CloudInitProfile::from_toml_file(p)?),
+                None => None,
+            };
+            // The clone lands on the *target* node (or src node if not
+            // pinned). Cloud-init mutations must hit the post-clone
+            // location, not src.
+            let landing_node = target.clone().unwrap_or_else(|| src_node.clone());
             let upid = client
                 .clone_guest(
                     &src_node,
@@ -1252,6 +1270,25 @@ pub async fn execute(
                     description.as_deref(),
                 )
                 .await?;
+            let cloudinit_result = if let Some(profile) = profile {
+                // Block until the clone task finishes — applying
+                // cloudinit before the disk image lands races PVE's
+                // own locking and returns a generic 500.
+                let status =
+                    crate::cli::common::poll_task_until_done(&client, &src_node, &upid, 0).await?;
+                if !status.is_success() {
+                    anyhow::bail!(
+                        "clone task did not succeed (status={:?}); skipping cloud-init apply",
+                        status.exitstatus
+                    );
+                }
+                Some(
+                    vm::apply_cloudinit_and_regen(&client, &landing_node, target_id, gt, &profile)
+                        .await?,
+                )
+            } else {
+                None
+            };
             Ok((
                 serde_json::json!({
                     "src_vmid": src_vmid,
@@ -1263,6 +1300,7 @@ pub async fn execute(
                     "full": full,
                     "snapname": snapname,
                     "task": upid,
+                    "cloudinit": cloudinit_result,
                 }),
                 0,
             ))

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,7 @@ mod common;
 mod console;
 mod ct;
 mod doctor;
+mod events;
 mod firewall;
 mod init;
 mod init_wizard;
@@ -179,6 +180,13 @@ pub enum Command {
         /// When set, fetch tasks from this node only (`/nodes/{n}/tasks`).
         #[arg(long)]
         node: Option<String>,
+    },
+    /// Real-time cluster event stream. Polls task queues across all nodes
+    /// (or a single node with --node) and prints new task starts and
+    /// completions as they happen. Press Ctrl-C to stop.
+    Events {
+        #[command(subcommand)]
+        action: events::EventsCommand,
     },
     /// Cancel a running task. PVE first signals cleanly, then SIGKILLs
     /// after a grace period. Use when a vzdump/migration is wedged.
@@ -1101,6 +1109,7 @@ pub async fn execute(
             let cfg = client.get_guest_config(&node, vmid, &gt).await?;
             Ok((serde_json::to_value(cfg)?, 0))
         }
+        Command::Events { action } => events::execute_events(&client, action).await,
         Command::Tasks { limit, node } => {
             let tasks = if let Some(n) = node {
                 client

--- a/src/cli/vm.rs
+++ b/src/cli/vm.rs
@@ -2,15 +2,116 @@
 //! lifecycle, snapshots, live disk move/resize (pre-flight gated), and
 //! QEMU Guest Agent file ops + network introspection.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Subcommand;
+use serde::Deserialize;
 use serde_json::Value;
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::cli::common::{
     classify_pending, enforce_preflight, find_guest, find_guest_full, parse_kv_pairs,
     require_non_empty_params, wait_and_classify,
 };
+
+fn expand_tilde(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return format!("{}/{}", home.to_string_lossy(), rest);
+        }
+    }
+    path.to_owned()
+}
+
+/// TOML profile for cloud-init customization at clone time. Every
+/// field is optional — the user file pulls in just the keys they
+/// want to override. `sshkey_file` is a convenience: read a public
+/// key from disk so callers don't have to inline a multi-line key.
+#[derive(Debug, Default, Deserialize)]
+pub struct CloudInitProfile {
+    pub ciuser: Option<String>,
+    pub cipassword: Option<String>,
+    pub sshkey: Option<String>,
+    pub sshkey_file: Option<String>,
+    pub ipconfig0: Option<String>,
+    pub searchdomain: Option<String>,
+    pub nameserver: Option<String>,
+}
+
+impl CloudInitProfile {
+    pub fn from_toml_file(path: &Path) -> Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("read cloud-init profile {}", path.display()))?;
+        let mut p: Self = toml::from_str(&raw)
+            .with_context(|| format!("parse cloud-init profile {}", path.display()))?;
+        if let Some(kf) = &p.sshkey_file {
+            let kp = expand_tilde(kf);
+            let key =
+                std::fs::read_to_string(&kp).with_context(|| format!("read sshkey_file {kp}"))?;
+            let key = key.trim().to_string();
+            if p.sshkey.is_some() {
+                anyhow::bail!("cloud-init profile: set either `sshkey` or `sshkey_file`, not both");
+            }
+            p.sshkey = Some(key);
+        }
+        Ok(p)
+    }
+
+    pub fn to_params(&self) -> Result<Vec<(String, String)>> {
+        let mut params: Vec<(String, String)> = Vec::new();
+        if let Some(v) = &self.ciuser {
+            params.push(("ciuser".into(), v.clone()));
+        }
+        if let Some(v) = &self.cipassword {
+            params.push(("cipassword".into(), v.clone()));
+        }
+        if let Some(v) = &self.sshkey {
+            params.push(("sshkeys".into(), v.clone()));
+        }
+        if let Some(v) = &self.ipconfig0 {
+            use std::str::FromStr;
+            let parsed = crate::api::types::Ipconfig::from_str(v)?;
+            params.push(("ipconfig0".into(), parsed.to_string()));
+        }
+        if let Some(v) = &self.searchdomain {
+            params.push(("searchdomain".into(), v.clone()));
+        }
+        if let Some(v) = &self.nameserver {
+            params.push(("nameserver".into(), v.clone()));
+        }
+        Ok(params)
+    }
+}
+
+/// Apply a CloudInitProfile to a QEMU guest and regenerate the
+/// cloud-init drive. No-op on empty profile (returns
+/// `applied=false`). LXC is rejected — cloud-init is QEMU-only.
+pub async fn apply_cloudinit_and_regen(
+    client: &crate::api::PxClient,
+    node: &str,
+    vmid: u32,
+    gt: crate::api::types::GuestType,
+    profile: &CloudInitProfile,
+) -> Result<Value> {
+    use crate::api::types::GuestType;
+    use crate::api::ProxmoxGateway;
+    if !matches!(gt, GuestType::Qemu) {
+        anyhow::bail!("cloud-init is QEMU-only — VMID {vmid} is an LXC container");
+    }
+    let params = profile.to_params()?;
+    if params.is_empty() {
+        return Ok(serde_json::json!({ "applied": false }));
+    }
+    let task_set = client.update_guest_config(node, vmid, gt, &params).await?;
+    let task_regen = client.regenerate_cloudinit(node, vmid).await?;
+    let keys: Vec<String> = params.iter().map(|(k, _)| k.clone()).collect();
+    Ok(serde_json::json!({
+        "applied": true,
+        "keys": keys,
+        "config_task": task_set,
+        "regen_task": task_regen,
+    }))
+}
 
 /// QEMU `vm` subcommand tree. Three branches:
 ///   - `set` — type-checked top-level config keys (cores, memory, …)

--- a/src/mcp/dispatch.rs
+++ b/src/mcp/dispatch.rs
@@ -500,6 +500,74 @@ pub async fn handle_tool_call(
                 "events": enriched,
             }))?
         }
+        ToolAction::CloneWithCloudinit => {
+            use crate::api::types::GuestType;
+            let vmid = args
+                .get("guest_id")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0) as u32;
+            let (node, gt) = find_node_and_type(client, vmid)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Guest {vmid} not found"))?;
+            if !matches!(gt, GuestType::Qemu) {
+                anyhow::bail!("clone_with_cloudinit: VMID {vmid} is LXC — cloud-init is QEMU-only");
+            }
+            let newid_arg = args
+                .get("newid")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0) as u32;
+            let newid = if newid_arg == 0 {
+                client.next_free_vmid().await?
+            } else {
+                newid_arg
+            };
+            let name = args.get("name").and_then(|v| v.as_str());
+            let full = args
+                .get("full")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+
+            let profile = crate::cli::vm::CloudInitProfile {
+                ciuser: args
+                    .get("ciuser")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned),
+                cipassword: None,
+                sshkey: args
+                    .get("sshkey")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned),
+                sshkey_file: None,
+                ipconfig0: args
+                    .get("ipconfig0")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned),
+                searchdomain: args
+                    .get("searchdomain")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned),
+                nameserver: args
+                    .get("nameserver")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned),
+            };
+
+            let upid = client
+                .clone_guest(&node, vmid, gt, newid, name, None, None, full, None, None)
+                .await?;
+            // Block until clone lands — applying cloudinit before
+            // the disk image is ready races PVE's own locking.
+            let status = crate::cli::common::poll_task_until_done(client, &node, &upid, 0).await?;
+            if !status.is_success() {
+                anyhow::bail!(
+                    "clone task did not succeed (status={:?}); cloud-init not applied",
+                    status.exitstatus
+                );
+            }
+            let ci = crate::cli::vm::apply_cloudinit_and_regen(client, &node, newid, gt, &profile)
+                .await?;
+            format!("Cloned guest {vmid} → {newid} (UPID: {upid}); cloud-init applied: {ci}")
+        }
     };
 
     Ok(json!({

--- a/src/mcp/dispatch.rs
+++ b/src/mcp/dispatch.rs
@@ -447,6 +447,59 @@ pub async fn handle_tool_call(
                 }]
             }));
         }
+        ToolAction::ListClusterEvents => {
+            let limit = args
+                .get("limit")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(50)
+                .min(200) as usize;
+            let running_only = args
+                .get("running_only")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+
+            let mut tasks = client.get_cluster_tasks().await?;
+            if running_only {
+                tasks.retain(|t| t.endtime.is_none());
+            }
+            tasks.truncate(limit);
+
+            let enriched: Vec<serde_json::Value> = tasks
+                .iter()
+                .map(|t| {
+                    let elapsed_secs = if let Some(end) = t.endtime {
+                        end.saturating_sub(t.starttime)
+                    } else if t.starttime > 0 {
+                        now.saturating_sub(t.starttime)
+                    } else {
+                        0
+                    };
+                    serde_json::json!({
+                        "upid":         t.upid,
+                        "node":         t.node,
+                        "type":         t.task_type,
+                        "id":           t.id,
+                        "user":         t.user,
+                        "status":       t.status,
+                        "starttime":    t.starttime,
+                        "endtime":      t.endtime,
+                        "elapsed_secs": elapsed_secs,
+                        "running":      t.endtime.is_none(),
+                    })
+                })
+                .collect();
+
+            serde_json::to_string_pretty(&serde_json::json!({
+                "total": enriched.len(),
+                "running_only": running_only,
+                "events": enriched,
+            }))?
+        }
     };
 
     Ok(json!({

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -44,6 +44,8 @@ pub enum ToolAction {
     CreateGuest,
     // ── Events ───────────────────────────────────────────
     ListClusterEvents,
+    // ── Cloud-init ───────────────────────────────────────
+    CloneWithCloudinit,
 }
 
 // ── Const Tool Definitions ──────────────────────────────
@@ -547,6 +549,70 @@ pub const TOOLS: &[ToolDef] = &[
         action: ToolAction::ListClusterEvents,
         destructive: false,
         timeout_secs: 15,
+    },
+    // Tool #25 — clone + apply cloud-init in one shot
+    ToolDef {
+        name: "clone_with_cloudinit",
+        description: "Clone a QEMU template into a new VMID and apply cloud-init customization (user, sshkey, ipconfig0, …) in one call. Waits for the clone task to finish before mutating cloud-init. QEMU-only.",
+        params: &[
+            ParamDef {
+                name: "guest_id",
+                description: "Source VMID (template) to clone",
+                param_type: ParamType::Int,
+                required: true,
+            },
+            ParamDef {
+                name: "newid",
+                description: "New VMID (0 = auto-assign next free)",
+                param_type: ParamType::Int,
+                required: false,
+            },
+            ParamDef {
+                name: "name",
+                description: "Display name for the new VM",
+                param_type: ParamType::Str,
+                required: false,
+            },
+            ParamDef {
+                name: "full",
+                description: "Full clone (true) vs linked clone (false, default)",
+                param_type: ParamType::Bool,
+                required: false,
+            },
+            ParamDef {
+                name: "ciuser",
+                description: "Cloud-init default user account",
+                param_type: ParamType::Str,
+                required: false,
+            },
+            ParamDef {
+                name: "sshkey",
+                description: "SSH public key (single line, ssh-ed25519/ssh-rsa form)",
+                param_type: ParamType::Str,
+                required: false,
+            },
+            ParamDef {
+                name: "ipconfig0",
+                description: "First-NIC IP config, e.g. `ip=10.0.0.5/24,gw=10.0.0.1` or `ip=dhcp`",
+                param_type: ParamType::Str,
+                required: false,
+            },
+            ParamDef {
+                name: "searchdomain",
+                description: "DNS search domain",
+                param_type: ParamType::Str,
+                required: false,
+            },
+            ParamDef {
+                name: "nameserver",
+                description: "DNS resolver IP",
+                param_type: ParamType::Str,
+                required: false,
+            },
+        ],
+        action: ToolAction::CloneWithCloudinit,
+        destructive: true,
+        timeout_secs: 300,
     },
 ];
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -42,6 +42,8 @@ pub enum ToolAction {
     GetReplicationStatus,
     // ── Guest creation ───────────────────────────────────
     CreateGuest,
+    // ── Events ───────────────────────────────────────────
+    ListClusterEvents,
 }
 
 // ── Const Tool Definitions ──────────────────────────────
@@ -523,6 +525,28 @@ pub const TOOLS: &[ToolDef] = &[
         action: ToolAction::CreateGuest,
         destructive: true,
         timeout_secs: 120,
+    },
+    // Tool #24 — cluster event history
+    ToolDef {
+        name: "list_cluster_events",
+        description: "Return recent cluster-wide task events from all nodes. Shows task type, vmid, node, user, outcome, and elapsed time. Useful for understanding what has recently happened on the cluster.",
+        params: &[
+            ParamDef {
+                name: "limit",
+                description: "Maximum number of events to return (default 50, max 200)",
+                param_type: ParamType::Int,
+                required: false,
+            },
+            ParamDef {
+                name: "running_only",
+                description: "When true, return only tasks that are currently running",
+                param_type: ParamType::Bool,
+                required: false,
+            },
+        ],
+        action: ToolAction::ListClusterEvents,
+        destructive: false,
+        timeout_secs: 15,
     },
 ];
 

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -16,7 +16,7 @@ mod tests {
         // If someone adds a tool, this test forces them to update the count
         assert_eq!(
             TOOLS.len(),
-            23,
+            24,
             "Tool count changed! Update this test if intentional."
         );
     }

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -16,7 +16,7 @@ mod tests {
         // If someone adds a tool, this test forces them to update the count
         assert_eq!(
             TOOLS.len(),
-            24,
+            25,
             "Tool count changed! Update this test if intentional."
         );
     }


### PR DESCRIPTION
## Summary
- `proxxx clone <src> --cloud-init-user <file.toml>` — TOML profile (ciuser, cipassword, sshkey/sshkey_file, ipconfig0, searchdomain, nameserver) applied after clone task lands, drive regenerated in one shot
- MCP tool #25 `clone_with_cloudinit` — same flow callable by LLMs with inline params; QEMU-only

## Test plan
- [x] 7-stage gate green
- [x] Tool count test bumped 24→25
- [ ] Manual: `proxxx clone 9000 --cloud-init-user examples/ci-dev.toml` against template
- [ ] Manual: MCP `tools/call clone_with_cloudinit` with sshkey + ipconfig0

🤖 Generated with [Claude Code](https://claude.com/claude-code)