### PR TITLE
release: v0.2.0 — aarch64 musl, docs refresh, 25-tool MCP registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,18 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             archive_ext: tar.gz
-          # NOTE: aarch64-unknown-linux-musl was dropped from the v0.1.0
-          # matrix because the cross-link from `gcc-aarch64-linux-gnu` to
-          # the musl `core` crate fails on a transitive C dep (rusqlite /
-          # russh / sha2). The cross-build needs a proper musl-aarch64
-          # toolchain (e.g. `cross` or a containerized rustc) — out of
-          # scope for the 0.1.0 cut. ARM64 Linux users build from source
-          # for now (`cargo build --release` on the target host works).
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            archive_ext: tar.gz
+            # ARM64 Linux statically-linked binary. Built via
+            # `cross-rs/cross` which runs cargo inside a target-specific
+            # Docker image with the proper musl-aware aarch64 toolchain.
+            # This is the canonical solution for the C-dep cross-link
+            # issue (rusqlite, sha2, russh) the bare
+            # `gcc-aarch64-linux-gnu` approach hit. Runs on Pi 4/5,
+            # Ampere, Graviton, Oracle Free Tier — anywhere with arm64
+            # + Linux kernel ≥ 3.2.
+            use_cross: true
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -78,20 +83,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Install aarch64 cross-linker
-        if: matrix.target == 'aarch64-unknown-linux-musl'
-        # The Rust toolchain installs the std for aarch64-musl, but the
-        # linker has to come from the host's package set. `gcc-aarch64-
-        # linux-gnu` is the cross gcc; we point cargo at the matching
-        # musl-aware linker via env.
-        run: |
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          mkdir -p .cargo
-          cat >> .cargo/config.toml <<'EOF'
-
-          [target.aarch64-unknown-linux-musl]
-          linker = "aarch64-linux-gnu-gcc"
-          EOF
+      - name: Install cross (aarch64 musl)
+        if: matrix.use_cross == true
+        # `cross` runs cargo inside a target-specific Docker container
+        # with a working musl-aarch64 C toolchain — sidesteps the
+        # rusqlite/sha2/russh native-dep cross-link breakage that the
+        # bare `gcc-aarch64-linux-gnu` approach hit at v0.1.0. Pinned
+        # to a release tag, not @main.
+        uses: taiki-e/install-action@a26e89cad88f81bf65fb24e69a90bb96fd2ad391  # v2.62.7
+        with:
+          tool: cross@0.2.5
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
@@ -99,7 +100,12 @@ jobs:
           shared-key: release-${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
 
       - name: Verify Linux binary is statically linked
         if: contains(matrix.target, 'linux-musl')
@@ -116,6 +122,13 @@ jobs:
             exit 1
           fi
           echo "OK: $BIN is statically linked"
+
+      - name: Install aarch64 strip
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        # binutils only — gcc is not needed because `cross` did the
+        # linking inside its Docker image. We need only the `strip`
+        # tool here to debloat the artefact before packaging.
+        run: sudo apt-get update && sudo apt-get install -y binutils-aarch64-linux-gnu
 
       - name: Strip binary
         # Release profile already strips on macOS via the cargo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ SemVer contract:
 - Config schema is backwards compatible.
 - MCP tool registry is append-only.
 
-## [Unreleased] — v0.1.28
+## [Unreleased]
+
+## [0.2.0] — 2026-05-19
+
+Headline: **broad LLM + IaC surface expansion**. New subcommands for
+guest creation, cloud-init at clone time, real-time events, and a
+self-diagnostic. MCP registry grew from 22 → 25 tools (append-only,
+SemVer-safe). Audit log, EU compliance positioning, SIGHUP hot-reload,
+shell completions. Statically-linked **aarch64-musl** Linux binary
+now in the release matrix — Pi 4/5, Ampere, Graviton, Oracle Free Tier.
+
+Minor bump (not patch) because the cumulative CLI / MCP surface
+added since 0.1.27 is well beyond a single-feature release.
 
 ### Added
 - **Shell completions** — `proxxx completions {bash|zsh|fish|powershell}` prints the shell
@@ -58,6 +70,10 @@ SemVer contract:
 - **MCP tool `clone_with_cloudinit`** (tool #25) — same flow callable by LLMs
   with inline params (no file). QEMU-only; LXC is rejected explicitly.
   Registry SHA-256 updated; counter 24→25.
+- **ARM64 Linux release artefact** — `aarch64-unknown-linux-musl` statically-
+  linked binary in the release matrix, built via `cross` (Docker-based
+  cross-compile sidesteps rusqlite/sha2/russh native-dep linker breakage).
+  Pi 4/5, Ampere, Graviton, Oracle Free Tier.
 
 ## [0.1.27] — 2026-05-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.1.28"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.1.28"
+version = "0.2.0"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Pick the row that matches you and jump straight to the right page.
 | **Homelab solo** running 1-3 nodes | wizard, fast TUI, single binary, no daemons | [5-min homelab quickstart](https://fabriziosalmi.github.io/proxxx/guide/quickstart-homelab) |
 | **Platform / SRE** on 10-50 nodes with on-call | HITL Telegram gate, alert daemon, `--format json` for CI, `--profile` for multi-cluster | [Production checklist](https://fabriziosalmi.github.io/proxxx/guide/production-checklist) · [HITL](https://fabriziosalmi.github.io/proxxx/integrations/hitl) |
 | **DevOps** scripting Proxmox in pipelines | typed exit codes, deterministic JSON, pre-flight risk gate, batch ops with `--yes` | [CLI reference](https://fabriziosalmi.github.io/proxxx/reference/cli) · [Exit codes](https://fabriziosalmi.github.io/proxxx/reference/exit-codes) |
-| **LLM / agent integrator** wiring Claude/Cursor to a cluster | MCP server (stdio + Streamable HTTP), compile-time-fixed 23-tool registry, SHA-256 pinned for supply-chain audit | [LLM/MCP quickstart](https://fabriziosalmi.github.io/proxxx/guide/quickstart-llm-mcp) |
+| **LLM / agent integrator** wiring Claude/Cursor to a cluster | MCP server (stdio + Streamable HTTP), compile-time-fixed 25-tool registry, SHA-256 pinned for supply-chain audit | [LLM/MCP quickstart](https://fabriziosalmi.github.io/proxxx/guide/quickstart-llm-mcp) |
 | **Security / compliance** evaluating before deploy | typed errors, HITL replay protection, sigstore-signed releases, CycloneDX SBOM, gate on every commit | [Production checklist](https://fabriziosalmi.github.io/proxxx/guide/production-checklist) · [`SECURITY.md`](SECURITY.md) |
 | **EU-regulated ops** (NIS2 / ISO 27001 / GDPR) | append-only SQLite audit log with HMAC-SHA256 chain, `proxxx audit verify`, zero telemetry, fully self-hosted | [EU & compliance](#eu--compliance) |
 | **Contributor** sending a PR | 7-stage commit gate (live cluster + mutation lifecycle), no-skip-flags policy | [`CONTRIBUTING.md`](CONTRIBUTING.md) · [Pre-commit gate](https://fabriziosalmi.github.io/proxxx/guide/pre-commit-gate) |
@@ -76,7 +76,7 @@ proxxx is designed for operators who need auditability, data sovereignty, and su
 
 ## Install
 
-Pre-built binaries for **macOS Apple Silicon** and **Linux x86_64-musl** are attached to each [tagged release](https://github.com/fabriziosalmi/proxxx/releases). ARM64 Linux builds from source (cross-link toolchain bug; tracked).
+Pre-built binaries for **macOS Apple Silicon**, **Linux x86_64-musl**, and **Linux aarch64-musl** (Pi 4/5, Ampere, Graviton, Oracle Free Tier) are attached to each [tagged release](https://github.com/fabriziosalmi/proxxx/releases). All Linux artefacts are statically linked — no glibc, drops onto Alpine through RHEL.
 
 Download + verify the full supply-chain trio:
 
@@ -268,7 +268,7 @@ Pure Elm-pattern TUI over a typed REST client. The reducer is sync, total, and t
 | [`src/app/cache.rs`](src/app/cache.rs) | SQLite-backed time-travel cache, drives `proxxx replay <timestamp>`. |
 | [`src/app/preflight.rs`](src/app/preflight.rs) | 11 risk variants with per-op weighting and `--allow-risk` override. |
 | [`src/hitl/`](src/hitl) | Real Telegram round-trip via `HitlCoordinator` + a single shared `getUpdates` poller. Deny on 120 s timeout, deny when Telegram unconfigured but a policy matched. |
-| [`src/mcp/`](src/mcp) | JSON-RPC server with stdio + Streamable HTTP transports. Compile-time-fixed tool registry (23 tools). Surface SHA-256 pinned via `proxxx mcp tools --checksum`. |
+| [`src/mcp/`](src/mcp) | JSON-RPC server with stdio + Streamable HTTP transports. Compile-time-fixed tool registry (25 tools). Surface SHA-256 pinned via `proxxx mcp tools --checksum`. |
 | [`src/util/`](src/util) | `panic_hook` (flight recorder), `terminal_guard` (RAII raw-mode), `shutdown` (SIGTERM / SIGINT for daemons). |
 
 ## Documentation

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -50,15 +50,16 @@ proxxx --version
 
 Targets shipped today:
 
-| Target                      | Platform              |
-| :-------------------------- | :-------------------- |
-| `aarch64-apple-darwin`      | macOS Apple Silicon   |
-| `x86_64-unknown-linux-musl` | Linux x86_64 (static) |
+| Target                        | Platform                                       |
+| :---------------------------- | :--------------------------------------------- |
+| `aarch64-apple-darwin`        | macOS Apple Silicon                            |
+| `x86_64-unknown-linux-musl`   | Linux x86_64 (static, every distro)            |
+| `aarch64-unknown-linux-musl`  | Linux ARM64 (Pi 4/5, Ampere, Graviton, Oracle) |
 
-ARM64 Linux is **build from source** for now — the cross-link
-toolchain has a transitive C-dep bug (`rusqlite` / `russh` / `sha2`)
-that the matrix hasn't bridged cleanly yet. `cargo build --release`
-on the target host works fine.
+ARM64 Linux is now a first-class release artefact (since v0.2.0),
+built via `cross-rs/cross` against a containerized musl-aarch64
+toolchain. No glibc dependencies — drops straight onto Alpine,
+Raspberry Pi OS, Debian/Ubuntu, Amazon Linux on Graviton.
 
 ## From source
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ hero:
 
 features:
   - title: One binary, three callers
-    details: CLI, TUI, and MCP server in the same executable. Same risk gate, same HITL gate, same API client. The TUI is for interactive operations; the CLI is the same operations, scriptable, JSON-friendly, and CI-ready; the MCP surface is a deterministic 23-tool registry (stdio + Streamable HTTP transports) for LLM agents.
+    details: CLI, TUI, and MCP server in the same executable. Same risk gate, same HITL gate, same API client. The TUI is for interactive operations; the CLI is the same operations, scriptable, JSON-friendly, and CI-ready; the MCP surface is a deterministic 25-tool registry (stdio + Streamable HTTP transports) for LLM agents.
   - title: No agent on the cluster
     details: Direct REST against PVE (token or password) and PBS (token only), with typed error categories so callers match on the failure shape instead of grepping prose. SSH only for the paths PVE never exposed over REST — patch apply, full effective-permissions, per-guest interactive sessions.
   - title: Six-stage commit gate, no skip flags
@@ -111,7 +111,7 @@ onMounted(() => {
 | Binary                | 6–9 MB stripped depending on target · single static · no installer |
 | Supply chain          | `cargo audit --deny warnings` per push + nightly cron    |
 | System dependencies   | 0 — rustls only, no native-tls, no openssl               |
-| MCP tool registry     | 23 tools · stdio + HTTP · SHA-256 pinned · compile-time fixed |
+| MCP tool registry     | 25 tools · stdio + HTTP · SHA-256 pinned · compile-time fixed |
 
 ## A taste
 

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -15,7 +15,8 @@ HITL gate as human callers.
 
 ## The tool surface
 
-Closed enum, compile-time fixed:
+Closed enum, compile-time fixed — 25 tools as of v0.2.0. Regenerate this
+table from your binary with `proxxx mcp tools --json`:
 
 | Tool | Destructive | Budget | Description |
 | :--- | :---: | :---: | :--- |
@@ -26,9 +27,24 @@ Closed enum, compile-time fixed:
 | `stop_guest` | **yes** | 60 s | Graceful or hard stop |
 | `restart_guest` | **yes** | 60 s | Restart |
 | `delete_guest` | **yes** | 180 s | Permanent delete (cannot be undone) |
+| `suspend_guest` | no | 60 s | Pause a running guest |
+| `resume_guest` | no | 60 s | Resume a suspended guest |
+| `clone_guest` | **yes** | 180 s | Clone a VM/LXC to a new VMID |
+| `clone_with_cloudinit` | **yes** | 300 s | Clone QEMU template + apply cloud-init (user, sshkey, ipconfig0) in one call |
+| `migrate_guest` | **yes** | 300 s | Live-migrate to another node |
+| `create_guest` | **yes** | 120 s | Create new QEMU VM or LXC (node, type, name, memory, cores, disk, …) |
 | `create_snapshot` | no | 120 s | Create snapshot |
+| `list_snapshots` | no | 30 s | List snapshots for a guest |
 | `delete_snapshot` | **yes** | 120 s | Delete snapshot |
 | `get_storage_pools` | no | 30 s | Per-node storage list with usage |
+| `get_node_resources` | no | 30 s | Node CPU / memory / status detail |
+| `get_node_status` | no | 30 s | Node uptime, kernel, version |
+| `get_cluster_status` | no | 30 s | Cluster-wide quorum, nodes, services |
+| `list_tasks` | no | 30 s | Recent cluster tasks (running + completed) |
+| `get_task_log` | no | 30 s | Task log output by UPID |
+| `list_cluster_events` | no | 15 s | Recent task events with elapsed time |
+| `list_backup_jobs` | no | 30 s | Configured vzdump jobs |
+| `get_replication_status` | no | 30 s | Replication job status for a node |
 
 The full schema is exposed by `proxxx mcp tools --json`. Example
 entry:
@@ -82,7 +98,7 @@ Drop into `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
-Restart Claude Desktop. The agent now sees the 10-tool surface.
+Restart Claude Desktop. The agent now sees the 25-tool surface.
 
 ## Audit the registry
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -212,8 +212,32 @@ within a major version.
 
 | Command | What it does |
 | :--- | :--- |
+| `proxxx doctor`                  | Self-diagnostic: config, cluster connectivity, auth, Telegram HITL, PBS, SSH key, audit log. Exits 0 if all critical checks pass |
 | `proxxx dev-panic [--message X]` | Flight-recorder smoke — trigger a controlled panic to test the flight-recorder hook |
 | `proxxx version --json`          | Test count, vector framework hash, audit ignores, build metadata |
+| `proxxx completions {bash\|zsh\|fish\|powershell}` | Print shell completion script to stdout — pipe to your shell's completions dir |
+
+## Audit log
+
+| Command | What it does |
+| :--- | :--- |
+| `proxxx audit log [--limit N] [--since T]`        | Show recent audit entries (SQLite, append-only) |
+| `proxxx audit export --format {json\|csv}`        | Dump entries for SIEM ingestion |
+| `proxxx audit verify`                             | Walk the full HMAC-SHA256 chain — NIS2/ISO 27001 evidence |
+
+## Guest lifecycle (additional)
+
+| Command | What it does |
+| :--- | :--- |
+| `proxxx vm create --node <n> [--vmid <id>] [--name <s>] [--memory <M>] [--cores <N>] [--disk <storage:sizeG>] [--iso <volid>] [--ostype <t>] [--bridge <br>] [--wait]` | Create new QEMU VM from scratch. VMID auto-assigned if omitted |
+| `proxxx ct create --node <n> --template <volid> [--vmid <id>] [--hostname <h>] [--memory <M>] [--cores <N>] [--rootfs <storage:sizeG>] [--bridge <br>] [--password <p>] [--wait]` | Create new LXC from template |
+| `proxxx clone <src_vmid> [--newid <id>] [--name <s>] [--cloud-init-user <file.toml>]` | Clone guest; with `--cloud-init-user`, parse TOML profile (ciuser, sshkey, ipconfig0, …) and apply after clone task lands + regen drive |
+
+## Events
+
+| Command | What it does |
+| :--- | :--- |
+| `proxxx events stream [--interval <s>] [--node <n>] [--type <t>] [--vmid <id>] [--no-existing] [--format {text\|json}]` | Tail real-time cluster task events (START/DONE/FAIL). NDJSON output with `--format json` |
 
 ## Configuration bootstrap
 


### PR DESCRIPTION
## Summary
- Version bump 0.1.28 → **0.2.0** (cumulative surface since 0.1.27 warrants minor)
- **aarch64-unknown-linux-musl** added to release matrix (built via `cross`, sidesteps the rusqlite/sha2/russh native-dep cross-link issue)
- README + GitHub Pages docs refreshed: MCP tool table regenerated 10→25 entries, new CLI reference sections (doctor, completions, audit, vm/ct create, clone --cloud-init-user, events stream), installation page promotes ARM64 Linux to first-class

## Test plan
- [x] Pre-commit gate green on both commits (release bump + docs refresh)
- [ ] Tag `v0.2.0` after merge → release workflow builds 3-target matrix + cosign-signs + attaches SBOM
- [ ] Verify aarch64-musl tarball runs on a Pi / Graviton (post-release smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)