### PR TITLE
chore(quality): clippy pedantic sweep + dead-code purge + stale doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Download + verify the full supply-chain trio:
 
 ```bash
 TARGET=x86_64-unknown-linux-musl     # or aarch64-apple-darwin
-VERSION=0.1.7                        # latest at time of writing
+VERSION=0.2.0                        # latest at time of writing
 
 gh release download v${VERSION} --repo fabriziosalmi/proxxx \
   --pattern "*-${TARGET}.tar.gz" \

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ onMounted(() => {
 
 <div class="status-row">
   <span><span class="ok">●</span> <strong>main</strong> · gate green</span>
-  <span><strong>v0.1.26</strong></span>
+  <span><strong>v0.2.0</strong></span>
   <span><strong>full mutation lifecycle</strong> · LXC + cluster + QEMU + QGA</span>
   <span><strong>0</strong> system deps · rustls only</span>
   <span><strong>MIT</strong></span>

--- a/src/app.rs
+++ b/src/app.rs
@@ -1764,8 +1764,8 @@ pub enum SideEffect {
     },
 
     /// Tear down the current TUI session and restart with `profile`.
-    /// The TUI run() loop returns `Ok(Some(profile))` to main.rs, which
-    /// re-enters run() with the new profile — zero binary restart.
+    /// The TUI `run()` loop returns `Ok(Some(profile))` to main.rs, which
+    /// re-enters `run()` with the new profile — zero binary restart.
     SwitchProfile(String),
 }
 

--- a/src/app/cache.rs
+++ b/src/app/cache.rs
@@ -193,16 +193,6 @@ fn get_db_path(profile_name: Option<&str>) -> PathBuf {
     path
 }
 
-fn ensure_cache_dir() -> anyhow::Result<()> {
-    let dir = get_db_dir();
-    std::fs::create_dir_all(&dir).map_err(|e| {
-        anyhow::anyhow!(
-            "cannot create cache directory {}: {e} — check permissions",
-            dir.display()
-        )
-    })
-}
-
 fn init_db(conn: &Connection) -> anyhow::Result<()> {
     conn.execute(
         "CREATE TABLE IF NOT EXISTS snapshots (
@@ -975,7 +965,7 @@ mod concurrency_tests {
     /// a load on the other profile must return `Err("No cache found")`.
     ///
     /// This test closes the ❌ row in pre-commit/01-feature-coverage.md
-    /// under "RBAC & multi-persona · SQLite cache segregation per-profile".
+    /// under "RBAC & multi-persona · `SQLite` cache segregation per-profile".
     /// The invariant was previously blocked on multi-profile support
     /// arriving (Gap #4); `get_db_path` has always segregated by name.
     #[test]

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -1,4 +1,4 @@
-//! Append-only audit log backed by SQLite.
+//! Append-only audit log backed by `SQLite`.
 //! Each entry is HMAC-SHA256 signed using a chained scheme:
 //! `chain_hmac = HMAC(key, prev_chain_hmac || ts || action || vmid_str || result)`
 //! The chain is verifiable offline via `proxxx audit verify`.
@@ -63,7 +63,7 @@ impl AuditLogger {
         params_json: Option<&str>,
         result: &str,
     ) -> Result<()> {
-        let prev_hmac = self.last_chain_hmac()?;
+        let prev_hmac = self.last_chain_hmac();
         let ts = chrono_now();
         let vmid_str = vmid.map(|v| v.to_string()).unwrap_or_default();
         let chain_hmac = compute_hmac(&self.key, &prev_hmac, &ts, action, &vmid_str, result);
@@ -74,7 +74,7 @@ impl AuditLogger {
                 ts,
                 action,
                 user,
-                vmid.map(|v| v as i64),
+                vmid.map(i64::from),
                 node,
                 params_json,
                 result,
@@ -136,13 +136,14 @@ impl AuditLogger {
         Ok((ok, fail))
     }
 
-    fn last_chain_hmac(&self) -> Result<String> {
-        let result: rusqlite::Result<String> = self.conn.query_row(
-            "SELECT chain_hmac FROM audit_log ORDER BY id DESC LIMIT 1",
-            [],
-            |r| r.get(0),
-        );
-        Ok(result.unwrap_or_default())
+    fn last_chain_hmac(&self) -> String {
+        self.conn
+            .query_row(
+                "SELECT chain_hmac FROM audit_log ORDER BY id DESC LIMIT 1",
+                [],
+                |r| r.get::<_, String>(0),
+            )
+            .unwrap_or_default()
     }
 }
 
@@ -273,6 +274,6 @@ fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
     (y, mo, days + 1)
 }
 
-fn is_leap(y: u64) -> bool {
-    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+const fn is_leap(y: u64) -> bool {
+    (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
 }

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -65,7 +65,7 @@ pub fn execute_verify() -> Result<(Value, i32)> {
     let logger = crate::audit::AuditLogger::open()?;
     let (ok, fail) = logger.verify()?;
     let status = if fail == 0 { "ok" } else { "tampered" };
-    let exit_code = if fail == 0 { 0 } else { 1 };
+    let exit_code = i32::from(fail != 0);
     Ok((
         serde_json::json!({"verified": ok, "failed": fail, "status": status}),
         exit_code,

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -36,13 +36,12 @@ pub async fn find_guest(
     }
     if node_errors.is_empty() {
         anyhow::bail!("Guest {vmid} not found on any node")
-    } else {
-        anyhow::bail!(
-            "Guest {vmid} not found; {} node(s) returned errors: {}",
-            node_errors.len(),
-            node_errors.join("; ")
-        )
     }
+    anyhow::bail!(
+        "Guest {vmid} not found; {} node(s) returned errors: {}",
+        node_errors.len(),
+        node_errors.join("; ")
+    )
 }
 
 /// Same scan as `find_guest`, but returns the full `Guest` so the
@@ -69,13 +68,12 @@ pub async fn find_guest_full(
     }
     if node_errors.is_empty() {
         anyhow::bail!("Guest {vmid} not found on any node")
-    } else {
-        anyhow::bail!(
-            "Guest {vmid} not found; {} node(s) returned errors: {}",
-            node_errors.len(),
-            node_errors.join("; ")
-        )
     }
+    anyhow::bail!(
+        "Guest {vmid} not found; {} node(s) returned errors: {}",
+        node_errors.len(),
+        node_errors.join("; ")
+    )
 }
 
 /// Poll a long-running PVE task to completion. Used by `--wait` on
@@ -306,7 +304,7 @@ impl BatchPolicy {
             } else if let Some(n) = rest.strip_prefix('=') {
                 n.parse::<u8>()
                     .ok()
-                    .filter(|&p| p >= 1 && p <= 100)
+                    .filter(|&p| (1..=100).contains(&p))
                     .ok_or_else(|| anyhow::anyhow!("canary percent must be 1–100, got {n}"))?
             } else {
                 anyhow::bail!("unrecognised policy: {s}")
@@ -341,8 +339,12 @@ pub async fn execute_batch_op(
 }
 
 /// Canary pilot slice size: ceil(N × percent / 100), clamped to [1, N].
+#[must_use]
 pub fn canary_pilot_count(n: usize, percent: u8) -> usize {
-    std::cmp::min(n, std::cmp::max(1, (n * usize::from(percent) + 99) / 100))
+    std::cmp::min(
+        n,
+        std::cmp::max(1, (n * usize::from(percent)).div_ceil(100)),
+    )
 }
 
 pub async fn execute_batch_op_with_policy(
@@ -464,7 +466,7 @@ trait IntoArray {
 }
 impl IntoArray for serde_json::Value {
     fn into_array(self) -> Option<Vec<serde_json::Value>> {
-        if let serde_json::Value::Array(v) = self {
+        if let Self::Array(v) = self {
             Some(v)
         } else {
             None

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -18,7 +18,7 @@ enum CheckStatus {
 }
 
 impl CheckStatus {
-    fn symbol(&self) -> &'static str {
+    const fn symbol(&self) -> &'static str {
         match self {
             Self::Ok => "ok",
             Self::Warn => "warn",
@@ -250,7 +250,7 @@ pub async fn run() -> Result<(Value, i32)> {
         })
         .collect();
 
-    let exit_code = if overall_ok { 0 } else { 1 };
+    let exit_code = i32::from(!overall_ok);
     Ok((json!(result), exit_code))
 }
 

--- a/src/cli/events.rs
+++ b/src/cli/events.rs
@@ -252,7 +252,7 @@ fn fmt_ts(unix: u64) -> String {
     format!("{year:04}-{month:02}-{day:02}T{hours:02}:{mins:02}:{secs:02}Z")
 }
 
-fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
+const fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
     // Algorithm from Henry Warren "Hacker's Delight" §12-3, adjusted for u64.
     days += 719468; // shift epoch to 0000-03-01
     let era = days / 146097;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -303,7 +303,7 @@ pub enum Command {
         /// Cloud-init customization TOML file. Applied (and the
         /// cloud-init drive regenerated) after the clone task
         /// completes. QEMU-only. Supported keys: ciuser,
-        /// cipassword, sshkey, sshkey_file, ipconfig0,
+        /// cipassword, sshkey, `sshkey_file`, ipconfig0,
         /// searchdomain, nameserver.
         #[arg(long, value_name = "FILE")]
         cloud_init_user: Option<std::path::PathBuf>,

--- a/src/cli/vm.rs
+++ b/src/cli/vm.rs
@@ -83,7 +83,7 @@ impl CloudInitProfile {
     }
 }
 
-/// Apply a CloudInitProfile to a QEMU guest and regenerate the
+/// Apply a `CloudInitProfile` to a QEMU guest and regenerate the
 /// cloud-init drive. No-op on empty profile (returns
 /// `applied=false`). LXC is rejected — cloud-init is QEMU-only.
 pub async fn apply_cloudinit_and_regen(

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,12 @@ fn main() -> Result<()> {
 
     let rt = tokio::runtime::Runtime::new()?;
 
+    // `single_match_else` would suggest `if let Some(cmd) = cli.command
+    // { … } else { … }` which forces a 120-line dedent of the CLI arm
+    // for zero readability gain — the two branches are genuinely
+    // symmetrical ("either a CLI subcommand OR fall into the TUI
+    // run-loop"), which `match` expresses better than an `if let`.
+    #[allow(clippy::single_match_else)]
     match cli.command {
         // CLI mode: no ratatui, no crossterm, just stdout
         Some(cmd) => {

--- a/src/mcp/http_server.rs
+++ b/src/mcp/http_server.rs
@@ -41,7 +41,7 @@ struct McpState {
 }
 
 impl McpState {
-    fn new(client: Arc<PxClient>, config: ConfigHandle) -> Self {
+    const fn new(client: Arc<PxClient>, config: ConfigHandle) -> Self {
         Self { client, config }
     }
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -5,28 +5,28 @@
 //! (text/plain; version=0.0.4) in-process — no external crate needed.
 //!
 //! Exposed metrics:
-//!   proxxx_node_cpu_usage_ratio{node}        — 0.0–1.0 CPU utilisation
-//!   proxxx_node_cpu_count{node}              — logical CPUs
-//!   proxxx_node_memory_used_bytes{node}
-//!   proxxx_node_memory_total_bytes{node}
-//!   proxxx_node_disk_used_bytes{node}
-//!   proxxx_node_disk_total_bytes{node}
-//!   proxxx_node_uptime_seconds{node}
-//!   proxxx_node_up{node}                     — 1=online 0=offline/unknown
+//!   `proxxx_node_cpu_usage_ratio{node}`        — 0.0–1.0 CPU utilisation
+//!   `proxxx_node_cpu_count{node}`              — logical CPUs
+//!   `proxxx_node_memory_used_bytes{node}`
+//!   `proxxx_node_memory_total_bytes{node}`
+//!   `proxxx_node_disk_used_bytes{node}`
+//!   `proxxx_node_disk_total_bytes{node}`
+//!   `proxxx_node_uptime_seconds{node}`
+//!   `proxxx_node_up{node}`                     — 1=online 0=offline/unknown
 //!
-//!   proxxx_guest_cpu_usage_ratio{vmid,name,type,node}
-//!   proxxx_guest_cpu_count{vmid,name,type,node}
-//!   proxxx_guest_memory_used_bytes{vmid,name,type,node}
-//!   proxxx_guest_memory_total_bytes{vmid,name,type,node}
-//!   proxxx_guest_disk_used_bytes{vmid,name,type,node}
-//!   proxxx_guest_disk_total_bytes{vmid,name,type,node}
-//!   proxxx_guest_uptime_seconds{vmid,name,type,node}
-//!   proxxx_guest_running{vmid,name,type,node} — 1=running 0=else
+//!   `proxxx_guest_cpu_usage_ratio{vmid,name,type,node}`
+//!   `proxxx_guest_cpu_count{vmid,name,type,node}`
+//!   `proxxx_guest_memory_used_bytes{vmid,name,type,node}`
+//!   `proxxx_guest_memory_total_bytes{vmid,name,type,node}`
+//!   `proxxx_guest_disk_used_bytes{vmid,name,type,node}`
+//!   `proxxx_guest_disk_total_bytes{vmid,name,type,node}`
+//!   `proxxx_guest_uptime_seconds{vmid,name,type,node}`
+//!   `proxxx_guest_running{vmid,name,type,node}` — 1=running 0=else
 //!
-//!   proxxx_storage_used_bytes{node,storage,type}
-//!   proxxx_storage_total_bytes{node,storage,type}
-//!   proxxx_storage_avail_bytes{node,storage,type}
-//!   proxxx_storage_active{node,storage,type}  — 1=active 0=inactive
+//!   `proxxx_storage_used_bytes{node,storage,type}`
+//!   `proxxx_storage_total_bytes{node,storage,type}`
+//!   `proxxx_storage_avail_bytes{node,storage,type}`
+//!   `proxxx_storage_active{node,storage,type}`  — 1=active 0=inactive
 
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary

- **Clippy zero-warning** — sweep makes `cargo clippy --all-targets --all-features` silent (was 13 unique warning categories across 42 sites). All changes behaviour-neutral.
- **Dead code purged** — `ensure_cache_dir` orphan from commit 9a29908 removed; the dead-code warning was masking any future regression of the same class.
- **Stale doc** — README install snippet `VERSION=0.1.7` → `0.2.0`; docs/index.md status row `v0.1.26` → `v0.2.0`.

## Why the existing deny-tier didn't catch these

`[lints.clippy]` already denies `unwrap_used` / `expect_used` / `panic` / `todo` / `await_holding_lock` (the categories that map to real bugs). The pedantic + nursery tiers are `warn` — they accumulate without breaking CI. This PR drains that pool so the *next* regression of a meaningful lint isn't hidden in noise. No tier was tightened by this PR.

## Manual fixes (not auto-applied by `cargo clippy --fix`)

1. `ensure_cache_dir` in `src/app/cache.rs` — deleted.
2. `last_chain_hmac` in `src/audit/mod.rs` — collapsed from `fn(…) -> Result<String>` (always `Ok`) to `fn(…) -> String`; drop the unused `?` at the single internal call site.
3. `#[allow(clippy::single_match_else)]` on top-level `match cli.command` in `src/main.rs` — inline justification: the alternative `if let / else` would force a 120-line dedent of the CLI arm for zero readability gain; the two branches are genuinely symmetric ("CLI subcommand vs. TUI run-loop"), which `match` expresses better than `if let`.

## Gate verification

- ✅ Stage 1 (fmt) — `cargo fmt --check` clean.
- ✅ Stage 2 (clippy) — `cargo clippy --all-targets --all-features` silent.
- ✅ Stage 3 (audit) — `cargo audit` clean (0 vulns / 0 warnings on 565 crates).
- ✅ Stage 4 (test) — `cargo test --all-targets` green (600+ tests, 0 failed, 16 ignored = live opt-in).
- ⏭ Stages 5–6 (live cluster probes) — skipped at commit time, cluster 192.168.0.122 was unreachable from the worktree environment. CI re-runs stages 1–4 exactly (CI has no live-cluster stage), so the contract this PR depends on is fully re-verified there.

Committed with `--no-verify` and explicitly documented above per the gate's own escape-hatch policy in `scripts/gate.sh`.

## Test plan

- [x] `cargo clippy --all-targets --all-features` → 0 warnings
- [x] `cargo fmt --check` → no diff
- [x] `cargo test --all-targets` → all green
- [x] `cargo audit` → 0 advisories
- [ ] CI green on this PR (re-runs stages 1–4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)