### PR TITLE
ci: CodeQL Rust SAST workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,107 @@
+# CodeQL — semantic static analysis for Rust.
+#
+# Runs GitHub's CodeQL engine against the codebase to surface high-
+# confidence bug patterns that cargo-clippy + cargo-audit + cargo-deny
+# don't catch: taint flow (untrusted input reaching unsafe sinks),
+# path-traversal, command-injection candidates, use-after-free shapes,
+# and the broader CWE coverage CodeQL has accumulated.
+#
+# Sits alongside the existing pipeline:
+#
+#   - ci.yml:build-test            — fmt + clippy(deny) + test + build
+#   - ci.yml:audit                 — cargo-audit (RustSec CVEs)
+#   - ci.yml:deny                  — cargo-deny (license/source/banned)
+#   - ci.yml:musl-static           — portable static binary build
+#   - scorecard.yml                — OpenSSF posture score + SARIF
+#   - codeql.yml (this file)       — CodeQL Rust SAST + SARIF
+#
+# Findings land under Security → Code scanning with per-finding
+# remediation guidance. The weekly cron catches regressions when the
+# CodeQL query database itself is updated upstream (queries added
+# AFTER the last commit-time scan).
+#
+# All third-party actions are pinned to a 40-char commit SHA — same
+# policy as ci.yml and scorecard.yml. Dependabot github-actions
+# ecosystem keeps these in sync.
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Wednesdays 04:23 UTC — offset from ci.yml (04:17 daily) and
+    # scorecard.yml (04:31 Mondays) so the three security scans don't
+    # all hit Actions runners at once.
+    - cron: "23 4 * * 3"
+
+# Minimal top-level permissions — satisfy OpenSSF Scorecard
+# TokenPermissions. The `analyze` job below opts in to the specific
+# writes it needs.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyse (rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Required to upload SARIF results to Code-Scanning.
+      security-events: write
+      # Required for private repos so CodeQL can read internal package
+      # metadata; harmless on public.
+      packages: read
+      # Required for CodeQL action to clone and analyse.
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Single-language matrix today (Rust), but the matrix shape
+        # is the GitHub-recommended form so adding e.g. JavaScript for
+        # docs/.vitepress later is a one-line change.
+        language: [rust]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Install Rust toolchain (stable)
+        # CodeQL's autobuild for Rust invokes `cargo build`. Providing
+        # the toolchain explicitly (same version as ci.yml) means the
+        # build inside CodeQL exactly matches the one CI verifies, so
+        # any divergence between "what CodeQL sees" and "what we ship"
+        # cannot come from a toolchain mismatch.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (HEAD as of 2026-03-27)
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          # Distinct cache key — CodeQL's build produces extra artefacts
+          # (database/) that we don't want polluting other jobs' caches.
+          shared-key: codeql
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
+        with:
+          languages: ${{ matrix.language }}
+          # `security-and-quality` adds quality queries on top of
+          # security-focused defaults. The extra signal is worth the
+          # ~10 % runtime increase given how strict the existing
+          # clippy/audit/deny stack already is.
+          queries: security-and-quality
+
+      - name: Autobuild
+        # CodeQL's Rust autobuild runs `cargo build` to observe the
+        # full compilation graph. If it ever stops working for our
+        # build shape, replace with an explicit `cargo build
+        # --all-targets` step — same net effect.
+        uses: github/codeql-action/autobuild@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds CodeQL semantic static analysis for Rust, the layer the existing stack doesn't cover:

| Layer | Tool | Catches |
| :--- | :--- | :--- |
| Lint/style | clippy (deny tier) | bad patterns we declared |
| Supply-chain CVE | cargo audit | known RustSec advisories |
| Supply-chain policy | cargo deny (#38) | license / source / bans |
| Posture score | OpenSSF Scorecard | repo-config hygiene |
| **SAST + taint flow** | **CodeQL (this PR)** | **CWE patterns clippy misses** |

CodeQL adds taint-flow analysis (untrusted input reaching unsafe sinks), path-traversal patterns, command-injection candidates, use-after-free shapes, and the broader CWE coverage the CodeQL query database has accumulated. Findings land under **Security → Code scanning** with per-finding remediation, not buried in workflow logs.

## Workflow shape

- **Triggers**: push to main, PR to main, weekly cron Wed 04:23 UTC (offset from ci.yml @ 04:17 daily + scorecard.yml @ 04:31 Mon).
- **Permissions**: minimal top-level (`contents: read`); analyse job opts in to `security-events: write` + `packages: read` + `actions: read` — passes OpenSSF Scorecard TokenPermissions.
- **Matrix**: single-language `rust` today; matrix shape kept GitHub-recommended so adding JS for `docs/.vitepress` is one line later.
- **Query set**: `security-and-quality` (~10 % runtime cost over `security` for the quality queries — worth it given the existing strict clippy/audit/deny gate).
- **Toolchain**: SAME SHA as ci.yml (`dtolnay/rust-toolchain` stable @ 2026-03-27) so the CodeQL-observed compilation exactly matches what CI verifies — divergence cannot come from toolchain mismatch.
- **Caching**: distinct `shared-key: codeql` so the CodeQL database doesn't pollute build-test / audit / deny / musl caches.
- **SHA pinning**: all third-party actions pinned to 40-char commits with `# vX.Y.Z` comments, mirroring ci.yml + scorecard.yml policy. Dependabot github-actions ecosystem already covers `.github/workflows/*.yml`, so no dependabot config change needed.

## What this enables

Once landed, every PR gets a CodeQL run; findings (if any) become PR review comments with remediation guidance, plus a permanent record in the Security tab. The weekly cron catches regressions when the CodeQL query DB is updated upstream — queries added AFTER our last commit-time scan still run against our code.

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(...)\"` parses clean
- [ ] First execution on this PR open completes without errors
- [ ] SARIF lands in Security → Code scanning
- [ ] Zero findings expected on the current codebase (clippy + audit + deny are already strict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)