### PR TITLE
chore(deps): ignore keyring 4.x major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,19 @@ updates:
     commit-message:
       prefix: "deps(cargo)"
       include: "scope"
+    ignore:
+      # keyring 4.x — upstream maintainer explicitly says NOT to use
+      # this version for real apps (the v4 crate is "just a sample
+      # app" per the v4.0.0 release notes; app users should depend on
+      # `keyring-core` v1 instead, after picking a credential-store
+      # implementation crate). See
+      # https://github.com/open-source-cooperative/keyring-rs
+      # release notes for v4.0.0. We stay on keyring 3.x until either
+      # upstream walks back the deprecation OR we do the migration to
+      # `keyring-core` + a chosen backend. Closed PR #28 with this
+      # same rationale 2026-05-19.
+      - dependency-name: "keyring"
+        update-types: ["version-update:semver-major"]
     groups:
       patch-and-minor:
         update-types:


### PR DESCRIPTION
## Summary

Upstream `keyring` v4.0.0 release notes are explicit:

> IMPORTANT: Apps that use keyring-compatible credential stores should **not** be relying on this release! They should instead be relying on the v1 release of `keyring-core`.

The v4 crate is "just a sample app" per upstream. Our usage in [src/config/mod.rs:152](src/config/mod.rs#L152) (`keyring::Entry::new(service, item)` + `.get_password()`) is exactly the pattern v4 deprecates. Bumping would either fail to compile or silently break secret resolution from the OS keychain.

Closed Dependabot [PR #28](https://github.com/fabriziosalmi/proxxx/pull/28) with the same rationale; this ignore rule stops the same PR from re-opening every Monday.

## Future migration (not in this PR)

Move to `keyring-core` v1 + a chosen credential-store backend per OS:
- `secret-service` on Linux (Secret Service / GNOME Keyring / KWallet)
- `windows-credentials` on Windows
- `macos-keychain` on Darwin

The migration also lets us re-evaluate the `tokio::spawn_blocking` wrapper at [src/config/mod.rs:147](src/config/mod.rs#L147) if `keyring-core` exposes an async surface natively (TBD on reading the new API).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses clean
- [ ] Dependabot doesn't re-open keyring 4.x PR next Monday (delayed verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)