### PR TITLE
deps(cargo): tokio-tungstenite 0.24 → 0.29 + adapt to breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -4704,22 +4704,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
- "thiserror 1.0.69",
- "utf-8",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4818,12 +4816,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ vt100 = { package = "vt100-ctt", version = "0.17", default-features = false }
 # WebSocket client for Proxmox termproxy serial console (feature 1b).
 # Uses rustls (matching reqwest's existing rustls-tls feature) so we don't
 # pull in native-tls / openssl-sys as a new system dep.
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 # HTTP server for MCP Streamable HTTP transport (2025-03-26 spec).
 # axum is already tokio-native; tower-http adds SSE + timeout middleware.

--- a/src/wsterm/mod.rs
+++ b/src/wsterm/mod.rs
@@ -73,11 +73,15 @@ pub async fn connect(
     // ws.next() does not happen until the write returns, which fills
     // the kernel TCP recv buffer (~64 KB) and stalls the producer.
     use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
-    let ws_config = WebSocketConfig {
-        max_frame_size: Some(1 << 20),
-        max_message_size: Some(4 << 20),
-        ..Default::default()
-    };
+    // tungstenite 0.29 marked WebSocketConfig as `#[non_exhaustive]` so
+    // we can no longer construct it with a struct literal. Build via
+    // Default then mutate the two fields we care about — the other
+    // defaults (write_buffer_size, accept_unmasked_frames, …) stay
+    // upstream-controlled, which is the right behaviour here: we only
+    // want to override the OOM-ceiling pair, not freeze every knob.
+    let mut ws_config = WebSocketConfig::default();
+    ws_config.max_frame_size = Some(1 << 20);
+    ws_config.max_message_size = Some(4 << 20);
 
     info!("termproxy WSS connect: {}", target.url);
     let (mut ws, _resp) = tokio_tungstenite::connect_async_tls_with_config(
@@ -91,7 +95,9 @@ pub async fn connect(
 
     // Auth frame — must be a binary frame containing `<user>:<ticket>\n`.
     use futures_util::SinkExt;
-    ws.send(Message::Binary(target.auth.as_bytes().to_vec()))
+    // tungstenite 0.29: Message::Binary now wraps `bytes::Bytes` (not
+    // `Vec<u8>`). `Vec<u8>` → `Bytes` is a zero-copy `From` impl.
+    ws.send(Message::Binary(target.auth.as_bytes().to_vec().into()))
         .await
         .context("sending termproxy auth frame")?;
 
@@ -116,7 +122,7 @@ where
 {
     use futures_util::SinkExt;
     let frame = format!("1:{cols}:{rows}:");
-    ws.send(Message::Binary(frame.into_bytes()))
+    ws.send(Message::Binary(frame.into_bytes().into()))
         .await
         .context("sending termproxy resize frame")?;
     Ok(())
@@ -139,7 +145,7 @@ where
     payload.extend_from_slice(bytes.len().to_string().as_bytes());
     payload.push(b':');
     payload.extend_from_slice(bytes);
-    ws.send(Message::Binary(payload))
+    ws.send(Message::Binary(payload.into()))
         .await
         .context("sending termproxy data frame")?;
     Ok(())


### PR DESCRIPTION
## Summary

Replaces Dependabot [PR #19](https://github.com/fabriziosalmi/proxxx/pull/19), which couldn't auto-merge because tungstenite-rs 0.29 has two source-breaking changes between 0.24 and 0.29.

## Breaking changes addressed

### 1. `Message::Binary(...)` now wraps `bytes::Bytes` (was `Vec<u8>`)

`Vec<u8> → Bytes` is a zero-copy `From` impl, so the three send-side call sites in [src/wsterm/mod.rs](src/wsterm/mod.rs) get a trailing `.into()`:

| Line | Send |
| :--- | :--- |
| 94 | auth-frame (`<user>:<ticket>\n` payload) |
| 119 | resize-frame (`1:<cols>:<rows>:` payload) |
| 142 | data-frame (`0:<len>:<bytes>` payload) |

Pattern-match receive sites (e.g. `Ok(Message::Binary(payload))` at [src/cli/console.rs:540](src/cli/console.rs#L540)) need **no change** — `Bytes: Deref<Target=[u8]>` so `decode_data_frame(&payload)` keeps working invariantly.

### 2. `WebSocketConfig` is now `#[non_exhaustive]`

Struct-literal construction (`WebSocketConfig { ... ..Default::default() }`) no longer compiles. Rewritten as `let mut c = WebSocketConfig::default(); c.max_frame_size = ...; c.max_message_size = ...;` — keeps the same two overrides (1 MiB frame / 4 MiB message ceiling) without pinning every other knob upstream maintains.

The OOM-ceiling comment block above the config in [src/wsterm/mod.rs](src/wsterm/mod.rs) is preserved verbatim — same security property, same defence-in-depth chain (frame + message + backpressure).

## What we gain

- 5 minor versions collapsed (0.25 / 0.26 / 0.27 / 0.28 / 0.29), bringing internal perf and CVE fixes.
- Dep count down 565 → 563 (two fewer transitives).
- No new RustSec advisory in the upgrade path.

## Verification

- ✅ `cargo check --all-targets` clean
- ✅ `cargo clippy --all-targets --all-features` silent
- ✅ `cargo test --lib --bins --tests` — 600+ tests green, 0 failed
- ✅ `cargo audit --deny warnings` — 0 vulns / 0 warnings (563 crates)
- ✅ `cargo deny check` — advisories / bans / licenses / sources all ok

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)