### PR TITLE
docs: renumber gate to 8 stages + refresh post-hardening numbers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,18 +53,22 @@ cd docs && npm install && npx vitepress dev
 
 ## The gate (commit acceptance criteria)
 
-Every commit on `main` passes a 7-stage local gate AND CI. Bypassing
+Every commit on `main` passes an 8-stage local gate AND CI. Bypassing
 either with `--no-verify` is owned by the bypasser. Stages:
 
 | # | Stage | What | Roughly |
 | - | --- | --- | --- |
 | 0 | secret regression scan | Looks for tokens / passwords accidentally committed | <1 s |
 | 1 | `cargo fmt --check` | Code style | ~3 s |
-| 2 | `cargo clippy --release --all-targets` | Lints, deny tier (`unwrap_used`, `expect_used`, `panic`, `indexing_slicing`) | 10–60 s |
+| 2 | `cargo clippy --release --all-targets` | Lints, deny tier (`unwrap_used`, `expect_used`, `panic`, `todo`, `await_holding_lock`) | 10–60 s |
 | 3 | `cargo audit --deny warnings` | Supply-chain CVEs from `Cargo.lock` | 3–5 s |
-| 4 | `cargo test --release --all-targets` | All unit + integration + wiremock tests | 10–90 s |
-| 5 | `tests/live/test_run.sh` | 88 read-only probes against a real PVE cluster | ~30 s |
-| 6 | `tests/live/test_mutation.sh` | LXC 9999 lifecycle + cluster-level CRUD + QEMU 9998; opt-in QGA via `PROXXX_E2E_QGA_VMID=<vmid>` | ~60 s |
+| 4 | `cargo deny check` | License whitelist + banned crates + crates.io-only sources + wildcard ban | 2–4 s |
+| 5 | `cargo test --release --all-targets` | All unit + integration + wiremock + proptest cases (~25 properties × 256 random cases) | 10–90 s |
+| 6 | `tests/live/test_run.sh` | 87 read-only probes against a real PVE cluster | ~30 s |
+| 7 | `tests/live/test_mutation.sh` | LXC 9999 lifecycle + cluster-level CRUD + QEMU 9998; opt-in QGA via `PROXXX_E2E_QGA_VMID=<vmid>` | ~60 s |
+
+End-to-end wall time against a reachable cluster: **~340–480 s** (a
+release build dominates; stages 6+7 themselves are ~100 s combined).
 
 Hook setup:
 
@@ -75,8 +79,8 @@ cp tests/live/env.local.example tests/live/env.local
 # fill in PROXXX_E2E_PVE_URL / TOKEN / NODE
 ```
 
-Stages 5 + 6 require a reachable PVE cluster. If you don't have one,
-**explicitly skip stages 5 + 6** in your PR description — a maintainer
+Stages 6 + 7 require a reachable PVE cluster. If you don't have one,
+**explicitly skip stages 6 + 7** in your PR description — a maintainer
 will run them. Don't silently bypass.
 
 ## Live-cluster verification

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Pick the row that matches you and jump straight to the right page.
 | **LLM / agent integrator** wiring Claude/Cursor to a cluster | MCP server (stdio + Streamable HTTP), compile-time-fixed 25-tool registry, SHA-256 pinned for supply-chain audit | [LLM/MCP quickstart](https://fabriziosalmi.github.io/proxxx/guide/quickstart-llm-mcp) |
 | **Security / compliance** evaluating before deploy | typed errors, HITL replay protection, sigstore-signed releases, CycloneDX SBOM, gate on every commit | [`THREAT_MODEL.md`](THREAT_MODEL.md) · [`SECURITY.md`](SECURITY.md) · [Production checklist](https://fabriziosalmi.github.io/proxxx/guide/production-checklist) |
 | **EU-regulated ops** (NIS2 / ISO 27001 / GDPR) | append-only SQLite audit log with HMAC-SHA256 chain, `proxxx audit verify`, zero telemetry, fully self-hosted | [EU & compliance](#eu--compliance) |
-| **Contributor** sending a PR | 8-stage commit gate (live cluster + mutation lifecycle), no-skip-flags policy | [`ARCHITECTURE.md`](ARCHITECTURE.md) · [`CONTRIBUTING.md`](CONTRIBUTING.md) · [Pre-commit gate](https://fabriziosalmi.github.io/proxxx/guide/pre-commit-gate) |
+| **Contributor** sending a PR | 8-stage commit gate (fmt + clippy + audit + cargo-deny + test+proptest + live cluster + mutation lifecycle), no-skip-flags policy | [`ARCHITECTURE.md`](ARCHITECTURE.md) · [`CONTRIBUTING.md`](CONTRIBUTING.md) · [Pre-commit gate](https://fabriziosalmi.github.io/proxxx/guide/pre-commit-gate) |
 
 ---
 
@@ -216,21 +216,26 @@ Secrets resolve in order: CLI flag → `PROXXX_TOKEN_SECRET` env → `token_secr
 
 ## Quality gate
 
-Six stages, run as both a pre-commit hook and the CI contract in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+Eight stages, run as both a pre-commit hook and the CI contract in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
 | Stage | What | Time |
 | :---: | :--- | :---: |
+| 0 | secret regression scan | <1 s |
 | 1 | `cargo fmt --all -- --check` | ~3 s |
 | 2 | `cargo clippy --release --all-targets` | 10–60 s |
 | 3 | `cargo audit --deny warnings` | 3–5 s |
-| 4 | `cargo test --release --all-targets` | 10–90 s |
-| 5 | `tests/live/test_run.sh` (87 read-only probes against the live cluster) | ~30 s |
-| 6 | `tests/live/test_mutation.sh` (LXC + cluster-level CRUD + QEMU; opt-in QGA via `PROXXX_E2E_QGA_VMID=<vmid>`) | ~60 s |
+| 4 | `cargo deny check` (license / banned crates / sources / wildcards) | 2–4 s |
+| 5 | `cargo test --release --all-targets` (unit + integration + ~25 proptest properties × 256 cases each) | 10–90 s |
+| 6 | `tests/live/test_run.sh` (87 read-only probes against the live cluster) | ~30 s |
+| 7 | `tests/live/test_mutation.sh` (LXC + cluster-level CRUD + QEMU; opt-in QGA via `PROXXX_E2E_QGA_VMID=<vmid>`) | ~60 s |
+
+End-to-end wall time against a reachable cluster: **~340–480 s**.
 
 ```bash
 git config core.hooksPath .githooks
 chmod +x scripts/gate.sh .githooks/pre-commit .githooks/pre-push
 cargo install cargo-audit --locked
+cargo install cargo-deny --locked
 ```
 
 The clippy `[lints.clippy]` block in [`Cargo.toml`](Cargo.toml) denies `unwrap_used`, `expect_used`, `panic`, `todo`, `await_holding_lock` in production code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,8 @@ features:
     details: CLI, TUI, and MCP server in the same executable. Same risk gate, same HITL gate, same API client. The TUI is for interactive operations; the CLI is the same operations, scriptable, JSON-friendly, and CI-ready; the MCP surface is a deterministic 25-tool registry (stdio + Streamable HTTP transports) for LLM agents.
   - title: No agent on the cluster
     details: Direct REST against PVE (token or password) and PBS (token only), with typed error categories so callers match on the failure shape instead of grepping prose. SSH only for the paths PVE never exposed over REST — patch apply, full effective-permissions, per-guest interactive sessions.
-  - title: Six-stage commit gate, no skip flags
-    details: cargo fmt, cargo clippy --all-targets at deny tier, cargo audit against a pinned advisory policy, the full test suite, 87 read-only probes against a live cluster, and a full mutation lifecycle covering LXC, cluster-level CRUD, QEMU, and opt-in QGA agent-required round-trips. Every commit on main passes locally and in CI.
+  - title: Eight-stage commit gate, no skip flags
+    details: secret-shape scan, cargo fmt, cargo clippy --all-targets at deny tier, cargo audit against a pinned advisory policy, cargo deny check (license whitelist + banned crates + crates.io-only sources + wildcard ban), the full test suite (unit + integration + ~25 proptest properties at 256 random cases each, ~6 400 invariant checks total), 87 read-only probes against a live cluster, and a full mutation lifecycle covering LXC, cluster-level CRUD, QEMU, and opt-in QGA agent-required round-trips. Every commit on main passes locally and in CI.
   - title: Pre-flight risk gate plus HITL
     details: 11 risk variants — running, long-uptime, locked, HA-managed, tagged prod, active net traffic, listening on service, many snapshots, backup age warning, no backup found, deep-check skipped — refuse destructive operations on guests that look like production unless overridden explicitly. Above that, a real Telegram round-trip with deny-on-timeout for any op marked destructive by policy.
 ---
@@ -104,13 +104,14 @@ onMounted(() => {
 
 | Surface               | Today                                                    |
 | :-------------------- | :------------------------------------------------------- |
-| Source                | ~44 KLOC Rust · ~14 KLOC tests                           |
-| Quality gate          | 6 stages · ~80–260 s wall time                           |
-| Live cluster coverage | 87 read probes + full mutation lifecycle per gate run    |
+| Source                | ~48 KLOC Rust · ~14 KLOC tests                           |
+| Quality gate          | 8 stages · ~340–480 s wall time (live cluster path)      |
+| Live cluster coverage | 87 read probes + 47 mutation probes per gate run         |
+| Property testing      | ~25 proptest properties × 256 random cases = ~6 400 invariant checks per `cargo test` |
 | Mutation lifecycle    | LXC create→start→snapshot→stop→delete · cluster-level CRUD (pool / firewall-cluster / backup-jobs / notifications / storage-defs) · QEMU 9998 from alpine ISO · opt-in QGA round-trips |
 | Binary                | 6–9 MB stripped depending on target · single static · no installer |
-| Supply chain          | `cargo audit --deny warnings` per push + nightly cron    |
-| System dependencies   | 0 — rustls only, no native-tls, no openssl               |
+| Supply chain          | `cargo audit --deny warnings` + `cargo deny check` per push + nightly cron + CodeQL Rust SAST |
+| System dependencies   | 0 — rustls only, no native-tls, no openssl (banned in `deny.toml`) |
 | MCP tool registry     | 25 tools · stdio + HTTP · SHA-256 pinned · compile-time fixed |
 
 ## A taste


### PR DESCRIPTION
## Summary

After Sessione 1-3 hardening the local + CI gate runs **8 stages**, not the documented 7 (and not the docs-site claim of 6). cargo-deny was added as stage 4 (PR #38), shifting the live-cluster stages to 6+7. This sweep reconciles every stale reference across README, docs/index, and CONTRIBUTING.

## Stage map (now)

| # | Stage |
| - | --- |
| 0 | secret regression scan |
| 1 | `cargo fmt --check` |
| 2 | `cargo clippy --release --all-targets` (deny tier) |
| 3 | `cargo audit --deny warnings` |
| 4 | `cargo deny check` (license + bans + sources + wildcards) ← **NEW from #38** |
| 5 | `cargo test --release --all-targets` (incl. ~25 proptest properties × 256 random cases) |
| 6 | `tests/live/test_run.sh` (87 read-only probes against live PVE) |
| 7 | `tests/live/test_mutation.sh` (LXC + cluster CRUD + QEMU 9998) |

## Other corrections in this PR

- **clippy deny tier list** — CONTRIBUTING said `unwrap_used / expect_used / panic / indexing_slicing`. `indexing_slicing` was demoted to `allow` in Cargo.toml's `[lints.clippy]` block with a documented reason (140 already-bounds-checked sites in TUI renderers; `panic = deny` catches the real failure mode). Real deny tier is now `unwrap_used / expect_used / panic / todo / await_holding_lock`.
- **live read probe count** — CONTRIBUTING said 88, actual is 87.
- **wall-time** — docs/index claimed `6 stages · ~80–260 s`. Live path is now `~340–480 s`. Updated in all 3 files.
- **KLOC** — docs/index claimed ~44 KLOC. `wc -l src/**/*.rs` reports 48 319 after the proptest additions → ~48 KLOC.
- **By the numbers** — added a "Property testing" row to docs/index showing the ~6 400 invariant checks per `cargo test`. Updated "Supply chain" to mention cargo-deny + CodeQL alongside cargo-audit. Added "openssl/native-tls banned in deny.toml" qualifier on the system-deps row.

## Verification

- `cargo fmt --check` — clean (docs-only PR).
- No source code modified — pure documentation reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)