### PR TITLE
feat(state): cluster state export — foundation + pools (epic #74 PR 1)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,6 +16,7 @@ mod init_wizard;
 mod monitoring;
 mod node;
 mod patch;
+mod state;
 mod storage;
 pub mod vm;
 
@@ -721,6 +722,16 @@ pub enum Command {
     Audit {
         #[command(subcommand)]
         action: AuditAction,
+    },
+    /// Cluster state export + reconcile — the path toward declaratively
+    /// versioned Proxmox clusters tracked in epic #74.
+    ///
+    /// v1 ships `state export` for the `pools` resource only. Future
+    /// PRs add `state diff` / `state apply` plus the acl, storage,
+    /// firewall-cluster, backup-jobs, and notifications families.
+    State {
+        #[command(subcommand)]
+        action: state::StateCommand,
     },
     /// QEMU VM hardware/options/cloud-init management. The typed
     /// subcommands (`set`, `cloudinit`) cover the well-trodden config
@@ -1639,6 +1650,7 @@ pub async fn execute(
         Command::Completions { .. } => Ok((serde_json::json!({}), 0)),
         Command::Doctor => Ok((serde_json::json!({}), 0)),
         Command::Audit { .. } => Ok((serde_json::json!({}), 0)),
+        Command::State { action } => state::execute_state(&client, profile, action).await,
         Command::Vm { action } => vm::execute_vm(&client, action).await,
         Command::Ct { action } => ct::execute(&client, action).await,
         Command::Firewall { scope } => firewall::execute_firewall(&client, scope).await,

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -1,0 +1,102 @@
+//! `proxxx state {export}` — read live cluster state into TOML (or
+//! JSON).
+//!
+//! v1 ships export only, pools only. Subsequent commands (`diff`,
+//! `apply`) and resource families (acl, storage, firewall-cluster,
+//! backup-jobs, notifications) land in follow-up PRs tracked by epic
+//! [#74](https://github.com/fabriziosalmi/proxxx/issues/74).
+
+use anyhow::Result;
+use clap::{Subcommand, ValueEnum};
+use serde_json::Value;
+use std::sync::Arc;
+
+use crate::api::PxClient;
+use crate::state;
+
+/// Local output-format choice for `state export`. Independent of the
+/// global `--format` flag because TOML isn't part of `OutputFormat` —
+/// `state export` is the only command that emits TOML, so the format
+/// surface stays here rather than bleeding into the global enum.
+#[derive(Debug, Clone, Copy, ValueEnum, Default)]
+pub enum ExportFormat {
+    /// TOML (default). The canonical format for the `GitOps` workflow
+    /// — diff-stable byte-for-byte across runs against an unchanged
+    /// cluster.
+    #[default]
+    Toml,
+    /// JSON (pretty). For piping into `jq` / programmatic consumers.
+    Json,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum StateCommand {
+    /// Export the cluster's mutable state.
+    ///
+    /// v1 supports `--resource pools` only. More resource families
+    /// (acl, storage, firewall-cluster, backup-jobs, notifications)
+    /// land per the ladder in epic #74.
+    ///
+    /// The resulting document is byte-stable across runs against an
+    /// unchanged cluster — every collection is sorted by its identity
+    /// field on the way out — so a `git diff` after a re-export only
+    /// shows actual cluster drift, never serialisation noise.
+    ///
+    /// Examples:
+    ///   proxxx state export                                 # default: pools, TOML to stdout
+    ///   proxxx state export > state.toml                    # capture to file
+    ///   proxxx state export --output json | jq '.pools[0]'  # programmatic
+    Export {
+        /// Resource family to export. Valid in v1: `pools`. More
+        /// coming — see issue #74.
+        #[arg(long, default_value = "pools")]
+        resource: String,
+
+        /// Output format for the exported document. TOML (default)
+        /// is the canonical disk format for the GitOps workflow;
+        /// JSON is for piping into `jq` and other programmatic
+        /// consumers. Distinct from the global `--format` flag,
+        /// which controls how proxxx's normal table/json/plain
+        /// output is rendered — state export bypasses that pipeline
+        /// and writes the document directly to stdout.
+        #[arg(long, value_enum, default_value_t = ExportFormat::Toml)]
+        output: ExportFormat,
+    },
+}
+
+/// Execute a `proxxx state …` invocation.
+///
+/// Export prints the document directly to stdout in the requested
+/// format and returns `Value::Null` to skip the standard print
+/// pipeline — the document IS the output, re-serialising it through
+/// `format::print` would either escape the TOML's newlines or wrap
+/// the JSON in an additional outer layer.
+pub async fn execute_state(
+    client: &Arc<PxClient>,
+    profile: Option<&str>,
+    action: StateCommand,
+) -> Result<(Value, i32)> {
+    match action {
+        StateCommand::Export { resource, output } => {
+            let r = state::export::Resource::parse(&resource)?;
+            let profile_label = profile.unwrap_or("default");
+            let exported =
+                state::export::export_state(client.as_ref(), &[r], profile_label).await?;
+
+            match output {
+                ExportFormat::Toml => {
+                    let s = toml::to_string_pretty(&exported)?;
+                    print!("{s}");
+                    if !s.ends_with('\n') {
+                        println!();
+                    }
+                }
+                ExportFormat::Json => {
+                    let s = serde_json::to_string_pretty(&exported)?;
+                    println!("{s}");
+                }
+            }
+            Ok((Value::Null, 0))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod mcp;
 pub mod metrics;
 pub mod pbs;
 pub mod ssh;
+pub mod state;
 pub mod tui;
 pub mod util;
 pub mod wsterm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,16 +112,26 @@ fn main() -> Result<()> {
                 cli.secure,
             )) {
                 Ok((result, exit_code)) => {
-                    // Ensure the output is a JSON array if Json format is requested
-                    let result_array = if matches!(cli.format, util::format::OutputFormat::Json)
-                        && !result.is_array()
-                    {
-                        serde_json::json!([result])
-                    } else {
-                        result
-                    };
+                    // `Value::Null` is the convention for commands
+                    // that have already printed their full output
+                    // directly to stdout (e.g. `state export` emits
+                    // raw TOML; re-serialising through the format
+                    // pipeline would either escape the newlines or
+                    // wrap the document in a JSON array). Skip the
+                    // print step entirely on Null and exit cleanly.
+                    if !result.is_null() {
+                        // Ensure the output is a JSON array if Json
+                        // format is requested.
+                        let result_array = if matches!(cli.format, util::format::OutputFormat::Json)
+                            && !result.is_array()
+                        {
+                            serde_json::json!([result])
+                        } else {
+                            result
+                        };
 
-                    let _ = util::format::print(&result_array, cli.format);
+                        let _ = util::format::print(&result_array, cli.format);
+                    }
                     if exit_code != 0 {
                         std::process::exit(exit_code);
                     }

--- a/src/state/export.rs
+++ b/src/state/export.rs
@@ -1,0 +1,478 @@
+//! Read live cluster state into a `ClusterState`.
+//!
+//! Pure read: this layer never mutates. Pools-side calls go through a
+//! narrow [`PoolReadView`] trait that's a strict subset of the full
+//! [`ProxmoxGateway`](crate::api::ProxmoxGateway) — the blanket impl
+//! below means any production [`ProxmoxGateway`] auto-satisfies it,
+//! and unit tests implement the small trait directly without having
+//! to stub 200+ unrelated methods.
+//!
+//! Diff-stability: every collection is sorted on the way out by its
+//! identity field. Two calls to `export_state` against an unchanged
+//! cluster produce byte-identical TOML, so a `git diff` after a
+//! re-export only shows actual cluster drift.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::api::types::{ApiVersion, Pool, PoolDetails, PoolMember};
+use crate::state::model::{ClusterState, PoolDecl, StateMeta};
+
+/// Which resource families to export. Parsed from the CLI `--resource`
+/// argument; v1 supports `pools` only. Future variants will be added
+/// as the per-PR ladder in epic #74 lands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Resource {
+    Pools,
+}
+
+impl Resource {
+    /// Parse a `--resource` argument. Case-insensitive. Unknown values
+    /// produce an `Err` carrying the full set of currently-valid
+    /// options — operators see "what should I have typed" at the
+    /// point of failure.
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.trim().to_lowercase().as_str() {
+            "pools" => Ok(Self::Pools),
+            other => anyhow::bail!(
+                "unknown resource '{other}' (valid in v1: pools — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
+            ),
+        }
+    }
+
+    /// Human-readable name for logs / error messages.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pools => "pools",
+        }
+    }
+}
+
+/// Minimal read-only surface the pools exporter needs from PVE. A
+/// blanket impl below means anything that implements
+/// `ProxmoxGateway` auto-satisfies `PoolReadView`; tests implement
+/// this small trait directly to avoid stubbing the 200+ methods of
+/// `ProxmoxGateway`.
+#[async_trait]
+pub trait PoolReadView: Send + Sync {
+    async fn list_pools_view(&self) -> Result<Vec<Pool>>;
+    async fn get_pool_view(&self, poolid: &str) -> Result<PoolDetails>;
+    async fn get_api_version_view(&self) -> Result<ApiVersion>;
+}
+
+#[async_trait]
+impl<T> PoolReadView for T
+where
+    T: crate::api::ProxmoxGateway + Send + Sync + ?Sized,
+{
+    async fn list_pools_view(&self) -> Result<Vec<Pool>> {
+        crate::api::ProxmoxGateway::list_pools(self).await
+    }
+    async fn get_pool_view(&self, poolid: &str) -> Result<PoolDetails> {
+        crate::api::ProxmoxGateway::get_pool(self, poolid).await
+    }
+    async fn get_api_version_view(&self) -> Result<ApiVersion> {
+        crate::api::ProxmoxGateway::get_api_version(self).await
+    }
+}
+
+/// Top-level entry: read everything in `resources` from the live
+/// cluster and return a `ClusterState`. Always populates `meta` with
+/// the export provenance.
+pub async fn export_state<C: PoolReadView + ?Sized>(
+    client: &C,
+    resources: &[Resource],
+    profile: &str,
+) -> Result<ClusterState> {
+    let pve_version = client
+        .get_api_version_view()
+        .await
+        .map(|v| v.version)
+        .unwrap_or_default();
+
+    let mut state = ClusterState {
+        meta: Some(StateMeta {
+            profile: profile.to_string(),
+            exported_at: rfc3339_now(),
+            exported_from_proxxx: env!("CARGO_PKG_VERSION").to_string(),
+            pve_version,
+        }),
+        pools: Vec::new(),
+    };
+
+    for r in resources {
+        match r {
+            Resource::Pools => {
+                state.pools = export_pools(client)
+                    .await
+                    .with_context(|| "exporting pools")?;
+            }
+        }
+    }
+
+    Ok(state)
+}
+
+/// Read every pool + its membership and project to `Vec<PoolDecl>`.
+/// Pools sorted by `poolid`; members within each pool sorted by their
+/// `kind/id` string. Two calls against an unchanged cluster produce
+/// the identical Vec.
+async fn export_pools<C: PoolReadView + ?Sized>(client: &C) -> Result<Vec<PoolDecl>> {
+    let mut pools = client.list_pools_view().await.context("listing pools")?;
+    pools.sort_by(|a, b| a.poolid.cmp(&b.poolid));
+
+    let mut out = Vec::with_capacity(pools.len());
+    for p in pools {
+        let detail: PoolDetails = client
+            .get_pool_view(&p.poolid)
+            .await
+            .with_context(|| format!("reading pool '{}'", p.poolid))?;
+
+        let mut members: Vec<String> = detail
+            .members
+            .into_iter()
+            .filter_map(|m| pool_member_to_ref(&m))
+            .collect();
+        members.sort();
+
+        out.push(PoolDecl {
+            // `list_pools` and `get_pool` both carry `poolid` and
+            // `comment`; prefer the detail's comment as the source of
+            // truth since the index is a separate query that could
+            // theoretically be slightly stale (PVE keeps them
+            // synchronised in practice).
+            poolid: p.poolid,
+            comment: detail.comment,
+            members,
+        });
+    }
+    Ok(out)
+}
+
+/// Project one `PoolMember` to its identity string (`qemu/100`,
+/// `lxc/200`, `storage/<name>`). Returns `None` for unknown member
+/// types — PVE may add new kinds in future versions (SDN objects, for
+/// example), and unknown members are dropped on export rather than
+/// crashing the dump. The dropped count is logged via `tracing::warn`.
+fn pool_member_to_ref(m: &PoolMember) -> Option<String> {
+    match m.member_type.as_str() {
+        "qemu" => Some(format!("qemu/{}", m.vmid)),
+        "lxc" => Some(format!("lxc/{}", m.vmid)),
+        "storage" => Some(format!("storage/{}", m.storage)),
+        other => {
+            tracing::warn!(
+                kind = other,
+                id = %m.id,
+                "pool member of unknown kind skipped on export"
+            );
+            None
+        }
+    }
+}
+
+/// RFC 3339 timestamp in UTC for the export's `meta.exported_at`.
+/// Hand-rolled to avoid pulling chrono just for one timestamp; the
+/// audit module has the same algorithm and we deliberately don't
+/// share the helper to keep the two modules' formatters independent
+/// (a future change to one shouldn't silently rebase the other).
+fn rfc3339_now() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400;
+    let (y, mo, d) = days_to_ymd(days);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+const fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
+    let mut y = 1970u64;
+    loop {
+        let leap = (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400);
+        let dy = if leap { 366 } else { 365 };
+        if days < dy {
+            break;
+        }
+        days -= dy;
+        y += 1;
+    }
+    let leap = (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400);
+    let months: [u64; 12] = if leap {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+    let mut mo = 1u64;
+    let mut i = 0;
+    while i < months.len() {
+        if days < months[i] {
+            break;
+        }
+        days -= months[i];
+        mo += 1;
+        i += 1;
+    }
+    (y, mo, days + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::{Pool, PoolDetails, PoolMember};
+
+    #[test]
+    fn member_to_ref_qemu() {
+        let m = PoolMember {
+            id: "qemu/100".into(),
+            member_type: "qemu".into(),
+            vmid: 100,
+            ..Default::default()
+        };
+        assert_eq!(pool_member_to_ref(&m).as_deref(), Some("qemu/100"));
+    }
+
+    #[test]
+    fn member_to_ref_lxc() {
+        let m = PoolMember {
+            id: "lxc/200".into(),
+            member_type: "lxc".into(),
+            vmid: 200,
+            ..Default::default()
+        };
+        assert_eq!(pool_member_to_ref(&m).as_deref(), Some("lxc/200"));
+    }
+
+    #[test]
+    fn member_to_ref_storage_uses_storage_field_not_vmid() {
+        // PVE returns storage members with vmid=0 and the real id in
+        // the `storage` field. Pins that we read the right column.
+        let m = PoolMember {
+            id: "storage/pve-test-1/ceph-rbd".into(),
+            member_type: "storage".into(),
+            vmid: 0,
+            storage: "ceph-rbd".into(),
+            ..Default::default()
+        };
+        assert_eq!(pool_member_to_ref(&m).as_deref(), Some("storage/ceph-rbd"));
+    }
+
+    #[test]
+    fn member_to_ref_unknown_kind_is_skipped() {
+        // SDN objects, future PVE additions, etc. We log + drop
+        // rather than crash; the dropped count is observable via
+        // the tracing layer at warn level.
+        let m = PoolMember {
+            id: "sdn/somenet".into(),
+            member_type: "sdn".into(),
+            ..Default::default()
+        };
+        assert!(pool_member_to_ref(&m).is_none());
+    }
+
+    #[test]
+    fn resource_parse_accepts_pools_case_insensitive() {
+        assert_eq!(Resource::parse("pools").unwrap(), Resource::Pools);
+        assert_eq!(Resource::parse("Pools").unwrap(), Resource::Pools);
+        assert_eq!(Resource::parse("POOLS").unwrap(), Resource::Pools);
+        assert_eq!(Resource::parse(" pools ").unwrap(), Resource::Pools);
+    }
+
+    #[test]
+    fn resource_parse_rejects_unknown_with_helpful_message() {
+        // The error message should tell the operator what they
+        // SHOULD have typed — pinning so a future regression
+        // doesn't collapse to a generic "invalid argument".
+        let err = Resource::parse("acl").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unknown resource 'acl'"), "msg: {msg}");
+        assert!(
+            msg.contains("pools"),
+            "should hint at valid value, msg: {msg}"
+        );
+    }
+
+    /// In-process implementation of the narrow `PoolReadView` trait
+    /// for unit testing `export_pools` / `export_state` without
+    /// stubbing the 200+ methods of `ProxmoxGateway`.
+    #[derive(Default)]
+    struct FakePoolView {
+        pools: Vec<Pool>,
+        details: std::collections::HashMap<String, PoolDetails>,
+    }
+
+    #[async_trait]
+    impl PoolReadView for FakePoolView {
+        async fn list_pools_view(&self) -> Result<Vec<Pool>> {
+            Ok(self.pools.clone())
+        }
+        async fn get_pool_view(&self, poolid: &str) -> Result<PoolDetails> {
+            self.details
+                .get(poolid)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("pool '{poolid}' not in fake view"))
+        }
+        async fn get_api_version_view(&self) -> Result<ApiVersion> {
+            Ok(ApiVersion {
+                version: "9.1.9-test".into(),
+                release: "9.1".into(),
+                repoid: "fake".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn export_pools_sorts_pools_by_poolid() {
+        // Even if PVE returns pools in random order, the export must
+        // be sorted by poolid so the TOML is diff-stable across runs.
+        let mut fake = FakePoolView::default();
+        fake.pools = vec![
+            Pool {
+                poolid: "z-platform".into(),
+                comment: "z".into(),
+            },
+            Pool {
+                poolid: "a-dev".into(),
+                comment: "a".into(),
+            },
+            Pool {
+                poolid: "m-staging".into(),
+                comment: "m".into(),
+            },
+        ];
+        for p in &fake.pools {
+            fake.details.insert(
+                p.poolid.clone(),
+                PoolDetails {
+                    poolid: p.poolid.clone(),
+                    comment: p.comment.clone(),
+                    members: vec![],
+                },
+            );
+        }
+
+        let out = export_pools(&fake).await.expect("export");
+        let ids: Vec<&str> = out.iter().map(|p| p.poolid.as_str()).collect();
+        assert_eq!(ids, vec!["a-dev", "m-staging", "z-platform"]);
+    }
+
+    #[tokio::test]
+    async fn export_pools_sorts_members_within_each_pool() {
+        let mut fake = FakePoolView::default();
+        fake.pools = vec![Pool {
+            poolid: "p1".into(),
+            comment: String::new(),
+        }];
+        fake.details.insert(
+            "p1".into(),
+            PoolDetails {
+                poolid: "p1".into(),
+                comment: String::new(),
+                members: vec![
+                    PoolMember {
+                        id: "qemu/200".into(),
+                        member_type: "qemu".into(),
+                        vmid: 200,
+                        ..Default::default()
+                    },
+                    PoolMember {
+                        id: "storage/ceph-rbd".into(),
+                        member_type: "storage".into(),
+                        storage: "ceph-rbd".into(),
+                        ..Default::default()
+                    },
+                    PoolMember {
+                        id: "qemu/100".into(),
+                        member_type: "qemu".into(),
+                        vmid: 100,
+                        ..Default::default()
+                    },
+                ],
+            },
+        );
+
+        let out = export_pools(&fake).await.expect("export");
+        assert_eq!(out.len(), 1);
+        // Sorted: "qemu/100" < "qemu/200" < "storage/ceph-rbd"
+        // (lexical compare; member identity is a `kind/id` string).
+        assert_eq!(
+            out[0].members,
+            vec![
+                "qemu/100".to_string(),
+                "qemu/200".to_string(),
+                "storage/ceph-rbd".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn export_state_populates_meta_with_profile_and_pve_version() {
+        let fake = FakePoolView::default();
+        let s = export_state(&fake, &[Resource::Pools], "test-profile")
+            .await
+            .expect("export");
+        let meta = s.meta.expect("meta present");
+        assert_eq!(meta.profile, "test-profile");
+        assert_eq!(meta.pve_version, "9.1.9-test");
+        // exported_from_proxxx comes from CARGO_PKG_VERSION — should
+        // match the binary's compile-time version.
+        assert_eq!(meta.exported_from_proxxx, env!("CARGO_PKG_VERSION"));
+        // exported_at is RFC 3339 — basic shape check.
+        assert!(
+            meta.exported_at.ends_with('Z'),
+            "expected RFC 3339 Z suffix, got {:?}",
+            meta.exported_at
+        );
+        assert!(
+            meta.exported_at.contains('T'),
+            "expected RFC 3339 'T' separator, got {:?}",
+            meta.exported_at
+        );
+    }
+
+    #[tokio::test]
+    async fn export_state_is_byte_stable_on_two_runs_against_unchanged_state() {
+        // Diff-stability contract: two consecutive exports against
+        // identical input yield identical TOML modulo `exported_at`.
+        // This is the load-bearing property for GitOps — without it,
+        // every `git diff` post-re-export is noise.
+        let mut fake = FakePoolView::default();
+        fake.pools = vec![
+            Pool {
+                poolid: "alpha".into(),
+                comment: "a".into(),
+            },
+            Pool {
+                poolid: "beta".into(),
+                comment: "b".into(),
+            },
+        ];
+        for p in &fake.pools {
+            fake.details.insert(
+                p.poolid.clone(),
+                PoolDetails {
+                    poolid: p.poolid.clone(),
+                    comment: p.comment.clone(),
+                    members: vec![],
+                },
+            );
+        }
+
+        let s1 = export_state(&fake, &[Resource::Pools], "p").await.unwrap();
+        let s2 = export_state(&fake, &[Resource::Pools], "p").await.unwrap();
+
+        // The only field that legitimately differs is meta.exported_at
+        // (wall-clock-dependent). Strip it for the comparison.
+        let strip_ts = |mut s: ClusterState| {
+            if let Some(m) = s.meta.as_mut() {
+                m.exported_at.clear();
+            }
+            s
+        };
+        assert_eq!(strip_ts(s1), strip_ts(s2));
+    }
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,0 +1,37 @@
+//! Cluster state export + reconcile.
+//!
+//! This module is the foundation for `proxxx state {export,diff,apply}`
+//! — the path toward declaratively-versioned Proxmox clusters tracked
+//! in epic [#74](https://github.com/fabriziosalmi/proxxx/issues/74).
+//!
+//! v1 (this PR) ships **export only**, **pools only**. Subsequent PRs
+//! add ACL, storage definitions, cluster firewall, backup jobs,
+//! notifications, then the diff + apply layers.
+//!
+//! ## Layered design
+//!
+//! * [`model`] — serde structs per resource family, plus the top-level
+//!   [`ClusterState`](model::ClusterState). Strict TOML / JSON
+//!   serialisation; identity by PVE-side key (`poolid`, `(path,type,
+//!   ugid,roleid)`, `storage`, …). All collections sorted on export so
+//!   the output is diff-stable byte-for-byte across runs.
+//! * [`export`] — read live state through `api::ProxmoxGateway`. Pure
+//!   read; no mutation. Mockable for unit tests.
+//! * `diff` (future) — structural diff between two
+//!   `ClusterState` values; produces `Vec<Change>` (Create / Update /
+//!   Delete).
+//! * `apply` (future) — execute each `Change` via the api client;
+//!   pre-flight gate + audit log per change; HITL on destructive ops.
+//!
+//! ## Why a separate module
+//!
+//! The reducer in `app/` is the read/render side of the Elm-style
+//! state machine; that lives in-memory only and is recomputed every
+//! frame from the latest API responses. `state/` is the disk-side
+//! schema: declarative, versionable, externalised. They don't share
+//! types because their concerns differ (reducer cares about render
+//! ergonomics — sparkline buffers, selection cursors — `state/`
+//! cares about wire-stable identity and TOML readability).
+
+pub mod export;
+pub mod model;

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -1,0 +1,180 @@
+//! Serde model for cluster state — the on-disk schema of the
+//! declaratively-managed slice of a Proxmox cluster.
+//!
+//! Each resource family is a separate `*Decl` struct. The top-level
+//! [`ClusterState`] is a forest of those: a partial state (e.g. only
+//! `[[pools]]`) is a valid file, since every field defaults to empty.
+//! This lets operators export only what they care about and merge
+//! cross-PR without conflict.
+//!
+//! Identity rules:
+//! * Pools — keyed by `poolid`.
+//! * Members of a pool — encoded as stable strings (`qemu/100`,
+//!   `lxc/200`, `storage/<name>`) so a member set is a `Vec<String>`
+//!   directly serialisable as a TOML array.
+//!
+//! Future resource families (ACL, storage, firewall, backup jobs,
+//! notifications) will follow the same shape: a `*Decl` struct with
+//! the PVE-side identifier as the first field, a `default` impl so
+//! empty fields don't bloat the TOML, and a stable serialise order
+//! enforced at the export layer.
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level cluster state — the union of every declared resource.
+///
+/// Every field is optional (defaults to empty / `None`) so partial
+/// exports are valid documents. `meta` is emitted on export but
+/// optional on import; a hand-written declared state can omit it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ClusterState {
+    /// Provenance: where this state came from and when. Skipped on
+    /// serialisation when absent so hand-authored declared states
+    /// don't need it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<StateMeta>,
+
+    /// Pools — `GET /pools` + `GET /pools/{poolid}` for membership.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub pools: Vec<PoolDecl>,
+}
+
+/// Metadata header emitted by the export layer. Captures *which*
+/// cluster the state was read from, *when*, and *with what proxxx
+/// version*. Useful for audit trail and forensic comparison; ignored
+/// by the apply layer (apply consults live state, not metadata).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct StateMeta {
+    /// proxxx profile name the state was exported from.
+    pub profile: String,
+    /// RFC 3339 timestamp at export.
+    pub exported_at: String,
+    /// proxxx version that produced the export (from `CARGO_PKG_VERSION`).
+    pub exported_from_proxxx: String,
+    /// PVE API version reported by `GET /version` (e.g. `"9.1.9"`).
+    pub pve_version: String,
+}
+
+/// One pool declaration — poolid + comment + members.
+///
+/// Members are emitted as `kind/id` strings (`qemu/<vmid>`,
+/// `lxc/<vmid>`, `storage/<name>`) so the TOML is diff-readable: the
+/// PVE API returns a richer object per member, but only the kind + id
+/// is identity-bearing — every other field is recomputable.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PoolDecl {
+    pub poolid: String,
+    /// Free-form description. Empty by default; suppressed in the
+    /// serialised TOML when empty so the file stays terse.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub comment: String,
+    /// Sorted, deduplicated list of member references. Serialised as
+    /// a TOML array of strings.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub members: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_cluster_state_serializes_to_empty_toml() {
+        // Default ClusterState has no meta, no pools — every field is
+        // `skip_serializing_if` empty, so the resulting TOML is the
+        // empty string. Pinning this so an "all fields empty" export
+        // produces a stable, smallest possible file (useful for diffs
+        // against a freshly-provisioned cluster).
+        let s = ClusterState::default();
+        let toml_str = toml::to_string(&s).expect("serialize empty state");
+        assert!(toml_str.is_empty(), "expected empty, got {toml_str:?}");
+    }
+
+    #[test]
+    fn pool_decl_with_only_id_omits_comment_and_members() {
+        let p = PoolDecl {
+            poolid: "team-platform".to_string(),
+            comment: String::new(),
+            members: Vec::new(),
+        };
+        let s = ClusterState {
+            meta: None,
+            pools: vec![p],
+        };
+        let toml_str = toml::to_string(&s).expect("serialize");
+        // No "comment = " line, no "members = " line — only poolid.
+        assert!(toml_str.contains("poolid = \"team-platform\""));
+        assert!(!toml_str.contains("comment"));
+        assert!(!toml_str.contains("members"));
+    }
+
+    #[test]
+    fn pool_decl_with_members_emits_sorted_array() {
+        let p = PoolDecl {
+            poolid: "team-platform".to_string(),
+            comment: "platform engineering".to_string(),
+            members: vec![
+                "qemu/100".to_string(),
+                "qemu/101".to_string(),
+                "storage/ceph-rbd".to_string(),
+            ],
+        };
+        let toml_str = toml::to_string(&p).expect("serialize");
+        assert!(toml_str.contains("poolid = \"team-platform\""));
+        assert!(toml_str.contains("comment = \"platform engineering\""));
+        assert!(toml_str.contains("\"qemu/100\""));
+        assert!(toml_str.contains("\"storage/ceph-rbd\""));
+    }
+
+    #[test]
+    fn round_trip_preserves_pool_membership() {
+        // Build a state, serialize, deserialize, compare. Pins the
+        // serde contract: every field that round-trips through TOML
+        // survives unchanged. Catches accidental case-sensitivity
+        // issues, missing #[serde(default)], etc.
+        let s = ClusterState {
+            meta: Some(StateMeta {
+                profile: "prod".into(),
+                exported_at: "2026-05-19T22:00:00Z".into(),
+                exported_from_proxxx: "0.2.1".into(),
+                pve_version: "9.1.9".into(),
+            }),
+            pools: vec![
+                PoolDecl {
+                    poolid: "p1".into(),
+                    comment: "first".into(),
+                    members: vec!["qemu/100".into(), "lxc/200".into()],
+                },
+                PoolDecl {
+                    poolid: "p2".into(),
+                    comment: String::new(),
+                    members: vec![],
+                },
+            ],
+        };
+        let toml_str = toml::to_string(&s).expect("serialize");
+        let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");
+        assert_eq!(s, parsed);
+    }
+
+    #[test]
+    fn partial_state_with_only_pools_deserializes() {
+        // Operators hand-authoring a declared state should not need
+        // a `[meta]` header. Pins the "partial document is valid"
+        // contract.
+        let toml_str = r#"
+[[pools]]
+poolid = "team-platform"
+comment = "engineering"
+members = ["qemu/100", "storage/ceph-rbd"]
+"#;
+        let s: ClusterState = toml::from_str(toml_str).expect("deserialize");
+        assert!(s.meta.is_none());
+        assert_eq!(s.pools.len(), 1);
+        assert_eq!(s.pools[0].poolid, "team-platform");
+        assert_eq!(s.pools[0].members.len(), 2);
+    }
+}


### PR DESCRIPTION
First PR in the **Cluster as compiled state** epic ([#74](https://github.com/fabriziosalmi/proxxx/issues/74)). Read-side foundation: a serde model for declarative cluster state, an export function that reads live PVE into that model through a narrow read-view trait, and `proxxx state export` to emit TOML or JSON.

This PR is **read-only**. Diff and apply layers, plus the remaining resource families (acl, storage, firewall-cluster, backup-jobs, notifications), land in subsequent PRs against the same epic.

## What it does

```bash
$ proxxx state export
[meta]
profile = "default"
exported_at = "2026-05-19T21:29:12Z"
exported_from_proxxx = "0.2.1"
pve_version = "9.1.1"

[[pools]]
poolid = "platform"
comment = "engineering"
members = ["qemu/100", "qemu/101", "storage/ceph-rbd"]
```

JSON output via `--output json`. The document is **byte-stable** across runs against an unchanged cluster — every collection is sorted by its identity field on the way out — so a `git diff` after a re-export only shows actual cluster drift.

## Module layout

| File | Responsibility |
| :--- | :--- |
| `src/state/model.rs` | `ClusterState`, `StateMeta`, `PoolDecl`. Serde types with `#[serde(skip_serializing_if = \"…\")]` on every optional field; empty / partial states serialise / deserialise cleanly. 5 unit tests. |
| `src/state/export.rs` | `export_state(client, resources, profile)`. Reads through a narrow `PoolReadView` trait that's a strict subset of `ProxmoxGateway`; a blanket impl makes every `ProxmoxGateway` auto-satisfy it, so production calls work transparently while unit tests implement `PoolReadView` on a 30-line fake (vs stubbing 200+ methods of `ProxmoxGateway`). 10 unit tests. |
| `src/cli/state.rs` | `StateCommand::Export { resource, output }`. |

## CLI

- `proxxx state export` — default `--resource pools --output toml` to stdout.
- `proxxx state export --output json` — same data, JSON.

The `--output` flag is **local to `state export`**, distinct from the global `--format` flag (which controls how proxxx's normal table/json/plain output is rendered). A previous draft tried to reuse the global `--format` and crashed clap at runtime with a type-id downcast mismatch.

`main.rs` gains a small new branch: commands returning `Value::Null` skip the standard print pipeline. `state export` uses this because it already wrote the full TOML document to stdout — re-serialising through the JSON-array wrapper would either escape the newlines or wrap the document in an outer `[…]`.

## Live-cluster verification

Smoke-tested against PVE 9.1.1 via the Tailscale subnet route:

| Step | Output |
| :--- | :--- |
| Empty cluster (no pools) | only `[meta]` block |
| Create `proxxx-state-test`, re-export | `[[pools]]` block with poolid + comment, no `members` line (empty) |
| `--output json` | equivalent JSON document |
| Delete pool, re-export | back to only `[meta]` |

## Verification

- ✅ `cargo test --lib state::` → 15 unit tests (5 model + 10 export, including the byte-stable double-export property)
- ✅ `cargo clippy --all-targets --all-features` silent
- ✅ `cargo fmt --check` clean
- ✅ `cargo audit --deny warnings` — 0 vulns / 0 warnings
- ✅ `cargo deny check` — advisories / bans / licenses / sources all ok
- ✅ Live smoke against PVE 9.1.1 — create pool, export, JSON export, delete pool, re-export all pass

Closes a slice of [#74](https://github.com/fabriziosalmi/proxxx/issues/74) (pools export only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)