### PR TITLE
feat(state): export storage definitions (epic #74 PR 3)

### DIFF
--- a/src/state/export.rs
+++ b/src/state/export.rs
@@ -18,8 +18,8 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::api::types::{AclEntry, ApiVersion, Pool, PoolDetails, PoolMember};
-use crate::state::model::{AclDecl, ClusterState, PoolDecl, StateMeta};
+use crate::api::types::{AclEntry, ApiVersion, Pool, PoolDetails, PoolMember, StorageDefinition};
+use crate::state::model::{AclDecl, ClusterState, PoolDecl, StateMeta, StorageDecl};
 
 /// Which resource families to export. Parsed from the CLI `--resource`
 /// argument. New variants are added per the ladder in epic #74.
@@ -27,6 +27,7 @@ use crate::state::model::{AclDecl, ClusterState, PoolDecl, StateMeta};
 pub enum Resource {
     Pools,
     Acl,
+    Storage,
 }
 
 impl Resource {
@@ -38,9 +39,10 @@ impl Resource {
         match s.trim().to_lowercase().as_str() {
             "pools" => Ok(vec![Self::Pools]),
             "acl" => Ok(vec![Self::Acl]),
-            "all" => Ok(vec![Self::Pools, Self::Acl]),
+            "storage" => Ok(vec![Self::Storage]),
+            "all" => Ok(vec![Self::Pools, Self::Acl, Self::Storage]),
             other => anyhow::bail!(
-                "unknown resource '{other}' (valid: pools | acl | all — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
+                "unknown resource '{other}' (valid: pools | acl | storage | all — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
             ),
         }
     }
@@ -51,6 +53,7 @@ impl Resource {
         match self {
             Self::Pools => "pools",
             Self::Acl => "acl",
+            Self::Storage => "storage",
         }
     }
 }
@@ -68,6 +71,7 @@ pub trait StateReadView: Send + Sync {
     async fn list_pools_view(&self) -> Result<Vec<Pool>>;
     async fn get_pool_view(&self, poolid: &str) -> Result<PoolDetails>;
     async fn list_acl_view(&self) -> Result<Vec<AclEntry>>;
+    async fn list_cluster_storages_view(&self) -> Result<Vec<StorageDefinition>>;
     async fn get_api_version_view(&self) -> Result<ApiVersion>;
 }
 
@@ -84,6 +88,9 @@ where
     }
     async fn list_acl_view(&self) -> Result<Vec<AclEntry>> {
         crate::api::ProxmoxGateway::list_acl(self).await
+    }
+    async fn list_cluster_storages_view(&self) -> Result<Vec<StorageDefinition>> {
+        crate::api::ProxmoxGateway::list_cluster_storages(self).await
     }
     async fn get_api_version_view(&self) -> Result<ApiVersion> {
         crate::api::ProxmoxGateway::get_api_version(self).await
@@ -113,6 +120,7 @@ pub async fn export_state<C: StateReadView + ?Sized>(
         }),
         pools: Vec::new(),
         acl: Vec::new(),
+        storage: Vec::new(),
     };
 
     for r in resources {
@@ -124,6 +132,11 @@ pub async fn export_state<C: StateReadView + ?Sized>(
             }
             Resource::Acl => {
                 state.acl = export_acl(client).await.with_context(|| "exporting acl")?;
+            }
+            Resource::Storage => {
+                state.storage = export_storage(client)
+                    .await
+                    .with_context(|| "exporting storage")?;
             }
         }
     }
@@ -191,6 +204,44 @@ async fn export_acl<C: StateReadView + ?Sized>(client: &C) -> Result<Vec<AclDecl
             .then(a.roleid.cmp(&b.roleid))
     });
     Ok(out)
+}
+
+/// Read every cluster-wide storage definition and project to
+/// `Vec<StorageDecl>`. Sorted by `storage` (the operator-chosen id,
+/// unique across the cluster).
+///
+/// The `digest` field from PVE's response is dropped — it's a stale-
+/// check identifier returned to support `If-Match` headers on PUT,
+/// not desired state. Including it would make the TOML churn on
+/// every API call even when the storage's configuration hasn't
+/// actually changed.
+async fn export_storage<C: StateReadView + ?Sized>(client: &C) -> Result<Vec<StorageDecl>> {
+    let mut storages = client
+        .list_cluster_storages_view()
+        .await
+        .context("listing cluster storages")?;
+    storages.sort_by(|a, b| a.storage.cmp(&b.storage));
+
+    Ok(storages
+        .into_iter()
+        .map(|s| StorageDecl {
+            storage: s.storage,
+            storage_type: s.storage_type,
+            content: s.content,
+            nodes: s.nodes,
+            disable: s.disable,
+            shared: s.shared,
+            path: s.path,
+            pool: s.pool,
+            server: s.server,
+            export: s.export,
+            datastore: s.datastore,
+            fingerprint: s.fingerprint,
+            username: s.username,
+            vgname: s.vgname,
+            thinpool: s.thinpool,
+        })
+        .collect())
 }
 
 /// Project one `PoolMember` to its identity string (`qemu/100`,
@@ -338,7 +389,7 @@ mod tests {
         // a `--resource all` export hits resources in a deterministic
         // sequence regardless of input ordering.
         let v = Resource::parse("all").unwrap();
-        assert_eq!(v, vec![Resource::Pools, Resource::Acl]);
+        assert_eq!(v, vec![Resource::Pools, Resource::Acl, Resource::Storage]);
     }
 
     #[test]
@@ -363,6 +414,7 @@ mod tests {
         pools: Vec<Pool>,
         details: std::collections::HashMap<String, PoolDetails>,
         acl: Vec<AclEntry>,
+        storage: Vec<StorageDefinition>,
     }
 
     #[async_trait]
@@ -378,6 +430,9 @@ mod tests {
         }
         async fn list_acl_view(&self) -> Result<Vec<AclEntry>> {
             Ok(self.acl.clone())
+        }
+        async fn list_cluster_storages_view(&self) -> Result<Vec<StorageDefinition>> {
+            Ok(self.storage.clone())
         }
         async fn get_api_version_view(&self) -> Result<ApiVersion> {
             Ok(ApiVersion {
@@ -634,6 +689,71 @@ mod tests {
         assert!(
             pools_idx < acl_idx,
             "pools must come before acl in TOML, got pools_idx={pools_idx} acl_idx={acl_idx}"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_storage_sorts_by_storage_id() {
+        // PVE returns storages in roughly creation order; the export
+        // must canonicalise to alphabetical by `storage` id so the
+        // TOML is byte-stable.
+        let mut fake = FakeStateView::default();
+        fake.storage = vec![
+            StorageDefinition {
+                storage: "zfs-fast".into(),
+                storage_type: "zfspool".into(),
+                pool: "rpool/data".into(),
+                content: "images,rootdir".into(),
+                shared: false,
+                ..Default::default()
+            },
+            StorageDefinition {
+                storage: "local".into(),
+                storage_type: "dir".into(),
+                path: "/var/lib/vz".into(),
+                content: "iso,backup,vztmpl".into(),
+                ..Default::default()
+            },
+            StorageDefinition {
+                storage: "ceph-rbd".into(),
+                storage_type: "rbd".into(),
+                pool: "rbd".into(),
+                content: "images".into(),
+                shared: true,
+                ..Default::default()
+            },
+        ];
+
+        let out = export_storage(&fake).await.expect("export");
+        let ids: Vec<&str> = out.iter().map(|s| s.storage.as_str()).collect();
+        assert_eq!(ids, vec!["ceph-rbd", "local", "zfs-fast"]);
+    }
+
+    #[tokio::test]
+    async fn export_storage_drops_digest_from_pve_response() {
+        // PVE's `GET /storage` includes a `digest` field for ETag-
+        // style stale-check. It's not desired state; including it in
+        // the export would make the TOML churn on every API call.
+        // The model has no `digest` field; the export must not
+        // synthesise one. (Confirms by checking the serialised TOML.)
+        let mut fake = FakeStateView::default();
+        fake.storage = vec![StorageDefinition {
+            storage: "local".into(),
+            storage_type: "dir".into(),
+            content: "iso".into(),
+            path: "/var/lib/vz".into(),
+            digest: "abc123".into(),
+            ..Default::default()
+        }];
+        let out = export_storage(&fake).await.expect("export");
+        let toml_str = toml::to_string(&out[0]).expect("serialize");
+        assert!(
+            !toml_str.contains("digest"),
+            "digest must not survive export, got:\n{toml_str}"
+        );
+        assert!(
+            !toml_str.contains("abc123"),
+            "digest value must not survive export, got:\n{toml_str}"
         );
     }
 }

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -45,6 +45,14 @@ pub struct ClusterState {
     /// the value, not the identity (toggling it is an update).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub acl: Vec<AclDecl>,
+
+    /// Cluster-wide storage definitions — `GET /storage`. Identity
+    /// is the `storage` field (operator-chosen storage id). Type-
+    /// specific fields (path, pool, server, export, datastore, …)
+    /// are emitted only when present, so a `dir` storage doesn't
+    /// pollute the TOML with empty `server=""`/`pool=""` lines.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub storage: Vec<StorageDecl>,
 }
 
 /// Metadata header emitted by the export layer. Captures *which*
@@ -125,6 +133,88 @@ const fn default_true() -> bool {
     true
 }
 
+/// Serde `skip_serializing_if` helper. The signature is fixed by serde
+/// (`fn(&T) -> bool`), so we must take `&bool` here even though clippy
+/// would prefer `bool` by value — passing by reference is the contract.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// One cluster-wide storage definition — `GET /storage`. The
+/// `storage` field is the identity; everything else is value.
+///
+/// Type-specific fields (path / pool / server / export / datastore /
+/// fingerprint / username / vgname / thinpool) are all `#[serde(
+/// skip_serializing_if = "String::is_empty")]` so a `dir` storage's
+/// TOML doesn't carry empty `server=""`/`pool=""` lines. PVE's API
+/// returns the full union shape; we mirror that on disk but emit
+/// only the populated subset.
+///
+/// Deliberately NOT exported:
+/// * `digest` — PVE's stale-check identifier, not desired state.
+///   Including it would make the TOML churn on every API call even
+///   when nothing's changed.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct StorageDecl {
+    /// Storage id (operator-chosen name, unique across the cluster).
+    pub storage: String,
+    /// Storage type: `dir` | `lvm` | `lvmthin` | `zfspool` | `nfs` |
+    /// `cifs` | `iscsi` | `glusterfs` | `cephfs` | `rbd` | `pbs` |
+    /// `btrfs` | `esxi`.
+    #[serde(rename = "type")]
+    pub storage_type: String,
+    /// CSV of allowed content kinds, e.g.
+    /// `"vztmpl,iso,backup,images,rootdir,snippets"`. PVE accepts
+    /// CSV on input and emits CSV on output; we keep it as a string
+    /// rather than parsing into an array, since the order PVE
+    /// preserves on read-back is not stable.
+    pub content: String,
+    /// CSV of nodes this storage is restricted to. Empty = all
+    /// nodes (the default).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub nodes: String,
+    /// `true` = config kept but storage is administratively disabled.
+    #[serde(skip_serializing_if = "is_false")]
+    pub disable: bool,
+    /// `true` = visible to every node (NFS, PBS, `CephFS`, …). Local
+    /// storages (`dir`, `lvm`, `zfspool` against a node-local pool)
+    /// have this `false`.
+    #[serde(skip_serializing_if = "is_false")]
+    pub shared: bool,
+    // ── Type-specific subset (skip when empty) ──
+    /// `dir` / `btrfs`: filesystem path on the host.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub path: String,
+    /// `zfspool` / `rbd`: ZFS dataset / Ceph pool name.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub pool: String,
+    /// `nfs` / `cifs` / `pbs` / `iscsi`: server hostname / IP.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub server: String,
+    /// `nfs`: export path on the server.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub export: String,
+    /// `pbs`: PBS datastore name.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub datastore: String,
+    /// `pbs` / `cifs`: TLS fingerprint for verification (SHA-256
+    /// over the leaf cert).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub fingerprint: String,
+    /// `cifs` / `pbs`: auth username. For PBS, this is
+    /// `user@realm!tokenname`.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub username: String,
+    /// `lvm` / `lvmthin`: volume group name.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub vgname: String,
+    /// `lvmthin`: thin pool name within `vgname`.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub thinpool: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -152,6 +242,7 @@ mod tests {
             meta: None,
             pools: vec![p],
             acl: vec![],
+            storage: vec![],
         };
         let toml_str = toml::to_string(&s).expect("serialize");
         // No "comment = " line, no "members = " line — only poolid.
@@ -192,6 +283,7 @@ mod tests {
                 pve_version: "9.1.9".into(),
             }),
             acl: vec![],
+            storage: vec![],
             pools: vec![
                 PoolDecl {
                     poolid: "p1".into(),
@@ -241,6 +333,7 @@ roleid = "PVEVMAdmin"
             meta: None,
             pools: vec![],
             acl: vec![entry.clone()],
+            storage: vec![],
         };
         let toml_str = toml::to_string(&s).expect("serialize");
         let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");
@@ -264,6 +357,116 @@ propagate = false
         let s: ClusterState = toml::from_str(toml_str).expect("deserialize");
         assert_eq!(s.acl.len(), 1);
         assert!(!s.acl[0].propagate);
+    }
+
+    #[test]
+    fn storage_decl_omits_type_specific_empty_fields() {
+        // A `dir` storage doesn't have a `server`, `pool`, `datastore`,
+        // etc. — its `StorageDecl` must serialise to TOML without any
+        // of those empty fields appearing. Pins the
+        // `skip_serializing_if = "String::is_empty"` discipline so a
+        // future "add a default" regression doesn't pollute the
+        // diff.
+        let s = StorageDecl {
+            storage: "local".into(),
+            storage_type: "dir".into(),
+            content: "iso,backup".into(),
+            path: "/var/lib/vz".into(),
+            ..Default::default()
+        };
+        let toml_str = toml::to_string(&s).expect("serialize");
+        assert!(toml_str.contains("storage = \"local\""));
+        assert!(toml_str.contains("type = \"dir\""));
+        assert!(toml_str.contains("path = \"/var/lib/vz\""));
+        // None of the type-specific empties survive.
+        for k in &[
+            "server",
+            "pool",
+            "export",
+            "datastore",
+            "fingerprint",
+            "username",
+            "vgname",
+            "thinpool",
+        ] {
+            assert!(
+                !toml_str.contains(&format!("{k} =")),
+                "field '{k}' should be omitted (empty), got:\n{toml_str}"
+            );
+        }
+        // Defaulted bools (disable/shared) should also be omitted.
+        assert!(!toml_str.contains("disable"));
+        assert!(!toml_str.contains("shared"));
+    }
+
+    #[test]
+    fn storage_decl_emits_type_specific_fields_when_present() {
+        // A `pbs` storage has server + datastore + fingerprint +
+        // username; all four must survive serialisation. A `nfs`
+        // storage has server + export; pbs-only fields must NOT
+        // appear on it.
+        let pbs = StorageDecl {
+            storage: "backup-fra1".into(),
+            storage_type: "pbs".into(),
+            content: "backup".into(),
+            server: "pbs.example.com".into(),
+            datastore: "default".into(),
+            fingerprint: "AA:BB:CC".into(),
+            username: "backup@pbs!proxxx".into(),
+            shared: true,
+            ..Default::default()
+        };
+        let toml_str = toml::to_string(&pbs).expect("serialize");
+        assert!(toml_str.contains("server = \"pbs.example.com\""));
+        assert!(toml_str.contains("datastore = \"default\""));
+        assert!(toml_str.contains("fingerprint"));
+        assert!(toml_str.contains("username"));
+        assert!(toml_str.contains("shared = true"));
+        // No `pool`, `export`, `path` (those are for other types).
+        assert!(!toml_str.contains("pool"));
+        assert!(!toml_str.contains("export"));
+        assert!(!toml_str.contains("path"));
+    }
+
+    #[test]
+    fn storage_decl_round_trip_preserves_all_fields() {
+        let entries = vec![
+            StorageDecl {
+                storage: "local".into(),
+                storage_type: "dir".into(),
+                content: "iso,backup,vztmpl".into(),
+                path: "/var/lib/vz".into(),
+                disable: false,
+                shared: false,
+                ..Default::default()
+            },
+            StorageDecl {
+                storage: "ceph-rbd".into(),
+                storage_type: "rbd".into(),
+                content: "images,rootdir".into(),
+                pool: "rbd".into(),
+                shared: true,
+                ..Default::default()
+            },
+            StorageDecl {
+                storage: "shared-nfs".into(),
+                storage_type: "nfs".into(),
+                content: "backup".into(),
+                server: "10.0.0.5".into(),
+                export: "/exports/proxmox-backup".into(),
+                shared: true,
+                ..Default::default()
+            },
+        ];
+        let s = ClusterState {
+            meta: None,
+            pools: vec![],
+            acl: vec![],
+            storage: entries.clone(),
+        };
+        let toml_str = toml::to_string(&s).expect("serialize");
+        let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");
+        assert_eq!(parsed.storage, entries);
     }
 
     #[test]


### PR DESCRIPTION
> _Note: this re-opens #77 which was auto-closed when its base `feat/state-export-acl` was deleted on the #76 squash-merge. Same code, rebased onto current `main`._

Stacks on #76 (ACL, **merged**). Adds **cluster-wide storage definitions** as the third resource family. Storage has the largest field surface (15 fields, most type-specific); the model uses skip-empty discipline so a `dir` storage's TOML doesn't carry empty `server=""`/`pool=""` lines.

## What it does

```bash
$ proxxx state export --resource storage
[[storage]]
storage = "local"
type = "dir"
content = "import,backup,vztmpl,iso"
path = "/var/lib/vz"

[[storage]]
storage = "local-lvm"
type = "lvmthin"
content = "images,rootdir"
vgname = "pve"
thinpool = "data"

[[storage]]
storage = "storage"
type = "nfs"
content = "rootdir,images,import,iso,vztmpl,snippets"
shared = true
path = "/mnt/pve/storage"
server = "192.168.0.115"
export = "/volume1/pve-test-nfs"
```

`--resource all` now expands to `[pools, acl, storage]`.

## Model

| Decision | Note |
| :--- | :--- |
| 15 fields mirroring PVE's `StorageDefinition` | matches API 1:1 |
| Drop `digest` field | PVE returns it for ETag stale-check on PUT; including it would make TOML churn on every API call. Pinned by `export_storage_drops_digest_from_pve_response`. |
| `skip_serializing_if = "String::is_empty"` on every type-specific field | dir storage gets only `path`; lvmthin gets only `vgname`+`thinpool`; nfs gets `server`+`export`; etc. |
| `skip_serializing_if = "is_false"` on `disable` and `shared` bools | omits the default-false case from TOML |

## Tests

5 new tests covering: empty-fields omission, type-specific-fields presence, round-trip across 3 typical types, alphabetical sort, digest-omission regression.

## Live verification

Smoke-tested against PVE 9.1.1 — `local` (dir), `local-lvm` (lvmthin), `storage` (nfs) exported with EXACTLY their type-specific fields, no empty padding, correct `shared` bool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)