### PR TITLE
feat(incident): cluster-wide write kill-switch (`freeze`/`thaw`)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -533,6 +533,10 @@ impl PxClient {
         path: &str,
         params: &[(&str, &str)],
     ) -> Result<T> {
+        // Incident lockdown gate — refuses every mutation when the
+        // freeze lock is active. Reads (GET) intentionally skip this
+        // check; investigators need observation during an incident.
+        crate::incident::check_not_frozen()?;
         let url = format!("{}/api2/json{}", self.base_url, path);
         debug!("POST {}", url);
 
@@ -566,6 +570,7 @@ impl PxClient {
         path: &str,
         params: &[(&str, &str)],
     ) -> Result<T> {
+        crate::incident::check_not_frozen()?;
         let url = format!("{}/api2/json{}", self.base_url, path);
         debug!("PUT {}", url);
 
@@ -586,6 +591,7 @@ impl PxClient {
 
     /// Rate-limited, auth-aware DELETE request with retry on transient failures.
     async fn delete<T: DeserializeOwned + Send + 'static>(&self, path: &str) -> Result<T> {
+        crate::incident::check_not_frozen()?;
         let url = format!("{}/api2/json{}", self.base_url, path);
         debug!("DELETE {}", url);
 

--- a/src/cli/explain.rs
+++ b/src/cli/explain.rs
@@ -260,6 +260,23 @@ pub const ENTRIES: &[ExplainEntry] = &[
         references: &["https://toml.io/en/"],
     },
     ExplainEntry {
+        id: "freeze-refusal",
+        title: "Incident lockdown active — mutations refused",
+        cause: "proxxx's freeze lock is active. Every POST/PUT/DELETE refuses immediately, exits 8, and tells the operator why. Reads still work — investigators need observation.",
+        fixes: &[
+            "If the freeze is intentional (live incident), wait for the TTL to expire or coordinate with the operator who froze.",
+            "If the freeze is stale (forgotten, no TTL, false alarm), thaw it: `proxxx incident thaw --reason '<text>'`.",
+            "Always pair `freeze` with `--ttl <duration>` — a forgotten freeze with no TTL is the operational nightmare we're trying to avoid.",
+            "Check the audit log for who froze and why: every freeze/thaw is recorded under the `incident.*` action prefix.",
+        ],
+        commands: &[
+            "proxxx incident status",
+            "proxxx incident thaw --reason '<text>'",
+            "proxxx audit export --limit 20 | grep incident",
+        ],
+        references: &["docs/reference/exit-codes.md"],
+    },
+    ExplainEntry {
         id: "preflight-refusal",
         title: "Pre-flight refused: SEVERE risk without --allow-risk",
         cause: "proxxx's pre-flight risk checks rated the requested operation `Severe` (e.g. deleting a guest with active TCP listeners, migrating with local disks while heavily loaded). The default policy is to refuse rather than execute — exit code 6.",
@@ -514,6 +531,8 @@ mod tests {
             "config-toml",
             // Preflight refusal (src/app/preflight.rs):
             "preflight-refusal",
+            // Incident lockdown (src/incident/mod.rs):
+            "freeze-refusal",
         ];
         for id in expected {
             assert!(

--- a/src/cli/incident.rs
+++ b/src/cli/incident.rs
@@ -1,0 +1,178 @@
+//! `proxxx incident {freeze, thaw, status}` — cluster-wide write
+//! kill-switch.
+//!
+//! Thin CLI wrapper over [`crate::incident`]. Every subcommand
+//! audit-logs the operation under the `incident.*` action prefix
+//! so the freeze trail survives even after the lock is gone.
+
+use anyhow::Result;
+use clap::Subcommand;
+use serde_json::Value;
+
+use crate::incident;
+
+#[derive(Debug, Subcommand)]
+pub enum IncidentCommand {
+    /// Freeze the cluster — every mutation entry point refuses
+    /// until you `thaw` (or the TTL expires).
+    ///
+    /// Reads keep working: investigators need observation. The lock
+    /// is local to this machine — for multi-operator coordination
+    /// during an incident, distribute the lock file via your usual
+    /// secret-sync (Ansible, Salt, manual `scp`).
+    ///
+    /// Examples:
+    ///   proxxx incident freeze --reason 'pveuser-bot token leaked'
+    ///   proxxx incident freeze --reason 'SIEM alert NXLog-42' --ttl 4h
+    Freeze {
+        /// Required free-form text. Surfaced in every refusal and
+        /// in the audit log; future-you / teammates need to know why.
+        #[arg(long)]
+        reason: String,
+
+        /// Auto-thaw after this duration. Accepts `30s`, `5m`, `2h`,
+        /// `1d`. Omit for "until explicitly thawed". A forgotten
+        /// freeze with no TTL is the operational nightmare we're
+        /// trying to avoid — pass a TTL when in doubt.
+        #[arg(long)]
+        ttl: Option<String>,
+    },
+
+    /// Lift the freeze. Idempotent — thawing when nothing is frozen
+    /// is a no-op (returns `null`).
+    Thaw {
+        /// Free-form text recording why the freeze is being lifted.
+        /// Audit-logged.
+        #[arg(long)]
+        reason: String,
+    },
+
+    /// Report the current freeze status (active / inactive +
+    /// metadata). Exits 0 either way — use `--format json` and
+    /// match on `active` for scripting.
+    Status,
+}
+
+pub fn execute_incident(action: IncidentCommand) -> Result<(Value, i32)> {
+    match action {
+        IncidentCommand::Freeze { reason, ttl } => {
+            let ttl_secs = match ttl.as_deref() {
+                Some(s) => Some(parse_duration_secs(s)?),
+                None => None,
+            };
+            let state = incident::freeze(&reason, ttl_secs)?;
+            audit_event("incident.freeze", &reason, &state);
+            Ok((serde_json::to_value(&state)?, 0))
+        }
+        IncidentCommand::Thaw { reason } => {
+            let prior = incident::thaw()?;
+            audit_thaw(&reason, prior.as_ref());
+            let payload = serde_json::json!({
+                "thawed": prior.is_some(),
+                "reason": reason,
+                "prior_state": prior,
+            });
+            Ok((payload, 0))
+        }
+        IncidentCommand::Status => {
+            let state = incident::current_state()?;
+            let payload = serde_json::json!({
+                "active": state.is_some(),
+                "state": state,
+            });
+            Ok((payload, 0))
+        }
+    }
+}
+
+/// Append an audit-log entry for a freeze / thaw event. Failures
+/// are downgraded to a warning — we don't want auditing to be the
+/// reason an incident-response command fails.
+fn audit_event(action: &str, reason: &str, state: &incident::FreezeState) {
+    let params = serde_json::to_string(&serde_json::json!({
+        "reason": reason,
+        "operator": state.operator,
+        "ttl_secs": state.ttl_secs,
+    }))
+    .unwrap_or_default();
+    if let Err(e) = with_logger(|l| l.log(action, &state.operator, None, None, Some(&params), "OK"))
+    {
+        tracing::warn!("incident: audit log failure (continuing anyway): {e:#}");
+    }
+}
+
+fn audit_thaw(reason: &str, prior: Option<&incident::FreezeState>) {
+    let operator = prior
+        .map(|s| s.operator.clone())
+        .unwrap_or_else(default_operator);
+    let params = serde_json::to_string(&serde_json::json!({
+        "reason": reason,
+        "prior_reason": prior.map(|s| s.reason.as_str()),
+    }))
+    .unwrap_or_default();
+    if let Err(e) =
+        with_logger(|l| l.log("incident.thaw", &operator, None, None, Some(&params), "OK"))
+    {
+        tracing::warn!("incident: audit log failure (continuing anyway): {e:#}");
+    }
+}
+
+fn default_operator() -> String {
+    let user = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
+    format!("{user}@unknown")
+}
+
+/// Open the audit logger, call `f`, then drop it. Encapsulates the
+/// open/close boilerplate so the two audit hooks stay tidy.
+fn with_logger<F, R>(f: F) -> Result<R>
+where
+    F: FnOnce(&mut crate::audit::AuditLogger) -> Result<R>,
+{
+    let mut logger = crate::audit::AuditLogger::open()?;
+    f(&mut logger)
+}
+
+/// Parse `30s`, `5m`, `2h`, `1d` into seconds. Hand-rolled; the
+/// codebase already avoids the `humantime` dep.
+fn parse_duration_secs(s: &str) -> Result<u64> {
+    let s = s.trim();
+    if s.is_empty() {
+        anyhow::bail!("empty duration");
+    }
+    let (num_str, suffix) = s.split_at(s.len() - 1);
+    // If the last char wasn't a recognised suffix, treat the whole
+    // thing as bare seconds.
+    let (n_str, mult): (&str, u64) = match suffix {
+        "s" => (num_str, 1),
+        "m" => (num_str, 60),
+        "h" => (num_str, 3600),
+        "d" => (num_str, 86400),
+        _ => (s, 1),
+    };
+    let n: u64 = n_str
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid duration `{s}` — try `30s`, `5m`, `2h`, `1d`"))?;
+    Ok(n.saturating_mul(mult))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_duration_supports_all_suffixes() {
+        assert_eq!(parse_duration_secs("30s").unwrap(), 30);
+        assert_eq!(parse_duration_secs("5m").unwrap(), 300);
+        assert_eq!(parse_duration_secs("2h").unwrap(), 7200);
+        assert_eq!(parse_duration_secs("1d").unwrap(), 86400);
+        // Bare number = seconds.
+        assert_eq!(parse_duration_secs("42").unwrap(), 42);
+    }
+
+    #[test]
+    fn parse_duration_rejects_garbage() {
+        assert!(parse_duration_secs("").is_err());
+        assert!(parse_duration_secs("forever").is_err());
+        assert!(parse_duration_secs("foo-bar").is_err());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,6 +12,7 @@ mod doctor;
 mod events;
 pub mod explain;
 mod firewall;
+mod incident;
 mod init;
 mod init_wizard;
 mod logs;
@@ -224,6 +225,14 @@ pub enum Command {
     /// references. Ships with the binary; no network needed.
     /// Run `proxxx explain` (no args) for the catalog.
     Explain(explain::ExplainArgs),
+
+    /// Incident-response primitives — cluster-wide write kill-switch.
+    /// `freeze` halts every mutation entry point; `thaw` lifts it;
+    /// `status` reports current state. Reads keep working.
+    Incident {
+        #[command(subcommand)]
+        action: incident::IncidentCommand,
+    },
     /// Cancel a running task. PVE first signals cleanly, then SIGKILLs
     /// after a grace period. Use when a vzdump/migration is wedged.
     TaskStop {
@@ -1221,6 +1230,7 @@ pub async fn execute(
             logs::execute_logs(&config, &client, action, render).await
         }
         Command::Explain(args) => explain::execute_explain(args),
+        Command::Incident { action } => incident::execute_incident(action),
         Command::Tasks { limit, node } => {
             let tasks = if let Some(n) = node {
                 client

--- a/src/incident/mod.rs
+++ b/src/incident/mod.rs
@@ -1,0 +1,406 @@
+//! Incident-response primitives.
+//!
+//! `freeze`/`thaw` is a cluster-wide write kill-switch that lives at
+//! `<data_dir>/freeze.lock`. When the lock is present (and not
+//! expired), every mutation call site that respects it refuses
+//! immediately. Reads keep working — investigators need observation.
+//!
+//! ## File format
+//!
+//! TOML at `<data_dir>/freeze.lock`, written atomically (write to a
+//! sibling temp file + `rename`) so a racing reader never sees a
+//! half-written file. Permissions 0600 on Unix.
+//!
+//! ```toml
+//! reason     = "compromised pveuser-bot token, rotating"
+//! operator   = "fab@laptop"
+//! frozen_at  = 1747700000     # unix epoch seconds
+//! ttl_secs   = 14400          # auto-thaw after 4h (None ⇒ omit)
+//! ```
+//!
+//! ## TTL semantics
+//!
+//! The lock file *never* gets touched by a daemon — auto-thaw is
+//! purely a read-time check: `is_frozen()` evaluates
+//! `frozen_at + ttl_secs <= now()` and treats an expired lock as
+//! absent. The next operator-issued `freeze` / `thaw` rewrites the
+//! file. Trade-off: a freeze stays "valid" only as long as someone
+//! checks. Acceptable because every mutation entry point checks on
+//! every call.
+//!
+//! ## What's wired today
+//!
+//! - `api::PxClient::{post, put, delete}` calls
+//!   [`check_not_frozen`] before issuing the request.
+//! - `proxxx incident {freeze, thaw, status}` is the operator
+//!   interface (CLI dispatch in `cli/incident.rs`).
+//! - Audit log entries on freeze + thaw, with the operator's
+//!   reason in `params_json`.
+//!
+//! ## Deferred per #64 "out of scope until needed"
+//!
+//! - MCP dispatch integration — the MCP server checks
+//!   [`check_not_frozen`] on every tool-call boundary. Tracked in
+//!   a follow-up PR.
+//! - Telegram HITL daemon broadcast on freeze events. Same.
+//! - Scheduler tick gating — the future scheduler (issue #63)
+//!   will plug in via the same primitive.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Persisted freeze state. Serialised to / from the lock file as TOML.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FreezeState {
+    /// Free-form reason text the operator provided. Surfaced in the
+    /// refusal message + audit log so future-self / teammates know
+    /// why mutations got refused.
+    pub reason: String,
+    /// Best-effort operator identity — `$USER@hostname` when we can
+    /// resolve them, falling back to `unknown@unknown`. Used for the
+    /// audit log; not load-bearing for the freeze itself.
+    pub operator: String,
+    /// Unix epoch seconds at which the freeze was created.
+    pub frozen_at: u64,
+    /// Optional TTL — when set, `frozen_at + ttl_secs > now()` is
+    /// the "still active" predicate. `None` means "until explicitly
+    /// thawed" (no auto-expiry).
+    pub ttl_secs: Option<u64>,
+}
+
+impl FreezeState {
+    /// True if this state is still active given `now` (unix epoch
+    /// seconds). Encapsulates the TTL math so callers don't have to
+    /// re-derive it.
+    #[must_use]
+    pub const fn is_active_at(&self, now: u64) -> bool {
+        match self.ttl_secs {
+            Some(ttl) => self.frozen_at.saturating_add(ttl) > now,
+            None => true,
+        }
+    }
+}
+
+/// Refusal error returned by [`check_not_frozen`] when the freeze is
+/// active. Like `PreflightRefusal`, carried via `anyhow` so callers
+/// can `?` through it unchanged; `main.rs` downcasts to map the
+/// dedicated exit code.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "refusing mutation — fleet is FROZEN (reason: {reason}, since {frozen_at}). \
+     Run `proxxx incident thaw --reason '...'` to lift the freeze, or wait for \
+     the TTL to expire."
+)]
+pub struct FreezeRefusal {
+    pub reason: String,
+    pub frozen_at: u64,
+}
+
+impl FreezeRefusal {
+    /// Process exit code for a freeze refusal. Matches the documented
+    /// "Incident lockdown active" contract (docs/reference/exit-codes.md).
+    pub const EXIT_CODE: i32 = 8;
+}
+
+/// Resolve the path to the freeze lock file. Platform default is
+/// `<data_local_dir>/freeze.lock`; overridable for tests via the
+/// `PROXXX_FREEZE_PATH` environment variable.
+///
+/// Returning `PathBuf` (not `Result`) — if `directories::ProjectDirs`
+/// can't resolve a home directory, we fall back to `/tmp/proxxx` so
+/// the binary still functions in odd container environments.
+#[must_use]
+pub fn freeze_path() -> PathBuf {
+    if let Ok(p) = std::env::var("PROXXX_FREEZE_PATH") {
+        return PathBuf::from(p);
+    }
+    let dir = directories::ProjectDirs::from("dev", "proxxx", "proxxx").map_or_else(
+        || PathBuf::from("/tmp/proxxx"),
+        |d| d.data_local_dir().to_path_buf(),
+    );
+    dir.join("freeze.lock")
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn operator_id() -> String {
+    let user = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
+    let host = hostname_or_unknown();
+    format!("{user}@{host}")
+}
+
+fn hostname_or_unknown() -> String {
+    // Avoid pulling in a hostname crate — `gethostname()` via libc
+    // would be a new dep. Use the environment fallback chain that
+    // covers the common cases (HOSTNAME exported, or NIX-style
+    // `HOST` exported).
+    std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("HOST"))
+        .unwrap_or_else(|_| "unknown".into())
+}
+
+/// Read the current freeze state from disk. Returns `Ok(None)` for:
+///   * file does not exist
+///   * file exists but TTL has expired (treated as auto-thawed)
+///
+/// Returns `Err` only for real I/O failure (permission denied,
+/// disk error) or malformed TOML — those should surface, not be
+/// silently swallowed.
+pub fn current_state() -> Result<Option<FreezeState>> {
+    current_state_at(&freeze_path())
+}
+
+/// `current_state` with an explicit lock-file path. Tests use this
+/// form to avoid mutating process-global env vars in parallel.
+pub fn current_state_at(path: &std::path::Path) -> Result<Option<FreezeState>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("reading freeze lock at {}", path.display()))?;
+    let state: FreezeState = toml::from_str(&content)
+        .with_context(|| format!("parsing freeze lock at {}", path.display()))?;
+    if state.is_active_at(now_secs()) {
+        Ok(Some(state))
+    } else {
+        // Expired — treat as thawed. Don't auto-delete the file; the
+        // next freeze/thaw command will overwrite it. Leaving it
+        // around preserves the forensic trail.
+        Ok(None)
+    }
+}
+
+/// Refuse the calling operation if the freeze is currently active.
+/// Every mutation entry point (`PxClient::{post, put, delete}`,
+/// future MCP dispatch, future scheduler tick) calls this at the
+/// top before any side-effect.
+///
+/// I/O errors reading the lock are treated as "no freeze" — we
+/// prefer to over-permit than to silently lock the cluster out due
+/// to a transient I/O failure. The error is logged but not
+/// propagated. This is a deliberate trade-off documented in #64
+/// discussion.
+pub fn check_not_frozen() -> Result<()> {
+    check_not_frozen_at(&freeze_path())
+}
+
+/// `check_not_frozen` with an explicit lock-file path. Tests use
+/// this form.
+pub fn check_not_frozen_at(path: &std::path::Path) -> Result<()> {
+    match current_state_at(path) {
+        Ok(Some(state)) => Err(anyhow::Error::from(FreezeRefusal {
+            reason: state.reason,
+            frozen_at: state.frozen_at,
+        })),
+        Ok(None) => Ok(()),
+        Err(e) => {
+            tracing::warn!("freeze: lock unreadable, allowing operation through: {e:#}");
+            Ok(())
+        }
+    }
+}
+
+/// Activate the freeze. Atomically writes `freeze_path()` with the
+/// supplied reason + optional TTL, returning the persisted state.
+/// Caller is responsible for the audit-log entry.
+pub fn freeze(reason: &str, ttl_secs: Option<u64>) -> Result<FreezeState> {
+    freeze_at(&freeze_path(), reason, ttl_secs)
+}
+
+/// `freeze` with an explicit lock-file path. Tests use this form.
+pub fn freeze_at(
+    path: &std::path::Path,
+    reason: &str,
+    ttl_secs: Option<u64>,
+) -> Result<FreezeState> {
+    if reason.trim().is_empty() {
+        anyhow::bail!("freeze reason is required (operator + reviewers need it later)");
+    }
+    let state = FreezeState {
+        reason: reason.to_string(),
+        operator: operator_id(),
+        frozen_at: now_secs(),
+        ttl_secs,
+    };
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating data dir {}", parent.display()))?;
+    }
+    write_atomic(path, &toml::to_string_pretty(&state)?)?;
+    Ok(state)
+}
+
+/// Lift the freeze. Removes the lock file; if there's no lock to
+/// remove, returns `Ok(None)` (idempotent — thawing a clean cluster
+/// is not an error).
+pub fn thaw() -> Result<Option<FreezeState>> {
+    thaw_at(&freeze_path())
+}
+
+/// `thaw` with an explicit lock-file path. Tests use this form.
+pub fn thaw_at(path: &std::path::Path) -> Result<Option<FreezeState>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let prior = current_state_at(path).ok().flatten();
+    std::fs::remove_file(path)
+        .with_context(|| format!("removing freeze lock at {}", path.display()))?;
+    Ok(prior)
+}
+
+/// Write `content` to `path` atomically: write to a sibling tempfile,
+/// fsync, then `rename` over the target. A reader who opens `path`
+/// either sees the full new content or the previous content; never a
+/// half-written file. On Unix the file mode is forced to 0600 because
+/// the reason text may name a compromised user / system.
+fn write_atomic(path: &std::path::Path, content: &str) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("freeze lock path has no parent — refusing to write to root")?;
+    let tmp = parent.join(format!(
+        "freeze.lock.tmp.{}.{}",
+        std::process::id(),
+        now_secs()
+    ));
+    {
+        use std::io::Write;
+        let mut f = std::fs::File::create(&tmp)
+            .with_context(|| format!("creating temp lock {}", tmp.display()))?;
+        f.write_all(content.as_bytes())?;
+        f.sync_all()?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("chmod 0600 {}", tmp.display()))?;
+    }
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each test gets its own private temp directory + lock file
+    /// path. Uses the explicit-path variants of every function so
+    /// no process-global state (env vars) is touched — safe to run
+    /// in parallel with every other test.
+    fn temp_path() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("freeze.lock");
+        (dir, path)
+    }
+
+    #[test]
+    fn current_state_returns_none_when_lock_absent() {
+        let (_dir, p) = temp_path();
+        assert!(current_state_at(&p).unwrap().is_none());
+    }
+
+    #[test]
+    fn freeze_then_current_state_round_trips() {
+        let (_dir, p) = temp_path();
+        let written = freeze_at(&p, "ransomware indicator on pve-1", Some(3600)).unwrap();
+        let read = current_state_at(&p).unwrap().unwrap();
+        assert_eq!(read.reason, "ransomware indicator on pve-1");
+        assert_eq!(read.ttl_secs, Some(3600));
+        assert_eq!(read.frozen_at, written.frozen_at);
+    }
+
+    #[test]
+    fn freeze_refuses_empty_reason() {
+        let (_dir, p) = temp_path();
+        assert!(freeze_at(&p, "", Some(60)).is_err());
+        assert!(freeze_at(&p, "   ", Some(60)).is_err());
+    }
+
+    #[test]
+    fn thaw_removes_the_lock() {
+        let (_dir, p) = temp_path();
+        freeze_at(&p, "test", None).unwrap();
+        assert!(p.exists());
+        let removed = thaw_at(&p).unwrap();
+        assert!(removed.is_some(), "thaw should return the prior state");
+        assert!(!p.exists(), "lock file should be gone after thaw");
+    }
+
+    #[test]
+    fn thaw_is_idempotent_when_no_freeze_active() {
+        let (_dir, p) = temp_path();
+        let r = thaw_at(&p).unwrap();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn ttl_expired_lock_reads_as_thawed() {
+        let (_dir, p) = temp_path();
+        // Hand-craft an expired state — frozen 2 hours ago, TTL 1 hour.
+        let expired = FreezeState {
+            reason: "old".into(),
+            operator: "test@host".into(),
+            frozen_at: now_secs().saturating_sub(7200),
+            ttl_secs: Some(3600),
+        };
+        std::fs::write(&p, toml::to_string_pretty(&expired).unwrap()).unwrap();
+        assert!(current_state_at(&p).unwrap().is_none());
+    }
+
+    #[test]
+    fn ttl_active_lock_still_shows_frozen() {
+        let (_dir, p) = temp_path();
+        freeze_at(&p, "active", Some(3600)).unwrap();
+        assert!(current_state_at(&p).unwrap().is_some());
+    }
+
+    #[test]
+    fn check_not_frozen_returns_typed_refusal_when_active() {
+        let (_dir, p) = temp_path();
+        freeze_at(&p, "locked", None).unwrap();
+        let err = check_not_frozen_at(&p).unwrap_err();
+        assert!(
+            err.downcast_ref::<FreezeRefusal>().is_some(),
+            "expected FreezeRefusal, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn check_not_frozen_passes_when_no_lock() {
+        let (_dir, p) = temp_path();
+        assert!(check_not_frozen_at(&p).is_ok());
+    }
+
+    #[test]
+    fn is_active_at_handles_no_ttl_as_indefinite() {
+        let s = FreezeState {
+            reason: "x".into(),
+            operator: "test@host".into(),
+            frozen_at: 100,
+            ttl_secs: None,
+        };
+        assert!(s.is_active_at(0));
+        assert!(s.is_active_at(u64::MAX));
+    }
+
+    #[test]
+    fn is_active_at_respects_ttl_boundary() {
+        let s = FreezeState {
+            reason: "x".into(),
+            operator: "test@host".into(),
+            frozen_at: 100,
+            ttl_secs: Some(50),
+        };
+        assert!(s.is_active_at(149)); // before expiry
+        assert!(!s.is_active_at(150)); // exactly at expiry (frozen_at + ttl = 150)
+        assert!(!s.is_active_at(200)); // long after
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod cli;
 pub mod config;
 pub mod handoff;
 pub mod hitl;
+pub mod incident;
 pub mod mcp;
 pub mod metrics;
 pub mod pbs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,14 @@ fn main() -> Result<()> {
                         {
                             return Some(proxxx::config::ConfigError::EXIT_CODE);
                         }
+                        // Incident lockdown — exit 8 maps to the
+                        // "fleet is frozen, refused mutation" case.
+                        if cause
+                            .downcast_ref::<proxxx::incident::FreezeRefusal>()
+                            .is_some()
+                        {
+                            return Some(proxxx::incident::FreezeRefusal::EXIT_CODE);
+                        }
                         None
                     });
                     if matches!(cli.format, util::format::OutputFormat::Json) {


### PR DESCRIPTION
Closes #64. **Completes Sprint 1** (4-of-4: #58 ✓, #69 ✓, #72 ✓, this).

`proxxx incident {freeze, thaw, status}` — one command halts every mutation across the cluster, no matter which proxxx code path issued it. Reads keep working; investigators need observation during an incident.

```bash
proxxx incident freeze --reason 'pveuser-bot token leaked'
proxxx incident freeze --reason 'SIEM alert NXLog-42' --ttl 4h
proxxx incident status --format json
proxxx incident thaw --reason 'rotation complete'
```

## What it does

A TOML lock file at `<data_local_dir>/freeze.lock` (atomic write via tempfile + rename, 0600 on Unix) carries `reason`, `operator` (`$USER@$HOSTNAME` best-effort), `frozen_at` (unix epoch), and an optional `ttl_secs`. Every PVE mutation entry point in `api::PxClient::{post, put, delete}` calls `check_not_frozen()` before the request — when the lock is active, the call returns a typed `FreezeRefusal` error that main.rs downcasts to **exit code 8**.

TTL semantics: `is_active_at(now)` is `frozen_at + ttl_secs > now`. Expired locks read as thawed but the file is NOT auto-removed — the next freeze/thaw rewrites or removes it, preserving the forensic trail until then.

I/O failure on the lock file is treated as "no freeze" — we prefer to over-permit than to silently lock the cluster out due to a transient I/O failure. Documented in the module rustdoc.

## Audit

Every freeze + thaw appends a row to the HMAC-chained audit log (`incident.freeze` / `incident.thaw` actions, with the reason and operator in `params_json`). The freeze trail survives even after the lock file is gone.

## Architecture

- **New module `src/incident/mod.rs`** (~330 LoC inc. tests) — `FreezeState`, `FreezeRefusal` typed error, public functions with both default-path (`freeze`/`thaw`/`current_state`/`check_not_frozen`) and explicit-path (`*_at(path, ...)`) variants. Tests use the `_at` variants exclusively so no process-global state (env vars) is touched — safe to run in parallel.
- **New CLI module `src/cli/incident.rs`** (~180 LoC) — thin wrapper that parses the duration suffix (`30s`/`5m`/`2h`/`1d`), calls the incident module, audit-logs the event.
- **Wiring in `src/api/client.rs`** — three one-line additions (`crate::incident::check_not_frozen()?;`) at the top of `post`, `put`, `delete`. Zero impact on the GET hot path.
- **Exit code 8** mapped in `main.rs` via the existing typed-error downcast chain (alongside ApiError + PreflightRefusal + ConfigError).
- **New explain entry** `freeze-refusal` so operators who hit the refusal can `proxxx explain freeze-refusal` for context + remediation.

## Out of scope (deferred per #64)

- MCP dispatch integration — the MCP server should call `check_not_frozen()` on every tool-call boundary. Tracked separately; the primitive is in place.
- Telegram HITL daemon broadcast on freeze events. Same.
- Scheduler tick gating (future issue #63 will plug in here).
- Network-level isolation of nodes (PVE firewall, iptables) — proxxx doesn't operate at that layer.

## Tests (11 new in `incident::tests`, 2 in `cli::incident::tests`)

- Round-trip: freeze + read + thaw with TTL preserved.
- Refuses empty / whitespace-only reason.
- Idempotent thaw when no lock present.
- TTL boundary: active up to but not including `frozen_at + ttl`.
- TTL-expired lock reads as None (auto-thaw).
- `check_not_frozen` returns typed `FreezeRefusal` when active, `Ok(())` when not.
- `is_active_at` no-TTL = indefinite.
- Duration parser: `30s`, `5m`, `2h`, `1d`, bare seconds; rejects garbage.
- `entries_cover_every_typed_error` updated to include the new freeze-refusal explain entry.

Total lib tests: 459 → **472**, all green.

## Live smoke against the cluster

```
incident status                      → {"active": false}
incident freeze --reason X --ttl 1m  → returns FreezeState
incident status                      → {"active": true, ...}
pool create --poolid x               → "refusing mutation — FROZEN...", exit 8
incident thaw --reason Y             → returns prior state
incident status                      → {"active": false}
```

## Quality

- `cargo fmt` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --lib` **472/472 green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)