### PR TITLE
feat(cli): cross-profile fanout — `ls --all-profiles` + `find`

### DIFF
--- a/src/cli/fanout.rs
+++ b/src/cli/fanout.rs
@@ -1,0 +1,299 @@
+//! Cross-profile fanout for read-only `ls` / `find` queries.
+//!
+//! Operators with `[profiles.dev]` + `[profiles.staging]` + `[profiles.prod]`
+//! in `config.toml` can pass `--all-profiles` (or `-A`) to fan a
+//! read-only query across every cluster concurrently. Each row gets
+//! a `profile` field added so the operator can tell where it came
+//! from. Per-cluster failures (unreachable, 401, etc.) surface as
+//! synthetic rows tagged `error: …` — they NEVER fail the whole
+//! command. The MVP rule: investigation should always make progress
+//! against the clusters that *are* reachable.
+//!
+//! Writes are deliberately NOT plumbed through this fanout — too
+//! easy to footgun ("stop every guest across every cluster"). For
+//! writes, the operator must `--profile <name>` explicitly. Issue
+//! #59 calls this out in its "Out of scope" section.
+
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+use std::sync::Arc;
+
+use crate::api::{ProxmoxGateway, PxClient};
+
+/// One row in a cross-profile result. The `profile` field is added
+/// at fanout time; the rest is whatever the per-profile call
+/// returned, serialised back through `serde_json::Value` so we
+/// don't have to know the concrete shape per resource kind.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProfileRow {
+    pub profile: String,
+    /// `data` for a successful row, `error` for a failure row.
+    /// Serialised flat so JSON consumers see `{profile, data}` or
+    /// `{profile, error}`.
+    #[serde(flatten)]
+    pub payload: ProfileRowPayload,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum ProfileRowPayload {
+    Data { data: Value },
+    Error { error: String },
+}
+
+/// Kinds of read-only query we know how to fan out. Each variant
+/// maps to a single per-profile `async` call against `ProxmoxGateway`.
+#[derive(Debug, Clone, Copy)]
+pub enum FanoutKind {
+    Nodes,
+    Guests,
+    Storage,
+}
+
+impl FanoutKind {
+    /// Map the `ls` resource string from the CLI to a fanout kind.
+    pub fn from_resource(s: &str) -> Option<Self> {
+        match s {
+            "nodes" => Some(Self::Nodes),
+            "guests" => Some(Self::Guests),
+            "storage" => Some(Self::Storage),
+            _ => None,
+        }
+    }
+}
+
+/// Fanout a `ls <kind>` query across every named profile in the
+/// config. Returns one or more rows per profile (depending on the
+/// per-call result shape):
+///   * Nodes → one row per cluster node
+///   * Guests → one row per guest
+///   * Storage → one row per storage pool
+///   * Error → one synthetic row with `error: <message>`
+///
+/// Per-profile errors are caught and converted to error rows. Hard
+/// `Err` is returned only if we can't even enumerate profiles (e.g.
+/// config file is unreadable). The shape mirrors `events stream`'s
+/// "graceful per-profile" pattern.
+pub async fn fanout_ls(kind: FanoutKind, cli_secret: Option<&str>) -> Result<Vec<ProfileRow>> {
+    let profiles = crate::config::list_profiles()?;
+    if profiles.is_empty() {
+        anyhow::bail!(
+            "no named profiles in config.toml — `--all-profiles` requires at least one \
+             `[profiles.NAME]` block (run `proxxx init` if this is a fresh setup)"
+        );
+    }
+
+    let cli_secret_owned = cli_secret.map(str::to_owned);
+    let handles: Vec<_> = profiles
+        .into_iter()
+        .map(|profile| {
+            let cli_secret = cli_secret_owned.clone();
+            tokio::spawn(async move {
+                let rows = match query_one_profile(&profile, kind, cli_secret.as_deref()).await {
+                    Ok(rows) => rows,
+                    Err(e) => vec![ProfileRow {
+                        profile: profile.clone(),
+                        payload: ProfileRowPayload::Error {
+                            error: format!("{e:#}"),
+                        },
+                    }],
+                };
+                rows
+            })
+        })
+        .collect();
+
+    let mut all_rows: Vec<ProfileRow> = Vec::new();
+    for h in handles {
+        // `join` itself could fail if the task panicked. Convert that
+        // into an error row so the operator sees which profile blew up
+        // rather than the whole command exiting non-zero.
+        match h.await {
+            Ok(rows) => all_rows.extend(rows),
+            Err(e) => all_rows.push(ProfileRow {
+                profile: "(unknown — task panicked)".into(),
+                payload: ProfileRowPayload::Error {
+                    error: format!("task join: {e}"),
+                },
+            }),
+        }
+    }
+    // Sort by (profile, then a stable secondary if available). Stable
+    // ordering matters for table rendering + scripted diff.
+    all_rows.sort_by(|a, b| a.profile.cmp(&b.profile));
+    Ok(all_rows)
+}
+
+/// Fanout a "find VMID X across every profile" query. Returns one
+/// row per profile that owns the VMID, plus error rows for
+/// unreachable profiles. Profiles that *don't* own the VMID are
+/// silently filtered out — they're the common case (3 profiles, 1
+/// owner) and would clutter the output otherwise.
+pub async fn fanout_find_vmid(vmid: u32, cli_secret: Option<&str>) -> Result<Vec<ProfileRow>> {
+    let profiles = crate::config::list_profiles()?;
+    if profiles.is_empty() {
+        anyhow::bail!("no named profiles in config.toml — `--all-profiles` requires at least one");
+    }
+
+    let cli_secret_owned = cli_secret.map(str::to_owned);
+    let handles: Vec<_> = profiles
+        .into_iter()
+        .map(|profile| {
+            let cli_secret = cli_secret_owned.clone();
+            tokio::spawn(
+                async move { find_one_profile(&profile, vmid, cli_secret.as_deref()).await },
+            )
+        })
+        .collect();
+
+    let mut rows: Vec<ProfileRow> = Vec::new();
+    for h in handles {
+        if let Ok(maybe_row) = h.await {
+            match maybe_row {
+                Ok(Some(row)) => rows.push(row),
+                Ok(None) => {} // VMID not in this profile — silent
+                Err(e) => rows.push(ProfileRow {
+                    profile: "(unknown)".into(),
+                    payload: ProfileRowPayload::Error {
+                        error: format!("{e:#}"),
+                    },
+                }),
+            }
+        }
+    }
+    rows.sort_by(|a, b| a.profile.cmp(&b.profile));
+    Ok(rows)
+}
+
+async fn query_one_profile(
+    profile: &str,
+    kind: FanoutKind,
+    cli_secret: Option<&str>,
+) -> Result<Vec<ProfileRow>> {
+    let cfg = crate::config::load_config(Some(profile))?;
+    let client = Arc::new(PxClient::new(cfg, cli_secret).await?);
+    let payload = match kind {
+        FanoutKind::Nodes => {
+            let v = client.get_nodes().await?;
+            serde_json::to_value(v)?
+        }
+        FanoutKind::Guests => {
+            let nodes = client.get_nodes().await?;
+            let mut all = Vec::new();
+            for n in &nodes {
+                if let Ok(g) = client.get_guests(&n.node).await {
+                    all.extend(g);
+                }
+            }
+            serde_json::to_value(all)?
+        }
+        FanoutKind::Storage => {
+            let nodes = client.get_nodes().await?;
+            let mut all = Vec::new();
+            for n in &nodes {
+                if let Ok(s) = client.get_storage_pools(&n.node).await {
+                    all.extend(s);
+                }
+            }
+            serde_json::to_value(all)?
+        }
+    };
+    // Per-resource arrays get flattened to one row per element so
+    // the table view shows N rows per profile, each with the
+    // `profile` column. Scalars (or non-array shapes) become a
+    // single row with the whole value.
+    let rows: Vec<ProfileRow> = if let Some(arr) = payload.as_array() {
+        arr.iter()
+            .map(|item| ProfileRow {
+                profile: profile.to_string(),
+                payload: ProfileRowPayload::Data { data: item.clone() },
+            })
+            .collect()
+    } else {
+        vec![ProfileRow {
+            profile: profile.to_string(),
+            payload: ProfileRowPayload::Data { data: payload },
+        }]
+    };
+    Ok(rows)
+}
+
+async fn find_one_profile(
+    profile: &str,
+    vmid: u32,
+    cli_secret: Option<&str>,
+) -> Result<Option<ProfileRow>> {
+    let cfg = crate::config::load_config(Some(profile))?;
+    let client = Arc::new(PxClient::new(cfg, cli_secret).await?);
+    // Walk nodes; first hit wins. Could parallelise per-node but
+    // each profile is itself fanned out at the outer level — a
+    // sequential per-node sweep here keeps the API call count
+    // proportional rather than explosive.
+    let nodes = client.get_nodes().await?;
+    for n in &nodes {
+        if let Ok(guests) = client.get_guests(&n.node).await {
+            if let Some(g) = guests.iter().find(|g| g.vmid == vmid) {
+                return Ok(Some(ProfileRow {
+                    profile: profile.to_string(),
+                    payload: ProfileRowPayload::Data {
+                        data: serde_json::to_value(g)?,
+                    },
+                }));
+            }
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fanout_kind_recognises_known_resources() {
+        assert!(matches!(
+            FanoutKind::from_resource("nodes"),
+            Some(FanoutKind::Nodes)
+        ));
+        assert!(matches!(
+            FanoutKind::from_resource("guests"),
+            Some(FanoutKind::Guests)
+        ));
+        assert!(matches!(
+            FanoutKind::from_resource("storage"),
+            Some(FanoutKind::Storage)
+        ));
+        assert!(FanoutKind::from_resource("acl").is_none());
+        assert!(FanoutKind::from_resource("").is_none());
+    }
+
+    #[test]
+    fn profile_row_data_serialises_flat() {
+        let row = ProfileRow {
+            profile: "dev".into(),
+            payload: ProfileRowPayload::Data {
+                data: serde_json::json!({"vmid": 100}),
+            },
+        };
+        let v: serde_json::Value = serde_json::to_value(&row).unwrap();
+        assert_eq!(v["profile"], "dev");
+        assert_eq!(v["data"]["vmid"], 100);
+        // No nested `payload` wrapper.
+        assert!(v.get("payload").is_none());
+    }
+
+    #[test]
+    fn profile_row_error_serialises_flat() {
+        let row = ProfileRow {
+            profile: "prod".into(),
+            payload: ProfileRowPayload::Error {
+                error: "connection refused".into(),
+            },
+        };
+        let v: serde_json::Value = serde_json::to_value(&row).unwrap();
+        assert_eq!(v["profile"], "prod");
+        assert_eq!(v["error"], "connection refused");
+        assert!(v.get("data").is_none());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ mod ct;
 mod doctor;
 mod events;
 pub mod explain;
+mod fanout;
 mod firewall;
 mod incident;
 mod init;
@@ -39,6 +40,24 @@ pub enum Command {
     Ls {
         /// Resource type: nodes, guests, storage
         resource: String,
+        /// Fan out the query across every named profile in
+        /// `config.toml` concurrently. Each output row gets a
+        /// `profile` field. Per-profile failures (401 / unreachable)
+        /// surface as `error` rows; the rest of the cluster keeps
+        /// answering. Read-only — writes still require explicit
+        /// `--profile <name>`.
+        #[arg(long, short = 'A')]
+        all_profiles: bool,
+    },
+
+    /// Find a guest by VMID across every cluster. Like `ls guests
+    /// --all-profiles` but filtered to one VMID. Returns one row per
+    /// profile that owns the VMID (typically 0 or 1). Useful for
+    /// "which cluster owns VMID 100?" without manual profile-switching.
+    #[command(alias = "where")]
+    Find {
+        /// VMID to find.
+        vmid: u32,
     },
     /// Start a guest
     Start {
@@ -917,6 +936,31 @@ pub async fn execute(
         }
     }
 
+    // `--all-profiles` short-circuits BEFORE load_config(profile) — the
+    // fanout creates its own per-profile PxClient internally; a single
+    // top-level profile selection would be ignored. Equally, `find`
+    // is always cross-profile (no `--profile` makes sense for it).
+    if let Command::Ls {
+        resource,
+        all_profiles: true,
+    } = &cmd
+    {
+        let kind = fanout::FanoutKind::from_resource(resource).ok_or_else(|| {
+            anyhow::anyhow!(
+                "--all-profiles is supported on `ls nodes|guests|storage` (got `{resource}`)"
+            )
+        })?;
+        let rows = fanout::fanout_ls(kind, cli_secret).await?;
+        return Ok((serde_json::to_value(rows)?, 0));
+    }
+    if let Command::Find { vmid } = &cmd {
+        let rows = fanout::fanout_find_vmid(*vmid, cli_secret).await?;
+        // Exit 5 (NotFound) if no profile owns the vmid — matches the
+        // existing `ls`+grep contract.
+        let exit = if rows.is_empty() { 5 } else { 0 };
+        return Ok((serde_json::to_value(rows)?, exit));
+    }
+
     if matches!(cmd, Command::Doctor) {
         return doctor::run().await;
     }
@@ -939,7 +983,10 @@ pub async fn execute(
     use crate::api::ProxmoxGateway;
 
     match cmd {
-        Command::Ls { resource } => match resource.as_str() {
+        Command::Ls {
+            resource,
+            all_profiles: _, // already handled in the short-circuit above when true
+        } => match resource.as_str() {
             "nodes" => {
                 let nodes = client.get_nodes().await?;
                 Ok((serde_json::to_value(nodes)?, 0))
@@ -1762,6 +1809,12 @@ pub async fn execute(
             Ok((serde_json::to_value(interfaces)?, 0))
         }
         Command::Storage { action } => storage::execute_storage(&client, action).await,
+        // `Find` is always cross-profile — short-circuited before
+        // load_config. This arm is unreachable but the match must
+        // be exhaustive.
+        Command::Find { .. } => {
+            unreachable!("Command::Find handled by --all-profiles short-circuit above")
+        }
     }
 }
 


### PR DESCRIPTION
Closes #59. Multi-cluster operators get one command to query every cluster without manual profile-switching. Per-cluster failures surface as synthetic `error` rows; the rest keep answering. Writes deliberately NOT plumbed through fanout (footgun avoidance).

```bash
proxxx ls guests --all-profiles    # every guest across every cluster
proxxx ls nodes -A                  # short alias
proxxx find 100                     # which cluster owns VMID 100?
```

3 new tests. Lib tests: 472 → 475. `fmt`+`clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)