### PR TITLE
feat(console): serial session recording + replay (asciinema cast v2)

### DIFF
--- a/src/cli/console.rs
+++ b/src/cli/console.rs
@@ -131,6 +131,7 @@ pub async fn execute_serial(
     vmid: u32,
     node: &str,
     kind_override: Option<SerialKind>,
+    record_path: Option<std::path::PathBuf>,
 ) -> Result<(Value, i32)> {
     use crate::api::ProxmoxGateway;
 
@@ -183,11 +184,42 @@ pub async fn execute_serial(
     let _ = stdout().flush();
 
     // Initial size sync.
-    if let Ok((cols, rows)) = terminal::size() {
-        let _ = crate::wsterm::send_resize(&mut ws, cols, rows).await;
-    }
+    let (cols, rows) = terminal::size().unwrap_or((80, 24));
+    let _ = crate::wsterm::send_resize(&mut ws, cols, rows).await;
 
-    let exit_code = serial_loop(&mut ws).await;
+    // Open the cast recorder upfront so failures are visible before
+    // the session starts (rather than half-way through). A failed
+    // open prints the error + continues without recording — the
+    // session itself is the important thing.
+    let mut recorder = if let Some(p) = &record_path {
+        match crate::console_record::CastWriter::create(
+            p,
+            cols,
+            rows,
+            &format!("proxxx serial vmid={vmid} node={node}"),
+        ) {
+            Ok(w) => {
+                eprintln!("recording → {}", p.display());
+                Some(w)
+            }
+            Err(e) => {
+                eprintln!(
+                    "warning: could not open recording at {}: {e:#}",
+                    p.display()
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let exit_code = serial_loop(&mut ws, recorder.as_mut()).await;
+    // Final flush before we drop — guarantees the last events made
+    // it to disk even if the process is killed before drop fires.
+    if let Some(r) = recorder.as_mut() {
+        r.flush();
+    }
 
     // Cleanup — best-effort. The panic hook is the safety net for the
     // unhappy path.
@@ -483,7 +515,10 @@ fn is_routable_ipv4(s: &str) -> bool {
 }
 
 /// Inner loop: keystrokes → WS, WS frames → stdout. Returns exit code.
-async fn serial_loop<S>(ws: &mut tokio_tungstenite::WebSocketStream<S>) -> i32
+async fn serial_loop<S>(
+    ws: &mut tokio_tungstenite::WebSocketStream<S>,
+    mut recorder: Option<&mut crate::console_record::CastWriter>,
+) -> i32
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
@@ -520,8 +555,11 @@ where
                             // Not the exit chord — forward Ctrl+] then this key.
                             let _ = crate::wsterm::send_input(ws, &[0x1D]).await;
                         }
-                        // Encode + forward.
+                        // Encode + forward + record (if active).
                         if let Some(bytes) = crate::ssh::pty::encode_key(&key) {
+                            if let Some(r) = recorder.as_deref_mut() {
+                                r.record_input(&bytes);
+                            }
                             if crate::wsterm::send_input(ws, &bytes).await.is_err() {
                                 return 1;
                             }
@@ -539,11 +577,17 @@ where
                 match msg {
                     Ok(Message::Binary(payload)) => {
                         if let Some(bytes) = crate::wsterm::decode_data_frame(&payload) {
+                            if let Some(r) = recorder.as_deref_mut() {
+                                r.record_output(bytes);
+                            }
                             let _ = stdout().write_all(bytes);
                             let _ = stdout().flush();
                         }
                     }
                     Ok(Message::Text(t)) => {
+                        if let Some(r) = recorder.as_deref_mut() {
+                            r.record_output(t.as_bytes());
+                        }
                         let _ = stdout().write_all(t.as_bytes());
                         let _ = stdout().flush();
                     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -680,6 +680,29 @@ pub enum Command {
         /// Guest type. Auto-detected from cluster if omitted.
         #[arg(long, value_enum)]
         kind: Option<console::SerialKind>,
+        /// Record the session in asciinema cast v2 format. Pass a
+        /// path to write there, or use `--record` alone to write to
+        /// the default `<data_dir>/sessions/<ts>-<vmid>-serial.cast`.
+        /// Operator keystrokes are recorded as `i` events; guest
+        /// output as `o` events. Replay with `proxxx replay <path>`
+        /// or any asciinema-compatible player.
+        #[arg(long, num_args = 0..=1, default_missing_value = "")]
+        record: Option<String>,
+    },
+
+    /// Console session recording — replay an asciinema cast v2
+    /// file produced by `proxxx serial --record …`. Renders the
+    /// recorded output with original timing; input events are
+    /// skipped (only the operator's view is played back, not their
+    /// keystrokes — same as `asciinema play`).
+    PlayCast {
+        /// Path to a `.cast` file.
+        path: std::path::PathBuf,
+        /// Playback speed multiplier. `1.0` is real-time; `2.0` is
+        /// 2× faster; `0.5` is half speed. Negative / zero falls
+        /// back to `1.0`.
+        #[arg(long, default_value_t = 1.0)]
+        speed: f64,
     },
     /// Open an interactive SSH session into a guest (NOT into the PVE
     /// node — for that, just `ssh root@<node>` directly). Per-guest
@@ -1758,11 +1781,28 @@ pub async fn execute(
         Command::Perms { userid, path, node } => {
             access::execute_perms(&config, &userid, path.as_deref(), &node).await
         }
-        Command::Serial { vmid, node, kind } => {
-            console::execute_serial(&client, &config, vmid, &node, kind).await
+        Command::Serial {
+            vmid,
+            node,
+            kind,
+            record,
+        } => {
+            // `--record` without a path → auto path under data dir.
+            let record_path = record.map(|p| {
+                if p.is_empty() {
+                    crate::console_record::default_recording_path(vmid, "serial")
+                } else {
+                    std::path::PathBuf::from(p)
+                }
+            });
+            console::execute_serial(&client, &config, vmid, &node, kind, record_path).await
         }
         Command::Ssh { vmid, cmd } => {
             console::execute_ssh(&client, &config, vmid, cmd.as_deref()).await
+        }
+        Command::PlayCast { path, speed } => {
+            crate::console_record::replay_cast(&path, speed).await?;
+            Ok((Value::Null, 0))
         }
         Command::Spice {
             vmid,

--- a/src/console_record.rs
+++ b/src/console_record.rs
@@ -1,0 +1,310 @@
+//! asciinema cast v2 recording + replay.
+//!
+//! [Asciicast v2 spec](https://docs.asciinema.org/manual/asciicast/v2/).
+//! The format is one JSON object per line:
+//!
+//! ```text
+//! {"version": 2, "width": 80, "height": 24, "timestamp": 1700000000, "title": "..."}
+//! [0.123, "o", "hello\r\n"]
+//! [0.234, "i", "q"]
+//! ```
+//!
+//! Events use:
+//!   * `"o"` — output (host → terminal, what the operator sees)
+//!   * `"i"` — input (terminal → host, what the operator typed)
+//!
+//! The text payload is a JSON string containing the raw UTF-8 bytes
+//! (asciinema treats it as a string, with the standard JSON
+//! `\uXXXX` / backslash / quote escapes for non-ASCII or control bytes).
+//! Our writer takes `&[u8]` and emits the string form via
+//! `String::from_utf8_lossy` — invalid sequences become the
+//! Unicode replacement character (U+FFFD), which the replayer
+//! renders verbatim.
+//! Lossy is acceptable for this use case (terminal control bytes
+//! are valid ASCII; UTF-8 substring corruption is rare).
+//!
+//! ## Replay
+//!
+//! [`replay_cast`] reads the file, parses each line, sleeps to
+//! re-create the timing, and writes the output bytes to stdout.
+//! Input events are SKIPPED on replay (we render only what the
+//! operator saw; their keystrokes are forensic data, not playback).
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::time::Instant;
+
+/// Asciicast v2 header (first line of every cast file).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CastHeader {
+    /// Always 2 for the v2 format.
+    pub version: u32,
+    pub width: u16,
+    pub height: u16,
+    /// Unix epoch seconds when recording started.
+    pub timestamp: u64,
+    pub title: String,
+}
+
+/// Streaming writer for an asciicast v2 file. One per session;
+/// dropping the writer closes the file (the writer is `BufWriter`-
+/// wrapped so the final flush happens on drop).
+///
+/// Failures are downgraded to `tracing::warn` on the recording
+/// side: we DO NOT want a failing recorder to bring down a live
+/// SSH/serial session. The session keeps running; the cast may
+/// just be missing the last few events.
+pub struct CastWriter {
+    file: BufWriter<std::fs::File>,
+    start: Instant,
+}
+
+impl CastWriter {
+    /// Open `path` and write the header line. The parent directory
+    /// is created if missing. File permissions 0600 on Unix.
+    pub fn create(path: &Path, width: u16, height: u16, title: &str) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create dir {}", parent.display()))?;
+        }
+        let file = std::fs::File::create(path)
+            .with_context(|| format!("open cast file {} for write", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("chmod 0600 {}", path.display()))?;
+        }
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let header = CastHeader {
+            version: 2,
+            width,
+            height,
+            timestamp,
+            title: title.to_string(),
+        };
+        let mut bw = BufWriter::new(file);
+        let header_line = serde_json::to_string(&header)?;
+        writeln!(bw, "{header_line}").context("write cast header")?;
+        Ok(Self {
+            file: bw,
+            start: Instant::now(),
+        })
+    }
+
+    /// Record a chunk of output bytes (host → terminal).
+    pub fn record_output(&mut self, bytes: &[u8]) {
+        self.record_event("o", bytes);
+    }
+
+    /// Record a chunk of input bytes (terminal → host).
+    pub fn record_input(&mut self, bytes: &[u8]) {
+        self.record_event("i", bytes);
+    }
+
+    /// Format one event line and append. I/O failures are logged
+    /// but not propagated — see the struct rustdoc.
+    fn record_event(&mut self, kind: &str, bytes: &[u8]) {
+        let elapsed = self.start.elapsed().as_secs_f64();
+        // Lossy is the right call for terminal data: the alternative
+        // (skipping invalid UTF-8) loses the operator's view. Lone
+        // replacement chars in a recording are diagnostic, not fatal.
+        let payload = String::from_utf8_lossy(bytes);
+        // Use serde_json to escape — its escape rules match asciinema's
+        // (RFC 8259 JSON string), guaranteeing the cast parses.
+        let payload_json = match serde_json::to_string(&payload) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("cast: payload serialise failed: {e}");
+                return;
+            }
+        };
+        // The asciinema format is a JSON array literal — emit it by
+        // hand to keep the timestamp formatting consistent (3 decimal
+        // digits is standard).
+        let line = format!("[{elapsed:.6}, \"{kind}\", {payload_json}]");
+        if let Err(e) = writeln!(self.file, "{line}") {
+            tracing::warn!("cast: write failed: {e}");
+        }
+    }
+
+    /// Force-flush. The Drop impl below also flushes; callers can
+    /// call this explicitly before exit if they need a guarantee.
+    pub fn flush(&mut self) {
+        if let Err(e) = self.file.flush() {
+            tracing::warn!("cast: flush failed: {e}");
+        }
+    }
+}
+
+impl Drop for CastWriter {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}
+
+/// Replay a cast file to stdout. Reads the header line + every
+/// event, sleeps the per-event delay, writes the output bytes.
+/// Input events are skipped (we render only what the operator saw).
+///
+/// `speed` is a multiplier — `1.0` plays at the recording rate;
+/// `2.0` plays 2× faster; `0.5` plays at half speed.
+pub async fn replay_cast(path: &Path, speed: f64) -> Result<()> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    let file = tokio::fs::File::open(path)
+        .await
+        .with_context(|| format!("open cast {}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+
+    // Header first.
+    let n = reader
+        .read_line(&mut line)
+        .await
+        .with_context(|| format!("read cast header {}", path.display()))?;
+    if n == 0 {
+        anyhow::bail!("empty cast file: {}", path.display());
+    }
+    let header: CastHeader = serde_json::from_str(line.trim())
+        .with_context(|| format!("parse cast header in {}", path.display()))?;
+    if header.version != 2 {
+        anyhow::bail!(
+            "unsupported cast version {} (expected 2) in {}",
+            header.version,
+            path.display(),
+        );
+    }
+    eprintln!(
+        "▶ replaying {} ({}×{}, recorded {} epoch s)",
+        header.title, header.width, header.height, header.timestamp
+    );
+
+    let mut stdout = tokio::io::stdout();
+    let mut prev_t = 0_f64;
+    let speed = if speed <= 0.0 { 1.0 } else { speed };
+
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            break;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // `[<seconds>, "<kind>", "<payload>"]` parses as a 3-tuple.
+        let event: (f64, String, String) = match serde_json::from_str(trimmed) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!("cast: skipping malformed event line: {e}");
+                continue;
+            }
+        };
+        let (t, kind, payload) = event;
+        // Skip input events on replay (operator keystrokes are
+        // forensic data, not playback).
+        if kind != "o" {
+            prev_t = t;
+            continue;
+        }
+        let delay = (t - prev_t).max(0.0) / speed;
+        if delay > 0.0 {
+            tokio::time::sleep(std::time::Duration::from_secs_f64(delay)).await;
+        }
+        prev_t = t;
+        stdout.write_all(payload.as_bytes()).await?;
+        stdout.flush().await?;
+    }
+    Ok(())
+}
+
+/// Default path for a recording: `<data_local_dir>/sessions/
+/// <ts>-<vmid>-<kind>.cast`. Overridable via the CLI flag — this
+/// is just the auto-generated fallback.
+#[must_use]
+pub fn default_recording_path(vmid: u32, kind: &str) -> std::path::PathBuf {
+    let dir = directories::ProjectDirs::from("dev", "proxxx", "proxxx")
+        .map_or_else(
+            || std::path::PathBuf::from("/tmp/proxxx"),
+            |d| d.data_local_dir().to_path_buf(),
+        )
+        .join("sessions");
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    dir.join(format!("{ts}-{vmid}-{kind}.cast"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cast_writer_emits_header_then_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.cast");
+        {
+            let mut w = CastWriter::create(&path, 120, 30, "test session").unwrap();
+            w.record_output(b"hello\r\n");
+            w.record_input(b"q");
+            w.flush();
+        }
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3);
+
+        // Header.
+        let header: CastHeader = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(header.version, 2);
+        assert_eq!(header.width, 120);
+        assert_eq!(header.height, 30);
+        assert_eq!(header.title, "test session");
+
+        // Output event.
+        let (_, kind, payload): (f64, String, String) = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(kind, "o");
+        assert_eq!(payload, "hello\r\n");
+
+        // Input event.
+        let (_, kind2, payload2): (f64, String, String) = serde_json::from_str(lines[2]).unwrap();
+        assert_eq!(kind2, "i");
+        assert_eq!(payload2, "q");
+    }
+
+    #[test]
+    fn cast_writer_handles_invalid_utf8_gracefully() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.cast");
+        {
+            let mut w = CastWriter::create(&path, 80, 24, "binary").unwrap();
+            // Invalid UTF-8 in terminal output — `from_utf8_lossy`
+            // should replace it with U+FFFD and the line should
+            // still serialise as valid JSON.
+            w.record_output(&[0xFF, b'a', 0xFE]);
+            w.flush();
+        }
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        // Header + one event; both must be valid JSON.
+        assert_eq!(lines.len(), 2);
+        let _: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        let _: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    }
+
+    #[test]
+    fn default_recording_path_has_session_dir_and_extension() {
+        let p = default_recording_path(100, "serial");
+        let s = p.to_string_lossy();
+        assert!(s.contains("sessions"));
+        assert!(s.ends_with(".cast"));
+        assert!(s.contains("-100-serial"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod app;
 pub mod audit;
 pub mod cli;
 pub mod config;
+pub mod console_record;
 pub mod handoff;
 pub mod hitl;
 pub mod incident;


### PR DESCRIPTION
Closes #67. `proxxx serial --record [path]` writes asciicast v2; `proxxx play-cast <path>` replays. Standard format. 3 new tests; 484->487. SSH integration deferred. `fmt`+`clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)