### PR TITLE
feat(state): pre-flight risk gates + interactive HITL for state apply

### DIFF
--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -114,15 +114,26 @@ pub enum StateCommand {
     ///   2 — at least one change failed
     ///   1 — error (file unreadable, PVE unreachable, etc.)
     ///
-    /// Pre-flight risk gates + HITL approval per destructive change
-    /// are tracked separately in epic #74; this command issues PVE
-    /// calls directly. Always run `--dry-run` first, then `--prune`
-    /// only when you've reviewed the diff.
+    /// Pre-flight risk gates fire BEFORE any PVE call. Severe
+    /// risks (deleting a non-empty pool, removing a root-equivalent
+    /// ACL grant, deleting a shared storage, very large change
+    /// batches) refuse the apply unless `--allow-risk` is set. Exit
+    /// code 6 ("Pre-flight risk refused") matches the per-guest
+    /// pre-flight contract.
+    ///
+    /// `--interactive` adds a Human-In-The-Loop step: each Severe
+    /// change prompts `[y/N]` on stdin. Use for one-off manual
+    /// applies; not for scripted pipelines (use `--allow-risk`).
+    ///
+    /// Always run `--dry-run` first, then `--prune` only when
+    /// you've reviewed the diff.
     ///
     /// Examples:
-    ///   proxxx state apply state.toml --dry-run     # preview
-    ///   proxxx state apply state.toml               # apply, no deletes
-    ///   proxxx state apply state.toml --prune       # apply + delete drift
+    ///   proxxx state apply state.toml --dry-run                       # preview
+    ///   proxxx state apply state.toml                                  # apply, no deletes
+    ///   proxxx state apply state.toml --prune                          # apply + delete drift
+    ///   proxxx state apply state.toml --prune --interactive            # prompt per Severe
+    ///   proxxx state apply state.toml --prune --allow-risk             # bypass gate (CI)
     Apply {
         /// Path to the declared state TOML file.
         declared: PathBuf,
@@ -145,6 +156,22 @@ pub enum StateCommand {
         /// ordering dependencies.
         #[arg(long)]
         continue_on_error: bool,
+
+        /// Override the pre-flight Severe-risk gate. Without this,
+        /// any Severe risk (non-empty pool delete, root-role ACL
+        /// delete, shared storage delete, batch ≥ 50 changes) refuses
+        /// the apply with exit code 6. Pass `--allow-risk` only when
+        /// the operator has explicitly reviewed the diff.
+        #[arg(long)]
+        allow_risk: bool,
+
+        /// Prompt `[y/N]` on stdin for every Severe-risk change.
+        /// Mutually informative with `--allow-risk`: --allow-risk
+        /// bypasses the gate silently; --interactive lets the
+        /// operator approve case-by-case. Don't use in CI pipelines
+        /// — there's no stdin.
+        #[arg(long)]
+        interactive: bool,
 
         /// Output format. Default: human-readable per-change line.
         #[arg(long, value_enum, default_value_t = ApplyOutputFormat::Text)]
@@ -276,6 +303,8 @@ pub async fn execute_state(
             dry_run,
             prune,
             continue_on_error,
+            allow_risk,
+            interactive,
             output,
         } => {
             let toml_str = std::fs::read_to_string(&declared)
@@ -300,7 +329,24 @@ pub async fn execute_state(
             )
             .await?;
 
-            let changes = state::diff::diff(&declared_state, &live_state);
+            let mut changes = state::diff::diff(&declared_state, &live_state);
+
+            // Pre-flight risk gate. Dry-run skips the gate (the
+            // operator is exploring, not committing) — every other
+            // path goes through enforce_state_preflight, which
+            // prints the risk list and may refuse with
+            // PreflightRefusal (exit 6).
+            if !dry_run {
+                state::preflight::enforce_state_preflight(&changes, &live_state, allow_risk)?;
+            }
+
+            // Interactive HITL: per-Severe-change stdin prompt.
+            // Filtered before dispatch so a rejected change becomes
+            // an explicit operator-skipped outcome.
+            if interactive && !dry_run {
+                changes = interactive_hitl_filter(&changes, &live_state);
+            }
+
             let opts = state::apply::ApplyOptions {
                 dry_run,
                 prune,
@@ -334,6 +380,73 @@ pub async fn execute_state(
             Ok((Value::Null, exit))
         }
     }
+}
+
+/// Interactive HITL filter: prompt `[y/N]` for every change whose
+/// pre-flight risk is Severe; return only the approved subset.
+///
+/// Notice/Warning-tier changes pass through unchanged — the gate
+/// fires only on Severe so the operator isn't drowned in prompts
+/// for routine drift convergence.
+///
+/// On EOF / unreadable stdin we treat the answer as "no" (refuse).
+/// That matches the spirit of HITL: silence = no consent.
+fn interactive_hitl_filter(
+    changes: &[state::diff::Change],
+    live_state: &state::model::ClusterState,
+) -> Vec<state::diff::Change> {
+    use std::io::{BufRead, Write};
+
+    let mut approved: Vec<state::diff::Change> = Vec::with_capacity(changes.len());
+    let stdin = std::io::stdin();
+
+    for change in changes {
+        // Re-assess this single change to know its severity tier.
+        // The full-list assess() runs cluster-wide checks (bulk
+        // count) that we don't want to repeat per change; for the
+        // per-change prompt we only care about the per-change
+        // risks.
+        let risks = state::preflight::assess(std::slice::from_ref(change), live_state);
+        let max = risks
+            .iter()
+            .map(state::preflight::StateRisk::level)
+            .max()
+            .unwrap_or(crate::app::preflight::RiskLevel::Notice);
+
+        if max != crate::app::preflight::RiskLevel::Severe {
+            approved.push(change.clone());
+            continue;
+        }
+
+        let summary = state::diff::summary_line(change);
+        eprintln!("\nSEVERE change pending:");
+        eprintln!("  {summary}");
+        for r in &risks {
+            if matches!(r.level(), crate::app::preflight::RiskLevel::Severe) {
+                eprintln!("  reason: {}", r.describe());
+            }
+        }
+        {
+            let mut out = std::io::stdout().lock();
+            let _ = write!(out, "Approve? [y/N] ");
+            let _ = out.flush();
+        }
+
+        let mut line = String::new();
+        let mut handle = stdin.lock();
+        let answer = match handle.read_line(&mut line) {
+            Ok(0) => false, // EOF
+            Ok(_) => matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes"),
+            Err(_) => false,
+        };
+        if answer {
+            eprintln!("  → approved");
+            approved.push(change.clone());
+        } else {
+            eprintln!("  → rejected (skipped)");
+        }
+    }
+    approved
 }
 
 /// Render one apply outcome as a single human-readable line.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -43,3 +43,4 @@ pub mod apply;
 pub mod diff;
 pub mod export;
 pub mod model;
+pub mod preflight;

--- a/src/state/preflight.rs
+++ b/src/state/preflight.rs
@@ -1,0 +1,564 @@
+//! Pre-flight risk gates for `proxxx state apply`.
+//!
+//! The existing per-guest pre-flight ([`crate::app::preflight`])
+//! grades destructive ops on a single [`Guest`](crate::api::types::Guest)
+//! against a fixed `Op` enum. State-apply changes are a different
+//! shape: they touch resources (pools, ACL grants, storages) that
+//! have their own risk profile distinct from "the guest is running".
+//!
+//! ## Risk model
+//!
+//! We grade each [`Change`] by *blast radius* — what's the worst
+//! thing that happens if this change goes wrong?
+//!
+//! | Risk                          | Why it's classified that way |
+//! | :---------------------------- | :--------------------------- |
+//! | [`StateRisk::PoolDeleteNonEmpty`] | Severe — orphans the members; PVE refuses but the error is opaque. We catch it up-front. |
+//! | [`StateRisk::AclDeleteRootRole`]  | Severe — removing root-equivalent ACL on `/` is a lock-out risk. |
+//! | [`StateRisk::AclDeleteAuditor`]   | Warning — removing audit/observation grants; not fatal but visibility loss. |
+//! | [`StateRisk::StorageDeleteShared`] | Severe — shared storages typically host live guest disks. |
+//! | [`StateRisk::StoragePropertyChange { what }`] | Warning — content-list or path changes can break running guests. |
+//! | [`StateRisk::AclPropagateFlip`]   | Warning — `propagate` change cascades to every descendant path. |
+//! | [`StateRisk::BulkChangeCount { n }`] | Notice → Warning if `n ≥ 10`, Severe if `n ≥ 50` (very large batches = high attention cost). |
+//!
+//! ## Decision contract
+//!
+//! [`enforce_state_preflight`] returns `Ok(())` only when:
+//!   * Every change is below `Severe`, **OR**
+//!   * `force == true` (operator passed `--allow-risk`).
+//!
+//! On refusal it returns a typed [`crate::app::preflight::PreflightRefusal`]
+//! so `main.rs` maps to exit code **6** (matches the existing per-guest
+//! pre-flight contract). The risk list is printed to stderr first.
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::app::preflight::{PreflightRefusal, RiskLevel};
+use crate::state::diff::{Change, ChangeKind};
+use crate::state::model::{AclDecl, ClusterState, PoolDecl, StorageDecl};
+
+/// State-change-specific risk taxonomy. Each variant carries
+/// enough context for the operator to understand WHAT'S RISKY,
+/// not just THAT IT'S RISKY.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StateRisk {
+    /// Delete change against a pool that has members in the
+    /// live state. PVE refuses with a 500 + opaque error;
+    /// catching it here gives the operator a clearer signal.
+    PoolDeleteNonEmpty { poolid: String, member_count: usize },
+
+    /// Delete of an ACL grant that gave a root-equivalent role
+    /// (`PVEAdmin` / `Administrator`). High lock-out risk.
+    AclDeleteRootRole {
+        path: String,
+        ugid: String,
+        role: String,
+    },
+
+    /// Delete of an audit/observer grant. Not fatal, but loses
+    /// visibility from a known principal.
+    AclDeleteAuditor {
+        path: String,
+        ugid: String,
+        role: String,
+    },
+
+    /// Delete of a shared storage. Live guest disks almost
+    /// certainly live there.
+    StorageDeleteShared { storage: String },
+
+    /// Update of a storage's content list or other operationally
+    /// significant property. Running guests may rely on the
+    /// removed content type.
+    StoragePropertyChange { storage: String, what: &'static str },
+
+    /// Propagate flag change on an ACL grant. Cascades to every
+    /// descendant path; small change with cluster-wide reach.
+    AclPropagateFlip {
+        path: String,
+        ugid: String,
+        new_value: bool,
+    },
+
+    /// Very-large-batch warning. Increases attention cost
+    /// proportionally; defer with `--allow-risk` if intentional.
+    BulkChangeCount { n: usize },
+}
+
+impl StateRisk {
+    /// Severity ladder. Notice < Warning < Severe.
+    #[must_use]
+    pub const fn level(&self) -> RiskLevel {
+        match self {
+            Self::PoolDeleteNonEmpty { .. }
+            | Self::AclDeleteRootRole { .. }
+            | Self::StorageDeleteShared { .. } => RiskLevel::Severe,
+            Self::StoragePropertyChange { .. }
+            | Self::AclPropagateFlip { .. }
+            | Self::AclDeleteAuditor { .. } => RiskLevel::Warning,
+            Self::BulkChangeCount { n } => {
+                if *n >= 50 {
+                    RiskLevel::Severe
+                } else if *n >= 10 {
+                    RiskLevel::Warning
+                } else {
+                    RiskLevel::Notice
+                }
+            }
+        }
+    }
+
+    /// Human-readable one-liner for stderr output.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Self::PoolDeleteNonEmpty {
+                poolid,
+                member_count,
+            } => format!(
+                "delete pool `{poolid}` — still has {member_count} members \
+                 (PVE will refuse with an opaque 500)"
+            ),
+            Self::AclDeleteRootRole { path, ugid, role } => format!(
+                "delete ACL grant on `{path}` for `{ugid}` (role `{role}`) — \
+                 LOCK-OUT RISK if this was the last admin grant"
+            ),
+            Self::AclDeleteAuditor { path, ugid, role } => format!(
+                "delete ACL grant on `{path}` for `{ugid}` (role `{role}`) — \
+                 you'll lose visibility from this principal"
+            ),
+            Self::StorageDeleteShared { storage } => format!(
+                "delete shared storage `{storage}` — live guests likely \
+                 depend on it"
+            ),
+            Self::StoragePropertyChange { storage, what } => format!(
+                "update storage `{storage}` — changing `{what}` may break \
+                 running guests that rely on the current value"
+            ),
+            Self::AclPropagateFlip {
+                path,
+                ugid,
+                new_value,
+            } => format!(
+                "ACL grant on `{path}` for `{ugid}`: propagate → {new_value} — \
+                 cascades to every descendant path"
+            ),
+            Self::BulkChangeCount { n } => {
+                format!("{n} changes in one apply — attention cost proportional")
+            }
+        }
+    }
+}
+
+/// Roles considered root-equivalent for the lock-out check.
+/// Conservative: anything that grants `Sys.PowerMgmt` or
+/// `Sys.Modify` against `/` is treated as admin-tier. We keep
+/// this list explicit and small; the operator can re-grant
+/// after a careful review.
+const ROOT_LIKE_ROLES: &[&str] = &["Administrator", "PVEAdmin", "Root"];
+
+/// Audit/observer roles. Removing them is warning-tier.
+const AUDITOR_LIKE_ROLES: &[&str] = &["PVEAuditor", "Auditor"];
+
+/// Assess every change against the live state, return the full
+/// risk list (one element per detected risk). Empty Vec means
+/// the apply is risk-free at this layer.
+///
+/// `declared` is what the operator wants the cluster to look
+/// like; `live` is the current state from `state::export`.
+/// Both are needed because some risks (pool member counts,
+/// shared-storage classification) come from live state, not
+/// from the change itself.
+#[must_use]
+pub fn assess(changes: &[Change], live: &ClusterState) -> Vec<StateRisk> {
+    let mut risks = Vec::new();
+
+    // Bulk-count gate first — independent of per-change checks.
+    if changes.len() >= 10 {
+        risks.push(StateRisk::BulkChangeCount { n: changes.len() });
+    }
+
+    for c in changes {
+        risks.extend(assess_one(c, live));
+    }
+    risks
+}
+
+/// Per-change risk surface. Pure function; no I/O.
+fn assess_one(change: &Change, live: &ClusterState) -> Vec<StateRisk> {
+    let mut out = Vec::new();
+    match (change.kind, change.resource) {
+        (ChangeKind::Delete, "pool") => {
+            // Look up the live pool to count members.
+            if let Some(pool) = live
+                .pools
+                .iter()
+                .find(|p: &&PoolDecl| p.poolid == change.identity)
+            {
+                if !pool.members.is_empty() {
+                    out.push(StateRisk::PoolDeleteNonEmpty {
+                        poolid: pool.poolid.clone(),
+                        member_count: pool.members.len(),
+                    });
+                }
+            }
+        }
+        (ChangeKind::Delete, "acl") => {
+            // Find the live ACL grant being deleted to classify
+            // its role tier. Identity format defined by the diff
+            // layer: `<path> [<kind>/<ugid>] <role>`.
+            if let Some(acl) = find_acl_by_identity(&change.identity, &live.acl) {
+                let path = acl.path.clone();
+                let ugid = acl.ugid.clone();
+                let role = acl.roleid.clone();
+                if ROOT_LIKE_ROLES
+                    .iter()
+                    .any(|r| r.eq_ignore_ascii_case(&role))
+                {
+                    out.push(StateRisk::AclDeleteRootRole { path, ugid, role });
+                } else if AUDITOR_LIKE_ROLES
+                    .iter()
+                    .any(|r| r.eq_ignore_ascii_case(&role))
+                {
+                    out.push(StateRisk::AclDeleteAuditor { path, ugid, role });
+                }
+            }
+        }
+        (ChangeKind::Update, "acl") => {
+            // Identity-key changes (path/kind/ugid/role) trigger
+            // delete+create, not update. The remaining update is
+            // a propagate flip — flag it.
+            if let Some(declared) = find_acl_by_identity_in(&change.identity, change.after.as_ref())
+            {
+                if let Some(current) = find_acl_by_identity(&change.identity, &live.acl) {
+                    if declared.propagate != current.propagate {
+                        out.push(StateRisk::AclPropagateFlip {
+                            path: current.path.clone(),
+                            ugid: current.ugid.clone(),
+                            new_value: declared.propagate,
+                        });
+                    }
+                }
+            }
+        }
+        (ChangeKind::Delete, "storage") => {
+            if let Some(storage) = live
+                .storage
+                .iter()
+                .find(|s: &&StorageDecl| s.storage == change.identity)
+            {
+                if storage.shared {
+                    out.push(StateRisk::StorageDeleteShared {
+                        storage: storage.storage.clone(),
+                    });
+                }
+            }
+        }
+        (ChangeKind::Update, "storage") => {
+            // Updates to storage are usually small (a comment
+            // change), but the operationally-significant fields
+            // — `content`, `path`, `server` for NFS — can break
+            // running guests. Detect them by diffing before/after
+            // serialised JSON.
+            if let (Some(before), Some(after)) = (change.before.as_ref(), change.after.as_ref()) {
+                for field in &["content", "path", "server", "shared"] {
+                    if before.get(field) != after.get(field) {
+                        out.push(StateRisk::StoragePropertyChange {
+                            storage: change.identity.clone(),
+                            what: field,
+                        });
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Find an ACL grant in `live.acl` by the same identity string
+/// the diff layer produced. The identity format is documented in
+/// `src/state/diff.rs::summary_line`; we re-parse it here so we
+/// don't need to thread the original ACL through every Change.
+fn find_acl_by_identity<'a>(identity: &str, acls: &'a [AclDecl]) -> Option<&'a AclDecl> {
+    let (path, rest) = identity.split_once(' ')?;
+    // rest = "[token/foo@pve!bar] PVEAdmin"
+    let rest = rest.trim_start_matches('[');
+    let (kind_ugid, role) = rest.split_once("] ")?;
+    let (kind, ugid) = kind_ugid.split_once('/')?;
+    acls.iter()
+        .find(|a| a.path == path && a.kind == kind && a.ugid == ugid && a.roleid == role)
+}
+
+/// Same lookup against a `serde_json::Value` representation
+/// (used when matching against `change.after`, which is the
+/// declared state in JSON form).
+fn find_acl_by_identity_in(identity: &str, value: Option<&serde_json::Value>) -> Option<AclDecl> {
+    let v = value?;
+    let acl: AclDecl = serde_json::from_value(v.clone()).ok()?;
+    let (path, rest) = identity.split_once(' ')?;
+    let rest = rest.trim_start_matches('[');
+    let (kind_ugid, role) = rest.split_once("] ")?;
+    let (kind, ugid) = kind_ugid.split_once('/')?;
+    if acl.path == path && acl.kind == kind && acl.ugid == ugid && acl.roleid == role {
+        Some(acl)
+    } else {
+        None
+    }
+}
+
+/// Refuse the apply if any risk is Severe and `force` is false.
+/// Prints the risk list to stderr regardless (so the operator
+/// always sees what was flagged, even on a successful pass).
+///
+/// Mirrors the `enforce_preflight` contract from `cli::common`
+/// so main.rs's exit-code dispatch needs no changes — the same
+/// `PreflightRefusal` carries through.
+pub fn enforce_state_preflight(changes: &[Change], live: &ClusterState, force: bool) -> Result<()> {
+    let risks = assess(changes, live);
+    if risks.is_empty() {
+        return Ok(());
+    }
+    eprintln!(
+        "STATE PRE-FLIGHT ({} change{}):",
+        changes.len(),
+        if changes.len() == 1 { "" } else { "s" }
+    );
+    for r in &risks {
+        eprintln!("  [{:7}] {}", r.level().as_str(), r.describe());
+    }
+    let max = risks
+        .iter()
+        .map(StateRisk::level)
+        .max()
+        .unwrap_or(RiskLevel::Notice);
+    if max == RiskLevel::Severe && !force {
+        return Err(anyhow::Error::from(PreflightRefusal));
+    }
+    if max == RiskLevel::Severe && force {
+        eprintln!("  --allow-risk passed; overriding SEVERE risk(s) and proceeding.");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::diff::{Change, ChangeKind};
+    use crate::state::model::{AclDecl, ClusterState, PoolDecl, StorageDecl};
+
+    fn sample_live() -> ClusterState {
+        ClusterState {
+            meta: None,
+            pools: vec![
+                PoolDecl {
+                    poolid: "empty-pool".into(),
+                    comment: String::new(),
+                    members: vec![],
+                },
+                PoolDecl {
+                    poolid: "prod-pool".into(),
+                    comment: String::new(),
+                    members: vec!["qemu/100".into(), "qemu/101".into()],
+                },
+            ],
+            acl: vec![
+                AclDecl {
+                    path: "/".into(),
+                    kind: "user".into(),
+                    ugid: "root@pam".into(),
+                    roleid: "Administrator".into(),
+                    propagate: true,
+                },
+                AclDecl {
+                    path: "/".into(),
+                    kind: "user".into(),
+                    ugid: "auditor@pve".into(),
+                    roleid: "PVEAuditor".into(),
+                    propagate: true,
+                },
+            ],
+            storage: vec![
+                StorageDecl {
+                    storage: "shared-nfs".into(),
+                    storage_type: "nfs".into(),
+                    shared: true,
+                    ..Default::default()
+                },
+                StorageDecl {
+                    storage: "local".into(),
+                    storage_type: "dir".into(),
+                    shared: false,
+                    ..Default::default()
+                },
+            ],
+        }
+    }
+
+    fn delete_change(resource: &'static str, identity: &str) -> Change {
+        Change {
+            kind: ChangeKind::Delete,
+            resource,
+            identity: identity.to_string(),
+            before: None,
+            after: None,
+        }
+    }
+
+    #[test]
+    fn pool_delete_empty_is_clean() {
+        let live = sample_live();
+        let changes = vec![delete_change("pool", "empty-pool")];
+        let risks = assess(&changes, &live);
+        assert!(risks.is_empty(), "got: {risks:?}");
+    }
+
+    #[test]
+    fn pool_delete_non_empty_is_severe() {
+        let live = sample_live();
+        let changes = vec![delete_change("pool", "prod-pool")];
+        let risks = assess(&changes, &live);
+        assert_eq!(risks.len(), 1);
+        assert_eq!(risks[0].level(), RiskLevel::Severe);
+        assert!(matches!(
+            &risks[0],
+            StateRisk::PoolDeleteNonEmpty {
+                member_count: 2,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn acl_delete_root_role_is_severe() {
+        let live = sample_live();
+        let changes = vec![delete_change("acl", "/ [user/root@pam] Administrator")];
+        let risks = assess(&changes, &live);
+        assert_eq!(risks.len(), 1);
+        assert_eq!(risks[0].level(), RiskLevel::Severe);
+        assert!(matches!(&risks[0], StateRisk::AclDeleteRootRole { .. }));
+    }
+
+    #[test]
+    fn acl_delete_auditor_is_warning() {
+        let live = sample_live();
+        let changes = vec![delete_change("acl", "/ [user/auditor@pve] PVEAuditor")];
+        let risks = assess(&changes, &live);
+        assert_eq!(risks.len(), 1);
+        assert_eq!(risks[0].level(), RiskLevel::Warning);
+        assert!(matches!(&risks[0], StateRisk::AclDeleteAuditor { .. }));
+    }
+
+    #[test]
+    fn storage_delete_shared_is_severe() {
+        let live = sample_live();
+        let changes = vec![delete_change("storage", "shared-nfs")];
+        let risks = assess(&changes, &live);
+        assert_eq!(risks.len(), 1);
+        assert_eq!(risks[0].level(), RiskLevel::Severe);
+    }
+
+    #[test]
+    fn storage_delete_local_is_clean() {
+        let live = sample_live();
+        let changes = vec![delete_change("storage", "local")];
+        let risks = assess(&changes, &live);
+        assert!(risks.is_empty());
+    }
+
+    #[test]
+    fn storage_content_change_is_warning() {
+        let live = sample_live();
+        let changes = vec![Change {
+            kind: ChangeKind::Update,
+            resource: "storage",
+            identity: "local".to_string(),
+            before: Some(serde_json::json!({"content": "iso,backup"})),
+            after: Some(serde_json::json!({"content": "iso,backup,images"})),
+        }];
+        let risks = assess(&changes, &live);
+        assert_eq!(risks.len(), 1);
+        assert_eq!(risks[0].level(), RiskLevel::Warning);
+        assert!(matches!(
+            &risks[0],
+            StateRisk::StoragePropertyChange {
+                what: "content",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn bulk_count_severity_ladder() {
+        let live = sample_live();
+        // 9 changes — no bulk risk.
+        let nine: Vec<Change> = (0..9)
+            .map(|i| delete_change("pool", &format!("p{i}")))
+            .collect();
+        let r9 = assess(&nine, &live);
+        assert!(!r9
+            .iter()
+            .any(|r| matches!(r, StateRisk::BulkChangeCount { .. })));
+
+        // 10 changes — Warning.
+        let ten: Vec<Change> = (0..10)
+            .map(|i| delete_change("pool", &format!("p{i}")))
+            .collect();
+        let r10 = assess(&ten, &live);
+        let bulk = r10
+            .iter()
+            .find(|r| matches!(r, StateRisk::BulkChangeCount { .. }))
+            .expect("expected BulkChangeCount risk");
+        assert_eq!(bulk.level(), RiskLevel::Warning);
+
+        // 50 changes — Severe.
+        let fifty: Vec<Change> = (0..50)
+            .map(|i| delete_change("pool", &format!("p{i}")))
+            .collect();
+        let r50 = assess(&fifty, &live);
+        let bulk = r50
+            .iter()
+            .find(|r| matches!(r, StateRisk::BulkChangeCount { n: 50 }))
+            .expect("expected BulkChangeCount(50)");
+        assert_eq!(bulk.level(), RiskLevel::Severe);
+    }
+
+    #[test]
+    fn enforce_passes_when_no_severe() {
+        let live = sample_live();
+        let changes = vec![delete_change("pool", "empty-pool")];
+        // No risks → passes regardless of force flag.
+        assert!(enforce_state_preflight(&changes, &live, false).is_ok());
+        assert!(enforce_state_preflight(&changes, &live, true).is_ok());
+    }
+
+    #[test]
+    fn enforce_refuses_severe_without_force() {
+        let live = sample_live();
+        let changes = vec![delete_change("pool", "prod-pool")];
+        let err = enforce_state_preflight(&changes, &live, false).unwrap_err();
+        // Typed PreflightRefusal so main.rs exit-code dispatch
+        // doesn't need a new arm.
+        assert!(err.downcast_ref::<PreflightRefusal>().is_some());
+    }
+
+    #[test]
+    fn enforce_overrides_severe_with_force() {
+        let live = sample_live();
+        let changes = vec![delete_change("pool", "prod-pool")];
+        // --allow-risk → proceeds.
+        assert!(enforce_state_preflight(&changes, &live, true).is_ok());
+    }
+
+    #[test]
+    fn risk_levels_serialise_lowercase_kind() {
+        let r = StateRisk::PoolDeleteNonEmpty {
+            poolid: "x".into(),
+            member_count: 1,
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["kind"], "pool_delete_non_empty");
+    }
+}


### PR DESCRIPTION
Closes the epic-#74 loose end. Risk taxonomy specific to state changes (pool/acl/storage), severity ladder, --allow-risk bypass, --interactive per-Severe stdin prompt. 12 new tests; 510→522. Reuses PreflightRefusal so exit-code 6 contract carries through unchanged. Telegram daemon HITL deferred (real daemon extension; tracked in v0.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)