### PR TITLE
chore(release): v0.3.0 — GitOps for Proxmox, 17 new commands, invariant attestation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ SemVer contract:
 
 ## [Unreleased]
 
+_no entries yet — next release will be v0.3.1 (patch) or v0.4.0 (minor)._
+
+## [0.3.0] — 2026-05-20
+
 Headline: **GitOps for Proxmox + 17 new top-level commands + honest invariant attestation**.
 24 feature PRs landed on 2026-05-20 morning closing the entire strategic-gap backlog
 (#57-#73) and the cluster-state epic (#74). The evening shipped three test-only sweeps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ onMounted(() => {
 
 <div class="status-row">
   <span><span class="ok">●</span> <strong>main</strong> · gate green</span>
-  <span><strong>v0.2.1</strong></span>
+  <span><strong>v0.3.0</strong></span>
   <span><strong>full mutation lifecycle</strong> · LXC + cluster + QEMU + QGA</span>
   <span><strong>0</strong> system deps · rustls only</span>
   <span><strong>MIT</strong></span>


### PR DESCRIPTION
## Summary

29 PRs landed on 2026-05-20 (#75 → #103 + #104 alignment) on top of v0.2.1. Cumulative additive surface is well past a patch bump — minor it is.

## What changed

- \`Cargo.toml\` — \`0.2.1\` → \`0.3.0\`
- \`Cargo.lock\` — \`proxxx\` package version follows
- \`CHANGELOG.md\` — \`[Unreleased]\` block promoted to \`## [0.3.0] — 2026-05-20\`; new empty \`[Unreleased]\` placeholder above it
- \`docs/index.md\` — version chip \`v0.2.1\` → \`v0.3.0\`

## v0.3.0 highlights (recap from CHANGELOG)

**Headline**: GitOps for Proxmox + 17 new top-level commands + honest invariant attestation.

- **Epic #74**: \`proxxx state {export,diff,apply}\` over pools / ACL / cluster storage. Byte-stable TOML, structural diff with exit 2 on drift, pre-flight risk gates refuse Severe changes (non-empty pool delete, root-role ACL delete, shared-storage delete, batch ≥ 50) unless \`--allow-risk\`; \`--interactive\` adds per-Severe \`[y/N]\` stdin prompts.
- **17 new commands**: \`migrate --stream\`, \`logs tail\`, \`explain\`, \`incident {freeze,thaw,status}\`, \`ls --all-profiles\`, \`find\`, \`describe\`, \`serial --record\`, \`play-cast\`, \`cloud-img\`, \`schedule\`, \`upgrade-check\`, \`accounting --timeframe\`, \`heatmap\`, \`anomaly\`, \`backup-verify\`, \`import\`, \`gpu-inspect\`, \`daemon serve\`.
- **MCP notifications**: stdio + HTTP/SSE at parity, \`task_state_change\` + \`incident\` events.
- **New exit code 8**: incident lockdown active.
- **3 latent typed-error gaps in \`src/api/client.rs\` fixed**: DNS NXDOMAIN, mid-stream TCP close, HTML-on-200 — all now produce \`ApiError::{Transport,Parse}\` so the exit-code dispatch routes them.
- **Honest end-to-end-verified coverage 24 → 73 rows** across \`pre-commit/*.md\` (\`02-error-handling.md\` and \`04-resilience-and-chaos.md\` fully ✅; \`01\` partial).
- **Tests**: 429 → 536 lib (+107); +49 new integration tests across the sweep suites.

## Test plan

- [x] \`Cargo.toml\` version field updated
- [x] \`Cargo.lock\` syncs (\`cargo update -p proxxx\`)
- [x] Pre-commit gate PASSED in 434s (8 stages + 87/87 read probes + 47/47 mutation lifecycle against PVE 9.1.1)
- [x] Pre-push gate PASSED in 187s (re-ran the same gate as defense in depth)
- [x] No source-code changes — bump only
- [ ] Merge → tag \`v0.3.0\` → release workflow auto-builds 3-target matrix + cosign + SBOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)