### PR TITLE
fix: char-boundary-safe truncation — 4 UTF-8 byte-slice panic vectors

### DIFF
--- a/src/cli/incident.rs
+++ b/src/cli/incident.rs
@@ -139,14 +139,17 @@ fn parse_duration_secs(s: &str) -> Result<u64> {
     if s.is_empty() {
         anyhow::bail!("empty duration");
     }
-    let (num_str, suffix) = s.split_at(s.len() - 1);
-    // If the last char wasn't a recognised suffix, treat the whole
-    // thing as bare seconds.
-    let (n_str, mult): (&str, u64) = match suffix {
-        "s" => (num_str, 1),
-        "m" => (num_str, 60),
-        "h" => (num_str, 3600),
-        "d" => (num_str, 86400),
+    // Match on the trailing CHAR, not a byte split. `split_at(len-1)`
+    // panics when the last char is multi-byte (e.g. `5µ`); the suffix
+    // units are all ASCII, so byte-slicing `len-1` is only safe inside
+    // the matched branches. If the last char wasn't a recognised
+    // suffix, treat the whole thing as bare seconds.
+    let last = s.chars().next_back().unwrap_or('\0');
+    let (n_str, mult): (&str, u64) = match last {
+        's' => (&s[..s.len() - 1], 1),
+        'm' => (&s[..s.len() - 1], 60),
+        'h' => (&s[..s.len() - 1], 3600),
+        'd' => (&s[..s.len() - 1], 86400),
         _ => (s, 1),
     };
     let n: u64 = n_str
@@ -174,5 +177,15 @@ mod tests {
         assert!(parse_duration_secs("").is_err());
         assert!(parse_duration_secs("forever").is_err());
         assert!(parse_duration_secs("foo-bar").is_err());
+    }
+
+    #[test]
+    fn parse_duration_does_not_panic_on_multibyte_suffix() {
+        // Regression: `split_at(len-1)` panicked when the trailing char
+        // was multi-byte. These must return Err cleanly, never panic.
+        assert!(parse_duration_secs("5µ").is_err());
+        assert!(parse_duration_secs("10€").is_err());
+        assert!(parse_duration_secs("3🔥").is_err());
+        assert!(parse_duration_secs("ч").is_err());
     }
 }

--- a/src/cli/schedule.rs
+++ b/src/cli/schedule.rs
@@ -156,13 +156,17 @@ pub fn parse_interval(s: &str) -> Result<u64> {
     if s.is_empty() {
         anyhow::bail!("empty interval");
     }
-    let (num_str, suffix) = s.split_at(s.len() - 1);
-    let (n_str, mult): (&str, u64) = match suffix {
-        "s" => (num_str, 1),
-        "m" => (num_str, 60),
-        "h" => (num_str, 3600),
-        "d" => (num_str, 86400),
-        "w" => (num_str, 86400 * 7),
+    // Match on the trailing CHAR, not a byte split. `split_at(len-1)`
+    // panics when the last char is multi-byte (e.g. `5µ`); the suffix
+    // units are all ASCII, so byte-slicing `len-1` is only safe inside
+    // the matched branches where the last char is provably 1 byte.
+    let last = s.chars().next_back().unwrap_or('\0');
+    let (n_str, mult): (&str, u64) = match last {
+        's' => (&s[..s.len() - 1], 1),
+        'm' => (&s[..s.len() - 1], 60),
+        'h' => (&s[..s.len() - 1], 3600),
+        'd' => (&s[..s.len() - 1], 86400),
+        'w' => (&s[..s.len() - 1], 86400 * 7),
         _ => (s, 1),
     };
     let n: u64 = n_str.parse().map_err(|_| {
@@ -449,6 +453,16 @@ mod tests {
         assert!(parse_interval("").is_err());
         assert!(parse_interval("forever").is_err());
         assert!(parse_interval("abc-def").is_err());
+    }
+
+    #[test]
+    fn parse_interval_does_not_panic_on_multibyte_suffix() {
+        // Regression: `split_at(len-1)` panicked when the trailing char
+        // was multi-byte. These must return Err cleanly, never panic.
+        assert!(parse_interval("5µ").is_err());
+        assert!(parse_interval("10€").is_err());
+        assert!(parse_interval("3🔥").is_err());
+        assert!(parse_interval("неделя").is_err());
     }
 
     #[test]

--- a/src/hitl/daemon.rs
+++ b/src/hitl/daemon.rs
@@ -317,12 +317,11 @@ pub async fn handle_callback_update(
                 .answer_callback(&cb.id, &format!("❌ Failed: {err_str}"))
                 .await;
             // Truncate long error strings in the message body —
-            // Telegram's 4096-char limit + readability.
-            let err_short = if err_str.len() > 200 {
-                format!("{}…", &err_str[..200])
-            } else {
-                err_str.clone()
-            };
+            // Telegram's 4096-char limit + readability. Char-boundary
+            // safe: PVE error text is frequently non-ASCII, and a naive
+            // `&err_str[..200]` byte slice panics when byte 200 splits a
+            // multi-byte char.
+            let err_short = crate::util::sanitize::truncate_ellipsis(&err_str, 200);
             edit_status(
                 &format!("❌ Failed: {err_short}"),
                 cb.from.username.as_deref().unwrap_or(&cb.from.first_name),

--- a/src/tui/views/snaptree.rs
+++ b/src/tui/views/snaptree.rs
@@ -338,9 +338,8 @@ fn format_duration(secs: u64) -> String {
 }
 
 fn trim_to(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}…", &s[..max])
-    }
+    // Char-boundary safe — snapshot descriptions are PVE-supplied and
+    // frequently non-ASCII; a naive `&s[..max]` byte slice panics when
+    // byte `max` splits a multi-byte char, crashing the whole TUI.
+    crate::util::sanitize::truncate_ellipsis(s, max)
 }

--- a/src/util/sanitize.rs
+++ b/src/util/sanitize.rs
@@ -52,6 +52,33 @@ const fn is_safe_char(c: char) -> bool {
     }
 }
 
+/// Truncate `s` to at most `max_chars` characters, appending `…` when
+/// truncation actually occurred.
+///
+/// Operates on `char` boundaries, so it never panics on multi-byte
+/// UTF-8 — unlike the naive `&s[..n]` byte-slice, which panics when
+/// byte `n` lands inside a multi-byte character. That naive form was a
+/// real crash vector: PVE-supplied snapshot descriptions and execution-
+/// error text in any non-ASCII locale (CJK, Cyrillic, emoji) routinely
+/// straddle an arbitrary byte offset.
+///
+/// Note: counts Unicode scalar values, not display columns. A string of
+/// wide CJK glyphs may render wider than `max_chars` cells; that's an
+/// acceptable approximation for the log/label call sites — the contract
+/// here is "bounded length, never panic", and ratatui clips the visual
+/// overflow at the widget boundary anyway.
+#[must_use]
+pub fn truncate_ellipsis(s: &str, max_chars: usize) -> String {
+    let mut chars = s.chars();
+    let head: String = chars.by_ref().take(max_chars).collect();
+    // If the iterator still yields, we dropped at least one char.
+    if chars.next().is_some() {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,6 +147,52 @@ mod tests {
         let s = sanitize_display("");
         assert!(matches!(s, Cow::Borrowed(_)));
         assert_eq!(s, "");
+    }
+
+    // ── truncate_ellipsis ──────────────────────────────────────
+
+    #[test]
+    fn truncate_shorter_than_max_is_unchanged() {
+        assert_eq!(truncate_ellipsis("vm-01", 40), "vm-01");
+    }
+
+    #[test]
+    fn truncate_exactly_max_has_no_ellipsis() {
+        assert_eq!(truncate_ellipsis("abcde", 5), "abcde");
+    }
+
+    #[test]
+    fn truncate_longer_gets_ellipsis() {
+        assert_eq!(truncate_ellipsis("abcdef", 5), "abcde…");
+    }
+
+    #[test]
+    fn truncate_does_not_panic_on_multibyte_boundary() {
+        // Regression: the naive `&s[..n]` byte slice panicked when byte
+        // `n` split a multi-byte char. Here every char is 2 bytes (µ) or
+        // 3 (CJK) or 4 (emoji); truncating at a char count that would
+        // land mid-byte under the old code must not panic.
+        let cyrillic = "Тестовый снимок производства"; // 2-byte chars
+        let _ = truncate_ellipsis(cyrillic, 10);
+        let cjk = "本番環境のスナップショットの説明"; // 3-byte chars
+        assert_eq!(truncate_ellipsis(cjk, 3), "本番環…");
+        let emoji = "🚀🔥💾🐧🦀"; // 4-byte chars
+        assert_eq!(truncate_ellipsis(emoji, 2), "🚀🔥…");
+        // The original crash repro: a 200-char budget against a string
+        // whose 200th *byte* is mid-char.
+        let mixed = "x".repeat(199) + "µ" + &"y".repeat(50);
+        let _ = truncate_ellipsis(&mixed, 200); // must not panic
+    }
+
+    #[test]
+    fn truncate_empty_is_empty() {
+        assert_eq!(truncate_ellipsis("", 10), "");
+        assert_eq!(truncate_ellipsis("", 0), "");
+    }
+
+    #[test]
+    fn truncate_zero_max() {
+        assert_eq!(truncate_ellipsis("abc", 0), "…");
     }
 }
 
@@ -223,6 +296,40 @@ mod proptests {
             let out_non_ascii: String =
                 out.chars().filter(|c| (*c as u32) >= 0x80).collect();
             prop_assert_eq!(in_non_ascii, out_non_ascii);
+        }
+
+        /// `truncate_ellipsis` NEVER panics for any (string, max) pair.
+        /// This is the core regression contract — the naive `&s[..n]`
+        /// byte slice it replaces panicked whenever `n` split a
+        /// multi-byte char. The result is always valid UTF-8 (guaranteed
+        /// by the `String` return type) and holds at most `max + 1`
+        /// chars (the body plus the ellipsis).
+        #[test]
+        fn truncate_never_panics_and_bounds_length(
+            s in any::<String>(),
+            max in 0usize..512,
+        ) {
+            let out = truncate_ellipsis(&s, max);
+            let out_chars = out.chars().count();
+            // Either we kept everything (no ellipsis, ≤ max chars)…
+            let kept_all = !out.ends_with('…') && out_chars <= max;
+            // …or we truncated (ellipsis present, body is exactly `max`
+            // chars so total is max + 1).
+            let truncated = out.ends_with('…') && out_chars == max + 1;
+            // Edge: max == 0 always yields just "…" (1 char).
+            let zero_case = max == 0 && out == "…" && s.chars().next().is_some();
+            prop_assert!(
+                kept_all || truncated || zero_case,
+                "unexpected truncate output {out:?} for max={max} input len {}",
+                s.chars().count()
+            );
+        }
+
+        /// Truncating a string already within budget is the identity.
+        #[test]
+        fn truncate_within_budget_is_identity(s in "\\PC{0,64}", pad in 0usize..64) {
+            let max = s.chars().count() + pad;
+            prop_assert_eq!(truncate_ellipsis(&s, max), s);
         }
     }
 }


### PR DESCRIPTION
## Summary

A code-wide debug pass (`debug estremo`) found **four** sites that slice or split a string at a **byte offset**, which panics when the offset lands inside a multi-byte UTF-8 character. PVE-supplied text (snapshot descriptions, execution-error messages) and operator input are routinely non-ASCII — so these were real, **remotely-triggerable crashes**.

## New helper

`util::sanitize::truncate_ellipsis(s, max_chars)` — truncates on char boundaries, appends `…` only when truncation occurred. Pinned by 7 unit tests + 2 proptest invariants (never-panics for any `(string, max)`; identity within budget).

## Sites fixed

| Site | Trigger | Severity |
| :--- | :--- | :--- |
| [hitl/daemon.rs:322](src/hitl/daemon.rs) `&err_str[..200]` | PVE execution-error text, non-ASCII at byte 200 | 🔴 CRITICAL (HITL daemon crash) |
| [tui/views/snaptree.rs:340](src/tui/views/snaptree.rs) `trim_to` → `&s[..max]` | PVE snapshot description, non-ASCII at byte 40 | 🔴 CRITICAL (TUI crash) |
| [cli/schedule.rs:159](src/cli/schedule.rs) `parse_interval` `split_at(len-1)` | `proxxx schedule add --every 5µ` | 🟠 HIGH (CLI panic) |
| [cli/incident.rs:142](src/cli/incident.rs) `parse_duration_secs` `split_at(len-1)` | `proxxx incident freeze --ttl 5µ` | 🟠 HIGH (CLI panic) |

The two duration parsers now match on the trailing **char** and byte-slice only inside the provably-ASCII suffix branches; multi-byte trailing chars fall through to "bare seconds" → clean `Err`, never a panic.

## Test plan

- [x] `cargo test --lib sanitize::` — 22 passed (incl. new truncate tests + 2 proptests)
- [x] 3 regression tests: `truncate_does_not_panic_on_multibyte_boundary`, `parse_interval_does_not_panic_on_multibyte_suffix`, `parse_duration_does_not_panic_on_multibyte_suffix`
- [x] `cargo clippy --all-targets --all-features` clean
- [x] Local gate PASSED in 488s (8 stages + live cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)