### PR TITLE
fix: client robustness — PBS typed errors, connect timeouts, bounded resize + stale-doc cleanup

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -3206,24 +3206,27 @@ impl ProxmoxGateway for PxClient {
             self.base_url
         );
         let auth = self.auth.read().await;
+        let path = format!("/nodes/{node}/{kind}/{vmid}/resize");
         let resp = auth
             .apply(self.http.put(&url))
             .form(&params)
             .send()
             .await
-            .with_context(|| format!("PUT resize {vmid} failed"))?;
+            // Transport-typed so a dead node on the resize path routes
+            // like every other request (it predated the typed-error pass).
+            .map_err(|e| super::ApiError::Transport(format!("PUT {path}: {e}")))?;
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            // Phase 7 — typed error on the disk-resize PUT (it was
-            // written before the typed-error pass).
-            let path = format!("/nodes/{node}/{kind}/{vmid}/resize");
             return Err(super::ApiError::from_status(status, &path, body).into());
         }
-        let parsed: ApiResponse<Option<String>> = resp
-            .json()
-            .await
-            .with_context(|| format!("parse resize {vmid} response"))?;
+        // Route through the shared bounded-read + typed-parse helpers so
+        // the resize PUT is no longer the one REST read with an unbounded
+        // body and an untyped (`anyhow`) parse error. A hostile node can
+        // no longer OOM proxxx on this path, and a non-JSON body now
+        // yields `ApiError::Parse`.
+        let bytes = read_bounded_body(resp, &path).await?;
+        let parsed: ApiResponse<Option<String>> = parse_json_maybe_blocking(bytes, &path).await?;
         // Proxmox returns null UPID for synchronous resizes (e.g. a
         // small grow that completes inline). Surface a synthetic marker
         // so callers don't have to special-case Option.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -915,10 +915,11 @@ pub enum Command {
         #[command(subcommand)]
         action: ct::CtCommand,
     },
-    /// Firewall rules — read-only inspection. PVE has three rule
-    /// scopes (datacenter, node, guest); pick one. Write operations
-    /// (add/remove rules, manage aliases/IPSets/groups) are not yet
-    /// implemented.
+    /// Firewall management. PVE has three rule scopes (datacenter,
+    /// node, guest); pick one. Read inspection plus full CRUD for
+    /// aliases, IP sets, and security groups (cluster + guest scope).
+    /// Individual allow/deny rule add/remove is not yet implemented —
+    /// edit those via the PVE web UI or `pvesh` for now.
     Firewall {
         #[command(subcommand)]
         scope: firewall::FirewallScope,

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -6,8 +6,9 @@
 //! storage definitions. Cluster firewall, backup jobs, notifications,
 //! and HA groups land in follow-up PRs tracked by epic
 //! [#74](https://github.com/fabriziosalmi/proxxx/issues/74). Pre-flight
-//! risk gates + HITL approval per destructive change are tracked
-//! separately and will wrap the apply dispatch without changing it.
+//! risk gates + HITL approval per destructive change are wired (shipped
+//! v0.3.0): `state::preflight` refuses Severe changes unless
+//! `--allow-risk`, and `--interactive` adds per-Severe `[y/N]` prompts.
 
 use anyhow::{Context, Result};
 use clap::{Subcommand, ValueEnum};

--- a/src/pbs/client.rs
+++ b/src/pbs/client.rs
@@ -22,6 +22,7 @@ use tracing::{debug, info};
 
 use super::types::{ArchiveInfo, DatastoreInfo, PbsVersion, SnapshotInfo};
 use crate::api::types::ApiResponse;
+use crate::api::ApiError;
 use crate::config::PbsConfig;
 
 type Limiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
@@ -89,24 +90,32 @@ impl PbsClient {
             .header("Authorization", &self.auth_header)
             .send()
             .await
-            .with_context(|| format!("GET {path}"))?;
+            // reqwest send failures (DNS, connect, TLS, timeout) are
+            // transport-level — surface the typed variant so the
+            // exit-code dispatch routes them like the PVE client does.
+            .map_err(|e| ApiError::Transport(format!("PBS GET {path}: {e}")))?;
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            if status == reqwest::StatusCode::UNAUTHORIZED {
-                anyhow::bail!(
-                    "PBS authentication failed (401). Check token_id / token_secret for user '{}'. \
-                     Token format in config: user = \"user@pbs\", token_id = \"tokenid\".",
-                    self.base_url,
-                );
-            }
-            if status == reqwest::StatusCode::FORBIDDEN {
-                anyhow::bail!(
-                    "PBS returned 403 Forbidden for {path}. \
-                     The token may lack 'Datastore.Audit' privilege on the target datastore.",
-                );
-            }
-            anyhow::bail!("PBS GET {path} returned {status}: {body}");
+            // Route through the typed `ApiError` so PBS auth failures
+            // exit 4 (not generic 1), 404 → 5, transient 5xx → 7 — same
+            // contract as the PVE client. 401/403 carry PBS-specific
+            // guidance in the message (token colon-vs-equals, the
+            // Datastore.Audit privilege) since those are the two an
+            // operator most often trips on.
+            let err = match status {
+                reqwest::StatusCode::UNAUTHORIZED => ApiError::Unauthorized(format!(
+                    "PBS {path}: authentication failed (401) — check token_id / token_secret. \
+                     PBS token format uses a COLON: `PBSAPIToken=user@pbs!tokenid:secret` \
+                     (PVE uses `=` in the same spot; the two are not interchangeable). {body}"
+                )),
+                reqwest::StatusCode::FORBIDDEN => ApiError::Forbidden(format!(
+                    "PBS {path}: 403 Forbidden — the token may lack 'Datastore.Audit' on the \
+                     target datastore. {body}"
+                )),
+                _ => ApiError::from_status(status, path, body),
+            };
+            return Err(err.into());
         }
         // same bounded-body read as the PVE client. A
         // misbehaving PBS could otherwise OOM proxxx with a giant
@@ -123,7 +132,9 @@ impl PbsClient {
         let mut buf: Vec<u8> = Vec::with_capacity(4096);
         let mut stream = resp.bytes_stream();
         while let Some(chunk) = stream.next().await {
-            let chunk = chunk.with_context(|| format!("reading PBS response chunk from {path}"))?;
+            let chunk = chunk.map_err(|e| {
+                ApiError::Transport(format!("reading PBS response chunk from {path}: {e}"))
+            })?;
             if buf.len().saturating_add(chunk.len()) > MAX_PBS_RESPONSE_BYTES {
                 anyhow::bail!(
                     "PBS response from {path} exceeded {MAX_PBS_RESPONSE_BYTES} bytes mid-stream"
@@ -131,8 +142,13 @@ impl PbsClient {
             }
             buf.extend_from_slice(&chunk);
         }
-        serde_json::from_slice::<T>(&buf)
-            .with_context(|| format!("parsing PBS response from {path}"))
+        serde_json::from_slice::<T>(&buf).map_err(|source| {
+            ApiError::Parse {
+                path: path.to_string(),
+                source,
+            }
+            .into()
+        })
     }
 }
 

--- a/src/ssh/session.rs
+++ b/src/ssh/session.rs
@@ -194,9 +194,21 @@ impl SshSession {
         };
 
         info!("ssh connecting to {user}@{host}:{port}");
-        let mut handle = client::connect(config, (host.as_str(), port), handler)
-            .await
-            .with_context(|| format!("ssh connect {host}:{port}"))?;
+        // Bound the TCP + SSH handshake. `Config.inactivity_timeout`
+        // governs an *established idle* session, not the initial
+        // connect — so without this a SYN to a black-holed host hangs
+        // until the OS TCP timeout (minutes). Affects the TUI PTY view
+        // and the `proxxx logs` cross-node fanout.
+        const SSH_CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+        let mut handle = tokio::time::timeout(
+            SSH_CONNECT_TIMEOUT,
+            client::connect(config, (host.as_str(), port), handler),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("ssh connect {host}:{port} timed out after {SSH_CONNECT_TIMEOUT:?}")
+        })?
+        .with_context(|| format!("ssh connect {host}:{port}"))?;
 
         // russh 0.60: `authenticate_publickey` now takes a
         // `PrivateKeyWithHashAlg` (the hash-alg pin lets the client

--- a/src/state/apply.rs
+++ b/src/state/apply.rs
@@ -16,11 +16,13 @@
 //!   apply (the remaining changes report as `Skipped { reason:
 //!   AbortedByPrior }`). `--continue-on-error` reverses this.
 //!
-//! Pre-flight + HITL gating per change is **out of scope for this
-//! PR** and tracked separately — the apply layer dispatches via the
-//! raw `StateWriteView` trait, and an outer wrapper can be added
-//! later to interpose those gates without touching the dispatch
-//! code.
+//! Pre-flight + HITL gating per change is layered ON TOP of this
+//! dispatch (shipped v0.3.0): the apply layer dispatches via the raw
+//! `StateWriteView` trait, and `state::preflight` interposes the risk
+//! gate (refusing Severe changes without `--allow-risk`, with optional
+//! `--interactive` per-Severe stdin prompts) before the dispatch runs.
+//! Keeping the gate in an outer layer is why this module stays a clean
+//! pure-dispatch unit.
 //!
 //! ## What apply supports today (per epic #74 PR 5)
 //!

--- a/src/wsterm/mod.rs
+++ b/src/wsterm/mod.rs
@@ -84,13 +84,30 @@ pub async fn connect(
     ws_config.max_message_size = Some(4 << 20);
 
     info!("termproxy WSS connect: {}", target.url);
-    let (mut ws, _resp) = tokio_tungstenite::connect_async_tls_with_config(
-        request,
-        Some(ws_config),
-        false,
-        connector,
+    // Bound the connect (TCP + TLS + WS handshake). Without this an
+    // unreachable / black-holed node leaves the call hanging until the
+    // OS TCP timeout (minutes) — and the terminal is already half
+    // set up, so the operator sees a frozen screen with no error.
+    // 20 s is generous for a real PVE node on a LAN/VPN yet fails fast
+    // on a dead one. Unlike the reqwest-based PVE/PBS clients (30 s
+    // request timeout that covers connect), tungstenite has none.
+    const WS_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+    let (mut ws, _resp) = tokio::time::timeout(
+        WS_CONNECT_TIMEOUT,
+        tokio_tungstenite::connect_async_tls_with_config(
+            request,
+            Some(ws_config),
+            false,
+            connector,
+        ),
     )
     .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "WS connect to {} timed out after {WS_CONNECT_TIMEOUT:?} — node unreachable?",
+            target.url
+        )
+    })?
     .with_context(|| format!("WS connect to {}", target.url))?;
 
     // Auth frame — must be a binary frame containing `<user>:<ticket>\n`.

--- a/tests/pbs_test.rs
+++ b/tests/pbs_test.rs
@@ -157,5 +157,62 @@ mod tests {
             err.to_string().contains("503"),
             "error mentions status: {err}"
         );
+        // 503 is transient → typed RateLimited → exit code 7.
+        let api = err
+            .chain()
+            .find_map(|e| e.downcast_ref::<proxxx::api::ApiError>())
+            .expect("503 must surface a typed ApiError");
+        assert_eq!(api.exit_code(), 7, "503 → exit 7 (cluster transient)");
+    }
+
+    /// Regression: PBS 401 must surface `ApiError::Unauthorized` → exit
+    /// code 4, not a plain anyhow error → generic exit 1. The whole PBS
+    /// `get()` helper used to bypass the typed-error layer.
+    #[tokio::test]
+    async fn pbs_401_surfaces_typed_unauthorized_exit_4() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/admin/datastore"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("authentication failure"))
+            .mount(&server)
+            .await;
+        let err = client(&server)
+            .await
+            .list_datastores()
+            .await
+            .expect_err("must error on 401");
+        let api = err
+            .chain()
+            .find_map(|e| e.downcast_ref::<proxxx::api::ApiError>())
+            .expect("401 must surface a typed ApiError");
+        assert!(matches!(api, proxxx::api::ApiError::Unauthorized(_)));
+        assert_eq!(api.exit_code(), 4, "PBS 401 → exit 4 (auth), not generic 1");
+        // The PBS-specific colon-vs-equals guidance must survive.
+        assert!(
+            format!("{api}").contains("COLON") || format!("{api}").contains("token"),
+            "401 message should carry PBS token guidance: {api}"
+        );
+    }
+
+    /// Regression: PBS 403 → `ApiError::Forbidden` → exit code 4.
+    #[tokio::test]
+    async fn pbs_403_surfaces_typed_forbidden_exit_4() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/admin/datastore"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("permission denied"))
+            .mount(&server)
+            .await;
+        let err = client(&server)
+            .await
+            .list_datastores()
+            .await
+            .expect_err("must error on 403");
+        let api = err
+            .chain()
+            .find_map(|e| e.downcast_ref::<proxxx::api::ApiError>())
+            .expect("403 must surface a typed ApiError");
+        assert!(matches!(api, proxxx::api::ApiError::Forbidden(_)));
+        assert_eq!(api.exit_code(), 4);
     }
 }


### PR DESCRIPTION
## Summary

Second batch of the code-wide debug pass (sibling of #106, the UTF-8 crash fixes). Three robustness fixes in the API/PBS/transport layer plus doc-drift cleanup.

## 🟠 PBS typed-error parity — exit code 4 on auth failure

[`src/pbs/client.rs`](src/pbs/client.rs) `get()` bypassed the typed `ApiError` layer entirely — PBS 401/403 bailed with plain `anyhow`, exiting **1** instead of the documented **4**. Now mirrors the PVE client:

| Response | Before | After |
| :--- | :--- | :--- |
| send() failure (DNS/connect/TLS) | `anyhow` → 1 | `ApiError::Transport` |
| 401 | `bail!` → 1 | `ApiError::Unauthorized` → **4** |
| 403 | `bail!` → 1 | `ApiError::Forbidden` → **4** |
| 404 / 5xx | `bail!` → 1 | `from_status` → 5 / 7 |
| chunk-read error | `anyhow` | `ApiError::Transport` |
| parse failure | `anyhow` | `ApiError::Parse` |

PBS-specific guidance (token colon-vs-equals, `Datastore.Audit`) preserved in 401/403 messages. **3 new wiremock tests** assert the typed variant + exit code.

## 🟡 Connect timeouts — hang vectors

- [`src/wsterm/mod.rs`](src/wsterm/mod.rs) — termproxy WSS connect had **no timeout**; a black-holed node hung for minutes with the terminal half-set-up. Now 20 s `tokio::time::timeout`.
- [`src/ssh/session.rs`](src/ssh/session.rs) — russh `client::connect` had no surrounding timeout (`inactivity_timeout` only covers an *established idle* session, not the handshake). Now 20 s. Affects TUI PTY + `proxxx logs` fanout.

## 🟡 Bounded resize body

[`src/api/client.rs`](src/api/client.rs) — the disk-resize PUT was the **one remaining REST read with an unbounded body** + an untyped parse error. Routed through the shared `read_bounded_body` (32 MiB cap) + `parse_json_maybe_blocking` (`ApiError::Parse`) helpers.

## 📄 Stale-doc cleanup (feature shipped, doc still said "deferred")

- [`src/state/apply.rs`](src/state/apply.rs) + [`src/cli/state.rs`](src/cli/state.rs) — removed "pre-flight + HITL out of scope" claims; that gate shipped in v0.3.0.
- [`src/cli/mod.rs`](src/cli/mod.rs) — firewall rustdoc said writes "not yet implemented"; alias/IP-set/group CRUD is implemented. Corrected to note only individual rule add/remove remains.

## Test plan

- [x] `cargo test --test pbs_test` — 7 passed (3 new typed-error assertions)
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] `cargo build` clean
- [x] Local gate PASSED in 531s (8 stages + live cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)