### PR TITLE
fix(cloud-img): real pinned checksums + dated URLs + qcow2 import content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,34 @@ SemVer contract:
 
 ## [Unreleased]
 
-_no entries yet — next release will be v0.3.1 (patch) or v0.4.0 (minor)._
+Next release will be **v0.4.0** (minor) — the post-v0.3.0 debug pass
+fixed remote-crash panics + several robustness gaps, and `cloud-img`
+becomes actually usable (behaviour change + a `--format json` field
+rename on a previously non-functional surface).
+
+### Fixed
+- **`cloud-img download` now works.** The v0.3.0 registry shipped with
+  all-zero placeholder SHAs (every download refused) AND two latent
+  bugs the placeholders masked: the Alpine entry named a non-existent
+  `nocloud_` artifact, and all three `.qcow2` entries used
+  `content=iso` — which PVE rejects with "wrong file extension"
+  (`.qcow2` requires `content=import`, PVE 8.2+). All four entries are
+  now pinned to **dated immutable build dirs** with **real checksums**
+  fetched from each distro's official sidecar, verified end-to-end
+  against PVE 9.1.1 (live Alpine download → checksum OK).
+- **Char-boundary-safe truncation** (#106) — 4 UTF-8 byte-slice panic
+  vectors on PVE-supplied / operator text.
+- **PBS client typed errors** (#107) — 401/403 now exit 4 (was 1).
+- **Connect timeouts** (#107) — termproxy WSS + SSH handshake no longer
+  hang indefinitely on a black-holed node (20 s each).
+
+### Changed
+- **`CloudImg` checksum model**: the `sha256` field is renamed
+  `checksum` and joined by `checksum_algorithm` (`sha256`/`sha512`),
+  because Debian + Alpine publish only SHA-512. Affects
+  `cloud-img list --output json` (field rename) and `cloud-img download`
+  JSON (`sha256` → `checksum` + `checksum_algorithm`). Justified as a
+  data-model fix on a surface that never produced a working download.
 
 ## [0.3.0] — 2026-05-20
 

--- a/src/cli/cloudimg.rs
+++ b/src/cli/cloudimg.rs
@@ -9,18 +9,21 @@
 //!
 //! ## What this MVP covers (per #65)
 //!
-//! - **Bundled registry** of cloud-image manifests. SHA-256 pinned
-//!   per release, append-only. v1 ships:
-//!     * Ubuntu 24.04 (noble) cloud, amd64 + arm64
+//! - **Bundled registry** of cloud-image manifests. Checksum-pinned
+//!   per release (SHA-256 for Ubuntu/Fedora, SHA-512 for Debian/Alpine
+//!   — each distro's native sidecar), pinned to dated immutable build
+//!   dirs, append-only. v1 ships:
+//!     * Ubuntu 24.04 (noble) cloud, amd64
 //!     * Debian 13 (trixie) genericcloud, amd64
-//!     * Alpine 3.20 cloud, `x86_64`
+//!     * Alpine 3.20 generic cloud, `x86_64`
 //!     * Fedora 41 cloud, `x86_64`
 //! - **`proxxx cloud-img list`** — print the registry as a table
-//!   (id / distro / version / arch / size / SHA-256 prefix).
+//!   (id / distro / version / arch / size / algo:checksum prefix).
 //! - **`proxxx cloud-img download <id> --node <n> --storage <s>`** —
-//!   issue PVE's `download-url` (server-side SHA-verified). The
+//!   issue PVE's `download-url` (server-side checksum-verified). The
 //!   bytes never transit through proxxx; PVE downloads + verifies
-//!   in one atomic step and rejects on hash mismatch.
+//!   in one atomic step and rejects on hash mismatch. `.img` images
+//!   deposit as `iso` content, `.qcow2` as `import` (PVE 8.2+).
 //!
 //! ## Scope deferred to a follow-up
 //!
@@ -58,20 +61,29 @@ pub struct CloudImg {
     pub arch: &'static str,
     /// Official upstream download URL (HTTPS).
     pub url: &'static str,
-    /// SHA-256 of the upstream file (lowercase hex, 64 chars).
-    /// PVE's `download-url` verifies this server-side and rejects
-    /// the download on mismatch.
-    pub sha256: &'static str,
+    /// Checksum of the upstream file (lowercase hex). 64 chars for
+    /// `sha256`, 128 for `sha512` — see `checksum_algorithm`. PVE's
+    /// `download-url` verifies this server-side and rejects the
+    /// download on mismatch.
+    pub checksum: &'static str,
+    /// Checksum algorithm: `"sha256"` or `"sha512"`. Distros differ —
+    /// Ubuntu/Fedora publish SHA-256 sidecars, Debian/Alpine publish
+    /// SHA-512 — so the algorithm is pinned per entry and forwarded to
+    /// PVE's `download-url` `checksum-algorithm` parameter.
+    pub checksum_algorithm: &'static str,
     /// Human-readable size estimate.
     pub size_human: &'static str,
     /// Filename to write into the storage. Conventionally
     /// `<distro>-<version>-<arch>.<ext>`.
     pub filename: &'static str,
-    /// PVE storage `content` type. Cloud images are imported as
-    /// disk images later, so we deposit as `iso` and the operator
-    /// imports with `qm importdisk`. (PVE 9.x will also accept
-    /// `import` content type on some storages, but `iso` works
-    /// everywhere.)
+    /// PVE storage `content` type — `"iso"` or `"import"`. The choice
+    /// is forced by PVE's per-content filename-extension validation:
+    /// `iso` accepts `.iso`/`.img` only, `import` accepts
+    /// `.qcow2`/`.raw`/`.vmdk`/`.vhdx` only. So a `.img` cloud image
+    /// (Ubuntu) deposits as `iso`; a `.qcow2` (Debian/Alpine/Fedora)
+    /// MUST deposit as `import` — PVE 8.2+ — or `download-url` rejects
+    /// it with "wrong file extension". The operator then imports the
+    /// disk with `qm importdisk` / `qm set --scsi0 …,import-from=…`.
     pub content: &'static str,
 }
 
@@ -79,23 +91,24 @@ pub struct CloudImg {
 /// entry once shipped, because operators may rely on the id being
 /// stable. Bump versions by adding new entries with new ids.
 ///
-/// All URLs + checksums verified against the official upstream
-/// at registry-edit time. The supply-chain discipline matches
-/// `app::iso_library::LIBRARY`.
+/// All URLs + checksums verified against the official upstream at
+/// registry-edit time (2026-05-21). URLs point at **dated, immutable**
+/// build directories — never `current`/`latest` symlinks — so the
+/// pinned checksum stays valid. When a distro ships a new point
+/// release, bump the entry (new dated URL + fresh checksum from the
+/// official SHA256SUMS / SHA512SUMS); a stale entry keeps working until
+/// then. The supply-chain discipline matches `app::iso_library::LIBRARY`.
 pub const REGISTRY: &[CloudImg] = &[
     CloudImg {
         id: "ubuntu-24.04-noble-amd64",
         distro: "Ubuntu",
-        version: "24.04 LTS (noble)",
+        version: "24.04 LTS (noble, build 20260321)",
         arch: "amd64",
-        url: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img",
-        // Upstream rotates the `current` artifact daily; we pin to a
-        // specific stable build (24.04.1, released 2024-08). For a
-        // truly reproducible build set, prefer a dated path like
-        // `noble/20240809/` and update the entry when bumping.
-        // Placeholder — operators verifying against upstream SHA-256
-        // should expect this to be re-pinned per real-world release.
-        sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+        // Dated immutable build dir (not noble/current/, which rotates
+        // daily). Checksum from this dir's SHA256SUMS.
+        url: "https://cloud-images.ubuntu.com/releases/noble/release-20260321/ubuntu-24.04-server-cloudimg-amd64.img",
+        checksum: "5c3ddb00f60bc455dac0862fabe9d8bacec46c33ac1751143c5c3683404b110d",
+        checksum_algorithm: "sha256",
         size_human: "~580 MiB",
         filename: "ubuntu-24.04-noble-amd64.img",
         content: "iso",
@@ -103,35 +116,44 @@ pub const REGISTRY: &[CloudImg] = &[
     CloudImg {
         id: "debian-13-trixie-amd64",
         distro: "Debian",
-        version: "13 (trixie) genericcloud",
+        version: "13 (trixie) genericcloud, build 20260518-2482",
         arch: "amd64",
-        url: "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2",
-        sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+        // Debian publishes SHA512SUMS only (no SHA256). Dated build dir.
+        url: "https://cloud.debian.org/images/cloud/trixie/20260518-2482/debian-13-genericcloud-amd64-20260518-2482.qcow2",
+        checksum: "7752ad2adce1bc49dd964dae8300ed7a239d0bf3c13112f55953b111447fe642d2cc01afeead234aa6ebe3605513f2e7c0e7c56785d675c38ff40110d5c8332b",
+        checksum_algorithm: "sha512",
         size_human: "~400 MiB",
         filename: "debian-13-trixie-amd64.qcow2",
-        content: "iso",
+        content: "import",
     },
     CloudImg {
         id: "alpine-3.20-virt-x86_64",
         distro: "Alpine",
-        version: "3.20 virt",
+        version: "3.20.10 generic (bios cloudinit)",
         arch: "x86_64",
-        url: "https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/cloud/nocloud_alpine-3.20.3-x86_64-bios-cloudinit-r0.qcow2",
-        sha256: "0000000000000000000000000000000000000000000000000000000000000000",
-        size_human: "~50 MiB",
+        // Alpine's generic cloud qcow2 (the registry previously named a
+        // non-existent `nocloud_` artifact). Per-file .sha512 sidecar;
+        // no .sha256 is published.
+        url: "https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/cloud/generic_alpine-3.20.10-x86_64-bios-cloudinit-r0.qcow2",
+        checksum: "dbf008c5910e22d2c9c2268ea9ce2dfef8b12e6f5e303c7515bdc1c4540d1b01cc7452fd351910b349162af6364f183af41ff01acdc2f6cb38a3652ee7f7e56e",
+        checksum_algorithm: "sha512",
+        size_human: "~190 MiB",
         filename: "alpine-3.20-virt-x86_64.qcow2",
-        content: "iso",
+        content: "import",
     },
     CloudImg {
         id: "fedora-41-cloud-x86_64",
         distro: "Fedora",
-        version: "41 cloud",
+        version: "41 cloud (Generic Base 1.4)",
         arch: "x86_64",
+        // Fedora release path is already immutable (versioned 41-1.4).
+        // Checksum from the Fedora-Cloud-41-1.4-x86_64-CHECKSUM file.
         url: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2",
-        sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+        checksum: "6205ae0c524b4d1816dbd3573ce29b5c44ed26c9fbc874fbe48c41c89dd0bac2",
+        checksum_algorithm: "sha256",
         size_human: "~470 MiB",
         filename: "fedora-41-cloud-x86_64.qcow2",
-        content: "iso",
+        content: "import",
     },
 ];
 
@@ -195,25 +217,28 @@ pub async fn execute_cloudimg(
                 return Ok((Value::Null, 0));
             }
             println!(
-                "{id:<32}  {distro:<8}  {version:<32}  {arch:<8}  {size:<10}  sha256",
+                "{id:<32}  {distro:<8}  {version:<40}  {arch:<8}  {size:<10}  checksum",
                 id = "id",
                 distro = "distro",
                 version = "version",
                 arch = "arch",
                 size = "size"
             );
-            let sep = "─".repeat(120);
+            let sep = "─".repeat(130);
             println!("{sep}");
             for e in REGISTRY {
-                let sha_short = &e.sha256[..16.min(e.sha256.len())];
+                // Char-boundary safe (checksums are ASCII hex, but use
+                // the shared helper for consistency).
+                let sum_short = crate::util::sanitize::truncate_ellipsis(e.checksum, 16);
                 println!(
-                    "{id:<32}  {distro:<8}  {version:<32}  {arch:<8}  {size:<10}  {sha}…",
+                    "{id:<32}  {distro:<8}  {version:<40}  {arch:<8}  {size:<10}  {algo}:{sum}",
                     id = e.id,
                     distro = e.distro,
                     version = e.version,
                     arch = e.arch,
                     size = e.size_human,
-                    sha = sha_short,
+                    algo = e.checksum_algorithm,
+                    sum = sum_short,
                 );
             }
             Ok((Value::Null, 0))
@@ -222,18 +247,18 @@ pub async fn execute_cloudimg(
             let entry = by_id(&id).with_context(|| {
                 format!("unknown template id `{id}` — run `proxxx template list` for the catalog")
             })?;
-            // PVE's download-url accepts a SHA-256; we always pass it
-            // so a registry placeholder (all zeros) fails the download
-            // explicitly rather than silently letting it succeed
-            // against an upstream that's been tampered with.
+            // Always forward the pinned checksum + algorithm so PVE
+            // verifies server-side and rejects on mismatch (or on a
+            // tampered upstream). The algorithm is per-entry: Ubuntu/
+            // Fedora are sha256, Debian/Alpine sha512.
             let upid = client
                 .download_to_storage(
                     &node,
                     &storage,
                     entry.url,
                     entry.filename,
-                    Some("sha256"),
-                    Some(entry.sha256),
+                    Some(entry.checksum_algorithm),
+                    Some(entry.checksum),
                     entry.content,
                 )
                 .await?;
@@ -244,10 +269,11 @@ pub async fn execute_cloudimg(
                     "storage": storage,
                     "url": entry.url,
                     "filename": entry.filename,
-                    "sha256": entry.sha256,
+                    "checksum": entry.checksum,
+                    "checksum_algorithm": entry.checksum_algorithm,
                     "task": upid,
                     "note": "Use `proxxx tasks --node <node>` to follow progress. \
-                             PVE verifies the SHA-256 server-side and rejects on mismatch.",
+                             PVE verifies the checksum server-side and rejects on mismatch.",
                 }),
                 0,
             ))
@@ -281,9 +307,44 @@ mod tests {
                 "url for `{}` is not HTTPS",
                 e.id
             );
+            // Checksum length must match the declared algorithm, be all
+            // lowercase hex, and NOT be a placeholder (all-zero). The
+            // all-zero guard is the regression pin against the v0.3.0
+            // shipped state where every entry was unusable.
+            let (algo_ok, want_len) = match e.checksum_algorithm {
+                "sha256" => (true, 64),
+                "sha512" => (true, 128),
+                _ => (false, 0),
+            };
             assert!(
-                e.sha256.len() == 64 && e.sha256.chars().all(|c| c.is_ascii_hexdigit()),
-                "sha256 for `{}` is not 64 hex chars",
+                algo_ok,
+                "checksum_algorithm for `{}` must be sha256 or sha512, got `{}`",
+                e.id, e.checksum_algorithm,
+            );
+            assert_eq!(
+                e.checksum.len(),
+                want_len,
+                "checksum for `{}` ({}) must be {want_len} hex chars",
+                e.id,
+                e.checksum_algorithm,
+            );
+            assert!(
+                e.checksum
+                    .chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+                "checksum for `{}` must be lowercase hex",
+                e.id,
+            );
+            assert!(
+                e.checksum.chars().any(|c| c != '0'),
+                "checksum for `{}` is an all-zero placeholder — repin from upstream",
+                e.id,
+            );
+            // Dated/immutable URL discipline: no `current`/`latest`
+            // symlinks (their content rotates, invalidating the pin).
+            assert!(
+                !e.url.contains("/current/") && !e.url.contains("/latest/"),
+                "url for `{}` uses a rotating symlink path; pin a dated build dir",
                 e.id,
             );
             assert!(!e.filename.is_empty(), "empty filename for {}", e.id);


### PR DESCRIPTION
## Summary

The v0.3.0 cloud-image registry shipped with all-zero placeholder SHAs — every `cloud-img download` refused. Populating real checksums (the "pin dated URLs + real SHAs now" path) surfaced **two further latent bugs** the placeholders had masked.

## Bugs found + fixed

1. **Alpine entry named a non-existent artifact** — `nocloud_alpine-3.20.3-…` doesn't exist; the real file is `generic_alpine-3.20.10-…`. (curl against the official mirror confirmed; the WebFetch summariser had even missed the qcow2 files.)
2. **`.qcow2` entries used `content=iso`** — PVE rejects this with `400 "wrong file extension"`. `.qcow2` disk images require `content=import` (PVE 8.2+). Only Ubuntu's `.img` is valid as `iso`. Confirmed against the live cluster.

## Changes

- **Per-entry `checksum` + `checksum_algorithm`** (replaces `sha256`): Ubuntu/Fedora publish SHA-256, Debian/Alpine publish **SHA-512 only**. Algorithm is forwarded to PVE's `download-url checksum-algorithm`.
- **All four entries repinned to dated immutable build dirs** (no `current`/`latest` symlinks — they rotate and invalidate a pinned SHA):

| Distro | Build | Algo |
| :--- | :--- | :--- |
| Ubuntu 24.04 | `releases/noble/release-20260321` | sha256 |
| Debian 13 | `trixie/20260518-2482` | sha512 |
| Alpine 3.20.10 | `generic_` qcow2 | sha512 |
| Fedora 41-1.4 | already-immutable release path | sha256 |

- `.qcow2` → `content=import`, Ubuntu `.img` → `content=iso`.

## Verification — live, end-to-end

Ran `cloud-img download alpine-3.20-virt-x86_64 --node pve-test-1 --storage local` against **PVE 9.1.1**: PVE fetched the 190 MiB qcow2 and the pinned **SHA-512 verified server-side** (task `exitstatus: OK`). Test artifact deleted afterward.

Registry tests now assert: checksum length matches algorithm (64/128 hex), lowercase, **not all-zero** (regression pin against the shipped placeholder state), and no rotating-symlink URLs.

## SemVer note

This is the **v0.4.0** (minor) trigger: `cloud-img download` goes from non-functional → working, and the `--format json` field renames (`sha256` → `checksum` + `checksum_algorithm`) on the `cloud-img list`/`download` surface. Justified as a data-model fix on a surface that never produced a working download. CHANGELOG `[Unreleased]` updated.

## Test plan

- [x] `cargo test --lib cloudimg` — 3 passed
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] Live download verified against PVE 9.1.1 (Alpine, sha512 OK)
- [x] Local gate PASSED in 527s

🤖 Generated with [Claude Code](https://claude.com/claude-code)