### PR TITLE
fix(tui): dispatch queued DeleteGuest (the d key was a dead enqueue)

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1513,7 +1513,17 @@ async fn dispatch_side_effect(
                                         .resize_disk(&node, vmid, g_type, &disk, &size)
                                         .await
                                 }
-                                _ => Err(anyhow::anyhow!("Unsupported in queue yet")),
+                                app::Action::DeleteGuest { .. } => {
+                                    // The `d` key in GuestList enqueues delete via
+                                    // EnqueueBatchOperation; without this arm those
+                                    // queued deletes failed with "Unsupported in
+                                    // queue yet". The queue's pre-flight gate above
+                                    // already guards the destructive op.
+                                    client_cloned.delete_guest(&node, vmid, g_type).await
+                                }
+                                _ => Err(anyhow::anyhow!(
+                                    "action not dispatchable from the operation queue"
+                                )),
                             };
 
                             match res {

--- a/tests/tui_keymap_e2e.rs
+++ b/tests/tui_keymap_e2e.rs
@@ -161,6 +161,7 @@ fn render_current_view(state: &AppState) {
             View::GuestList => views::guests::draw(f, f.area(), state),
             View::StorageList => views::storage::draw(f, f.area(), state),
             View::Heatmap => views::heatmap::draw(f, f.area(), state),
+            View::OperationQueue => views::queue::draw(f, f.area(), state),
             other => panic!(
                 "test seeded a sequence touching view {other:?} but the \
                  render dispatch in tui_keymap_e2e.rs has no arm for it; \
@@ -347,4 +348,44 @@ fn back_pops_view_stack_and_only_quits_when_empty() {
         matches!(effect, Some(SideEffect::Quit)),
         "expected Quit on empty nav_stack, got {effect:?}"
     );
+}
+
+/// Regression: pressing `d` on a guest enqueues a delete that the
+/// operation-queue executor must be able to dispatch. Before the fix,
+/// `Action::DeleteGuest` had no arm in the queue dispatcher and every
+/// queued delete failed at execution with "Unsupported in queue yet".
+///
+/// This pins the user-facing trigger: `d` on the guest list → a single
+/// `DeleteGuest` op lands on `op_queue`, and the view flips to the
+/// operation queue (which must render without panicking). The
+/// executor arm itself is a direct `delete_guest` gateway call,
+/// compile-checked + exercised by the live mutation gate.
+#[test]
+fn d_key_enqueues_a_dispatchable_delete() {
+    let mut state = AppState::new();
+    seed(&mut state);
+
+    // Navigate to the guest list and delete the highlighted guest.
+    step(&mut state, key_char('3'));
+    assert_eq!(*state.current_view(), View::GuestList);
+    let target = state
+        .visible_guests()
+        .first()
+        .map(|g| g.vmid)
+        .expect("seed has guests");
+
+    step(&mut state, key_char('d'));
+
+    // Exactly one op enqueued, and it's a DeleteGuest for the
+    // highlighted guest — NOT silently dropped, NOT a different action.
+    assert_eq!(state.op_queue.len(), 1, "d must enqueue exactly one op");
+    match &*state.op_queue[0].action {
+        app::Action::DeleteGuest { vmid } => {
+            assert_eq!(*vmid, target, "queued delete targets the highlighted guest");
+        }
+        other => panic!("expected a queued DeleteGuest, got {other:?}"),
+    }
+    // The reducer flips to the operation-queue view; rendering it in
+    // `step` above already asserted it doesn't panic.
+    assert_eq!(*state.current_view(), View::OperationQueue);
 }


### PR DESCRIPTION
## Summary

The `d` key on the TUI guest list enqueues `Action::DeleteGuest` via `EnqueueBatchOperation`, but the operation-queue executor's match in `tui/mod.rs` had **no `DeleteGuest` arm** — so every queued delete fell into `_ => Err("Unsupported in queue yet")` and failed at execution.

Start / Stop / Restart (the other `EnqueueBatchOperation` keys: `s`/`S`/`r`) were all handled. Delete (`d`) was the one lifecycle action that silently didn't work from the TUI.

## Root cause

Two enqueue layers diverged:
- `tui/event.rs` `d` → `EnqueueBatchOperation([DeleteGuest])` → reducer pushes to `op_queue`.
- `tui/mod.rs` queue executor handled `StartGuest`/`StopGuest`/`RestartGuest`/`MigrateGuest`/`ExecuteGuestCommand`/`MoveDisk`/`ResizeDisk` — but not `DeleteGuest`.

(The *direct* `Action::DeleteGuest` → `SideEffect::DeleteGuest` path works; only the **queued** path was dead.)

## Fix

- Added the `DeleteGuest` arm: a direct `client.delete_guest(node, vmid, g_type)` call mirroring the sibling lifecycle arms. The queue's pre-flight risk gate already runs before dispatch, so the destructive op stays guarded.
- Reworded the catch-all from "Unsupported in queue yet" → "action not dispatchable from the operation queue" (accurate; the remaining unmatched actions genuinely aren't queue-dispatchable).

## Test

`d_key_enqueues_a_dispatchable_delete` (tui_keymap_e2e.rs) drives the real keymap path: `d` on the guest list → exactly one `DeleteGuest` op on `op_queue` targeting the highlighted guest → view flips to the operation queue (rendered without panic via the test's TestBackend). 6/6 keymap tests pass.

## Test plan

- [x] `cargo test --test tui_keymap_e2e` — 6 passed (incl. new regression)
- [x] `cargo clippy --all-targets --all-features` — 0 warnings
- [x] Local gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)