### PR TITLE
feat(state): backup-jobs as a managed resource family (epic #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,16 @@ SemVer contract:
 
 ## [Unreleased]
 
-_no entries yet._
+### Added
+- **`state` now manages scheduled backup jobs** (epic #74). A new
+  `backup-jobs` resource family is wired through the full GitOps loop:
+  `state export --resource backup-jobs` snapshots every recurring
+  vzdump job (`/cluster/backup`) sorted by `id`, `state diff` detects
+  drift, and `state apply` converges (create / update / delete). The
+  scheduler-derived `next-run` and the deprecated `mailnotification`
+  field are dropped on export so the TOML stays diff-stable. Deleting a
+  backup job is flagged as a **Warning** by the pre-flight gate (silent
+  loss of data protection). `--resource all` now includes backup jobs.
 
 ## [0.4.0] — 2026-05-21
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -191,7 +191,7 @@ within a major version.
 
 | Command | What it does |
 | :--- | :--- |
-| `proxxx state export [--resource pools\|acl\|storage\|all] [--output toml\|json]` | Byte-stable snapshot of cluster state. Default emits TOML; `--output json` for piping. Diff-stable across runs against an unchanged cluster. |
+| `proxxx state export [--resource pools\|acl\|storage\|backup-jobs\|all] [--output toml\|json]` | Byte-stable snapshot of cluster state. Default emits TOML; `--output json` for piping. Diff-stable across runs against an unchanged cluster. |
 | `proxxx state diff <declared.toml> [--output text\|json]` | Structural diff of declared vs live. Exit 2 on drift. |
 | `proxxx state apply <declared.toml> [--dry-run] [--prune] [--continue-on-error] [--allow-risk] [--interactive] [--output text\|json]` | Converge live toward declared. Pre-flight risk gate refuses Severe changes (non-empty pool delete, root-role ACL delete, shared-storage delete, batch ≥ 50) without `--allow-risk`. `--interactive` adds per-Severe `[y/N]` stdin prompts. Exit code 6 on refusal. |
 

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -3,8 +3,8 @@
 //! toward declared.
 //!
 //! Resource families covered today: pools, ACL grants, cluster
-//! storage definitions. Cluster firewall, backup jobs, notifications,
-//! and HA groups land in follow-up PRs tracked by epic
+//! storage definitions, scheduled backup jobs. Cluster firewall,
+//! notifications, and HA groups land in follow-up PRs tracked by epic
 //! [#74](https://github.com/fabriziosalmi/proxxx/issues/74). Pre-flight
 //! risk gates + HITL approval per destructive change are wired (shipped
 //! v0.3.0): `state::preflight` refuses Severe changes unless
@@ -38,9 +38,9 @@ pub enum ExportFormat {
 pub enum StateCommand {
     /// Export the cluster's mutable state.
     ///
-    /// Supported resources: `pools`, `acl`, `all` (every supported
-    /// family). More (storage, firewall-cluster, backup-jobs,
-    /// notifications) land per the ladder in epic #74.
+    /// Supported resources: `pools`, `acl`, `storage`, `backup-jobs`,
+    /// `all` (every supported family). More (firewall-cluster,
+    /// notifications, HA groups) land per the ladder in epic #74.
     ///
     /// The resulting document is byte-stable across runs against an
     /// unchanged cluster — every collection is sorted by its identity
@@ -52,8 +52,8 @@ pub enum StateCommand {
     ///   proxxx state export > state.toml                    # capture to file
     ///   proxxx state export --output json | jq '.pools[0]'  # programmatic
     Export {
-        /// Resource family to export. Valid: `pools`, `acl`, `all`.
-        /// More families coming — see issue #74.
+        /// Resource family to export. Valid: `pools`, `acl`, `storage`,
+        /// `backup-jobs`, `all`. More families coming — see issue #74.
         #[arg(long, default_value = "pools")]
         resource: String,
 
@@ -260,15 +260,14 @@ pub async fn execute_state(
 
             // Export live across every supported family — diff
             // ignores anything that's not in BOTH declared and live,
-            // so over-fetching is cheap and correct.
+            // so over-fetching is cheap and correct. `Resource::all()`
+            // is the single source of truth so a newly-added family is
+            // never silently omitted here (which would make its
+            // declared entries diff as perpetual creates).
             let profile_label = profile.unwrap_or("default");
             let live_state = state::export::export_state(
                 client.as_ref(),
-                &[
-                    state::export::Resource::Pools,
-                    state::export::Resource::Acl,
-                    state::export::Resource::Storage,
-                ],
+                &state::export::Resource::all(),
                 profile_label,
             )
             .await?;
@@ -321,11 +320,7 @@ pub async fn execute_state(
             let profile_label = profile.unwrap_or("default");
             let live_state = state::export::export_state(
                 client.as_ref(),
-                &[
-                    state::export::Resource::Pools,
-                    state::export::Resource::Acl,
-                    state::export::Resource::Storage,
-                ],
+                &state::export::Resource::all(),
                 profile_label,
             )
             .await?;

--- a/src/state/apply.rs
+++ b/src/state/apply.rs
@@ -24,13 +24,14 @@
 //! Keeping the gate in an outer layer is why this module stays a clean
 //! pure-dispatch unit.
 //!
-//! ## What apply supports today (per epic #74 PR 5)
+//! ## What apply supports today (per epic #74)
 //!
 //! | Resource | Create | Update | Delete |
 //! | :--- | :---: | :---: | :---: |
 //! | Pool | ✓ | ✓ (comment + membership diff) | ✓ |
 //! | ACL | ✓ | ✓ (delete + recreate with new propagate) | ✓ |
 //! | Storage | ✓ | ✓ (mutable fields only) | ✓ |
+//! | Backup job | ✓ | ✓ (all mutable fields) | ✓ |
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -38,7 +39,7 @@ use serde::Serialize;
 
 use crate::api::types::{Pool, PoolDetails};
 use crate::state::diff::{Change, ChangeKind};
-use crate::state::model::{AclDecl, PoolDecl, StorageDecl};
+use crate::state::model::{AclDecl, BackupJobDecl, PoolDecl, StorageDecl};
 
 /// Options controlling apply behaviour.
 #[derive(Debug, Clone, Copy, Default)]
@@ -128,6 +129,11 @@ pub trait StateWriteView: Send + Sync {
         params: &[(&str, &str)],
     ) -> Result<()>;
     async fn delete_cluster_storage_view(&self, storage: &str) -> Result<()>;
+
+    // ── Backup-job surface ────────────────────────────────
+    async fn create_backup_job_view(&self, params: &[(&str, &str)]) -> Result<()>;
+    async fn update_backup_job_view(&self, id: &str, params: &[(&str, &str)]) -> Result<()>;
+    async fn delete_backup_job_view(&self, id: &str) -> Result<()>;
 }
 
 #[async_trait]
@@ -177,6 +183,16 @@ where
     ) -> Result<()> {
         crate::api::ProxmoxGateway::update_cluster_storage(self, storage, params).await
     }
+    async fn create_backup_job_view(&self, params: &[(&str, &str)]) -> Result<()> {
+        crate::api::ProxmoxGateway::create_backup_job(self, params).await
+    }
+    async fn update_backup_job_view(&self, id: &str, params: &[(&str, &str)]) -> Result<()> {
+        crate::api::ProxmoxGateway::update_backup_job(self, id, params).await
+    }
+    async fn delete_backup_job_view(&self, id: &str) -> Result<()> {
+        crate::api::ProxmoxGateway::delete_backup_job(self, id).await
+    }
+
     async fn delete_cluster_storage_view(&self, storage: &str) -> Result<()> {
         crate::api::ProxmoxGateway::delete_cluster_storage(self, storage).await
     }
@@ -246,6 +262,9 @@ async fn apply_one<C: StateWriteView + ?Sized>(client: &C, change: &Change) -> A
         ("storage", ChangeKind::Create) => apply_storage_create(client, change).await,
         ("storage", ChangeKind::Update) => apply_storage_update(client, change).await,
         ("storage", ChangeKind::Delete) => apply_storage_delete(client, change).await,
+        ("backup_job", ChangeKind::Create) => apply_backupjob_create(client, change).await,
+        ("backup_job", ChangeKind::Update) => apply_backupjob_update(client, change).await,
+        ("backup_job", ChangeKind::Delete) => apply_backupjob_delete(client, change).await,
         (resource, kind) => Err(anyhow::anyhow!(
             "unhandled change shape: resource={resource} kind={kind:?}"
         )),
@@ -573,6 +592,94 @@ async fn apply_storage_delete<C: StateWriteView + ?Sized>(
     client.delete_cluster_storage_view(&decl.storage).await
 }
 
+// ── Backup job ───────────────────────────────────────────────
+
+/// Build the `POST`/`PUT /cluster/backup` param set from a decl.
+/// `include_id` is true for create (PVE accepts a caller id) and
+/// false for update (the id is the URL segment, not a body param).
+fn backup_job_params(decl: &BackupJobDecl, include_id: bool) -> Vec<(String, String)> {
+    let mut params: Vec<(String, String)> = Vec::new();
+    if include_id {
+        params.push(("id".to_string(), decl.id.clone()));
+    }
+    push_optional(&mut params, "schedule", &decl.schedule);
+    push_optional(&mut params, "storage", &decl.storage);
+    push_optional(&mut params, "mode", &decl.mode);
+    // `enabled` is always sent (0/1) so an Update that flips it to
+    // false actually disables the job rather than leaving it enabled.
+    params.push((
+        "enabled".to_string(),
+        if decl.enabled { "1" } else { "0" }.to_string(),
+    ));
+    // `all` and `vmid` are mutually exclusive in PVE — send whichever
+    // the decl set. `all = true` wins; otherwise the explicit vmid CSV.
+    if decl.all {
+        params.push(("all".to_string(), "1".to_string()));
+    } else {
+        push_optional(&mut params, "vmid", &decl.vmid);
+    }
+    push_optional(&mut params, "node", &decl.node);
+    push_optional(&mut params, "mailto", &decl.mailto);
+    push_optional(&mut params, "compress", &decl.compress);
+    push_optional(&mut params, "comment", &decl.comment);
+    // PVE serialises these two with hyphens.
+    push_optional(&mut params, "notes-template", &decl.notes_template);
+    push_optional(&mut params, "prune-backups", &decl.prune_backups);
+    params
+}
+
+async fn apply_backupjob_create<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: BackupJobDecl = serde_json::from_value(
+        change
+            .after
+            .clone()
+            .context("backup_job create change missing `after` value")?,
+    )
+    .context("decoding BackupJobDecl from change.after")?;
+    let params = backup_job_params(&decl, true);
+    let borrowed: Vec<(&str, &str)> = params
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    client.create_backup_job_view(&borrowed).await
+}
+
+async fn apply_backupjob_update<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let after: BackupJobDecl = serde_json::from_value(
+        change
+            .after
+            .clone()
+            .context("backup_job update change missing `after` value")?,
+    )
+    .context("decoding BackupJobDecl from change.after")?;
+    let params = backup_job_params(&after, false);
+    let borrowed: Vec<(&str, &str)> = params
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    client.update_backup_job_view(&after.id, &borrowed).await
+}
+
+async fn apply_backupjob_delete<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: BackupJobDecl = serde_json::from_value(
+        change
+            .before
+            .clone()
+            .context("backup_job delete change missing `before` value")?,
+    )
+    .context("decoding BackupJobDecl from change.before")?;
+    client.delete_backup_job_view(&decl.id).await
+}
+
 fn push_optional(params: &mut Vec<(String, String)>, key: &str, value: &str) {
     if !value.is_empty() {
         params.push((key.to_string(), value.to_string()));
@@ -684,6 +791,16 @@ mod tests {
         }
         async fn delete_cluster_storage_view(&self, storage: &str) -> Result<()> {
             self.record(format!("delete_storage({storage})")).await
+        }
+        async fn create_backup_job_view(&self, params: &[(&str, &str)]) -> Result<()> {
+            self.record(format!("create_backup_job {params:?}")).await
+        }
+        async fn update_backup_job_view(&self, id: &str, params: &[(&str, &str)]) -> Result<()> {
+            self.record(format!("update_backup_job({id}) {params:?}"))
+                .await
+        }
+        async fn delete_backup_job_view(&self, id: &str) -> Result<()> {
+            self.record(format!("delete_backup_job({id})")).await
         }
     }
 
@@ -839,5 +956,150 @@ mod tests {
         assert!(matches!(out[0].result, ApplyResult::Applied));
         assert!(matches!(out[1].result, ApplyResult::Failed { .. }));
         assert!(matches!(out[2].result, ApplyResult::Applied));
+    }
+
+    fn backup_job_change(kind: ChangeKind, decl: &BackupJobDecl) -> Change {
+        let v = serde_json::to_value(decl).ok();
+        Change {
+            kind,
+            resource: "backup_job",
+            identity: decl.id.clone(),
+            before: if kind == ChangeKind::Delete {
+                v.clone()
+            } else {
+                None
+            },
+            after: if kind == ChangeKind::Delete { None } else { v },
+        }
+    }
+
+    #[test]
+    fn backup_job_params_create_includes_id_update_omits_it() {
+        let decl = BackupJobDecl {
+            id: "nightly".into(),
+            schedule: "*-*-* 02:00".into(),
+            storage: "pbs".into(),
+            ..BackupJobDecl::default()
+        };
+        let create = backup_job_params(&decl, true);
+        assert!(create.iter().any(|(k, v)| k == "id" && v == "nightly"));
+        let update = backup_job_params(&decl, false);
+        assert!(
+            !update.iter().any(|(k, _)| k == "id"),
+            "id is the URL segment on update, never a body param"
+        );
+    }
+
+    #[test]
+    fn backup_job_params_always_sends_enabled_and_hyphenates_keys() {
+        // `enabled` must always be present (0/1) so an Update that
+        // disables a job actually takes effect. notes-template /
+        // prune-backups must be hyphenated to match PVE's param names.
+        let decl = BackupJobDecl {
+            id: "j".into(),
+            schedule: "daily".into(),
+            storage: "local".into(),
+            enabled: false,
+            notes_template: "{{guestname}}".into(),
+            prune_backups: "keep-last=3".into(),
+            ..BackupJobDecl::default()
+        };
+        let p = backup_job_params(&decl, true);
+        assert!(p.iter().any(|(k, v)| k == "enabled" && v == "0"));
+        assert!(p
+            .iter()
+            .any(|(k, v)| k == "notes-template" && v == "{{guestname}}"));
+        assert!(p
+            .iter()
+            .any(|(k, v)| k == "prune-backups" && v == "keep-last=3"));
+        assert!(!p.iter().any(|(k, _)| k == "notes_template"));
+    }
+
+    #[test]
+    fn backup_job_params_all_and_vmid_are_mutually_exclusive() {
+        // `all = true` sends `all=1` and suppresses any vmid CSV.
+        let all = BackupJobDecl {
+            id: "j".into(),
+            all: true,
+            vmid: "100,200".into(),
+            ..BackupJobDecl::default()
+        };
+        let p = backup_job_params(&all, true);
+        assert!(p.iter().any(|(k, v)| k == "all" && v == "1"));
+        assert!(
+            !p.iter().any(|(k, _)| k == "vmid"),
+            "vmid must be suppressed when all=true"
+        );
+
+        // all = false sends the explicit vmid list, no `all` key.
+        let list = BackupJobDecl {
+            id: "j".into(),
+            all: false,
+            vmid: "100,200".into(),
+            ..BackupJobDecl::default()
+        };
+        let p2 = backup_job_params(&list, true);
+        assert!(p2.iter().any(|(k, v)| k == "vmid" && v == "100,200"));
+        assert!(!p2.iter().any(|(k, _)| k == "all"));
+    }
+
+    #[tokio::test]
+    async fn backup_job_create_dispatches_to_create_view() {
+        let c = RecordingClient::default();
+        let decl = BackupJobDecl {
+            id: "nightly".into(),
+            schedule: "*-*-* 02:00".into(),
+            storage: "pbs".into(),
+            all: true,
+            ..BackupJobDecl::default()
+        };
+        let out = apply(
+            &c,
+            vec![backup_job_change(ChangeKind::Create, &decl)],
+            ApplyOptions::default(),
+        )
+        .await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let lines = c.lines().await;
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].starts_with("create_backup_job"));
+        assert!(lines[0].contains("\"id\", \"nightly\""));
+    }
+
+    #[tokio::test]
+    async fn backup_job_delete_dispatches_only_with_prune() {
+        let decl = BackupJobDecl {
+            id: "old".into(),
+            ..BackupJobDecl::default()
+        };
+        // Without prune: skipped.
+        let c = RecordingClient::default();
+        let out = apply(
+            &c,
+            vec![backup_job_change(ChangeKind::Delete, &decl)],
+            ApplyOptions::default(),
+        )
+        .await;
+        assert!(matches!(
+            out[0].result,
+            ApplyResult::Skipped {
+                reason: SkipReason::PrunePolicy
+            }
+        ));
+        assert!(c.lines().await.is_empty());
+
+        // With prune: fires delete_backup_job(old).
+        let c2 = RecordingClient::default();
+        let out2 = apply(
+            &c2,
+            vec![backup_job_change(ChangeKind::Delete, &decl)],
+            ApplyOptions {
+                prune: true,
+                ..ApplyOptions::default()
+            },
+        )
+        .await;
+        assert!(matches!(out2[0].result, ApplyResult::Applied));
+        assert_eq!(c2.lines().await, vec!["delete_backup_job(old)".to_string()]);
     }
 }

--- a/src/state/diff.rs
+++ b/src/state/diff.rs
@@ -23,6 +23,7 @@
 //! * ACL — `(path, kind, ugid, roleid)` 4-tuple, rendered as
 //!   `"<path>:<kind>/<ugid>/<roleid>"` for display
 //! * Storage — `storage` (the operator-chosen id)
+//! * Backup job — `id` (the job id, operator- or PVE-assigned)
 //!
 //! Update detection compares the full `*Decl` value with `PartialEq`
 //! — every non-identity field is part of the value. Touching any
@@ -32,7 +33,7 @@
 
 use serde::Serialize;
 
-use crate::state::model::{AclDecl, ClusterState, PoolDecl, StorageDecl};
+use crate::state::model::{AclDecl, BackupJobDecl, ClusterState, PoolDecl, StorageDecl};
 
 /// Kind of mutation a change represents. `Create` + `Delete` are
 /// self-evident; `Update` is "identity matches, value differs".
@@ -75,16 +76,17 @@ pub struct Change {
 /// to enforce `--prune` semantics.
 ///
 /// The output order is stable: changes for `pool` first, then `acl`,
-/// then `storage`, each family sorted by identity. Within a family
-/// the order is `Delete` (so apply-with-prune teardown runs before
-/// create), then `Update`, then `Create` — but the apply layer
-/// re-orders by dependency where needed.
+/// then `storage`, then `backup_job`, each family sorted by identity.
+/// Within a family the order is `Delete` (so apply-with-prune teardown
+/// runs before create), then `Update`, then `Create` — but the apply
+/// layer re-orders by dependency where needed.
 #[must_use]
 pub fn diff(declared: &ClusterState, live: &ClusterState) -> Vec<Change> {
     let mut out = Vec::new();
     diff_pools(&declared.pools, &live.pools, &mut out);
     diff_acl(&declared.acl, &live.acl, &mut out);
     diff_storage(&declared.storage, &live.storage, &mut out);
+    diff_backup_jobs(&declared.backup_jobs, &live.backup_jobs, &mut out);
     out
 }
 
@@ -271,6 +273,58 @@ fn diff_storage(declared: &[StorageDecl], live: &[StorageDecl], out: &mut Vec<Ch
     }
 }
 
+fn diff_backup_jobs(declared: &[BackupJobDecl], live: &[BackupJobDecl], out: &mut Vec<Change>) {
+    use std::collections::HashMap;
+    let live_by: HashMap<&str, &BackupJobDecl> = live.iter().map(|j| (j.id.as_str(), j)).collect();
+    let decl_by: HashMap<&str, &BackupJobDecl> =
+        declared.iter().map(|j| (j.id.as_str(), j)).collect();
+
+    let mut deletes: Vec<_> = live_by
+        .keys()
+        .filter(|k| !decl_by.contains_key(*k))
+        .collect();
+    deletes.sort_unstable();
+    for k in deletes {
+        out.push(Change {
+            kind: ChangeKind::Delete,
+            resource: "backup_job",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: None,
+        });
+    }
+
+    let mut updates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| live_by.get(*k).is_some_and(|live_j| *live_j != decl_by[*k]))
+        .collect();
+    updates.sort_unstable();
+    for k in updates {
+        out.push(Change {
+            kind: ChangeKind::Update,
+            resource: "backup_job",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+
+    let mut creates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| !live_by.contains_key(*k))
+        .collect();
+    creates.sort_unstable();
+    for k in creates {
+        out.push(Change {
+            kind: ChangeKind::Create,
+            resource: "backup_job",
+            identity: (*k).to_string(),
+            before: None,
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+}
+
 /// Human-readable single-line summary of one change. Used by the
 /// CLI's default output mode. Keep it grep-friendly:
 /// `<sigil> <resource>: <identity>`.
@@ -291,7 +345,7 @@ pub fn summary_line(c: &Change) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::model::{AclDecl, ClusterState, PoolDecl, StorageDecl};
+    use crate::state::model::{AclDecl, BackupJobDecl, ClusterState, PoolDecl, StorageDecl};
 
     fn empty() -> ClusterState {
         ClusterState::default()
@@ -501,9 +555,10 @@ mod tests {
 
     #[test]
     fn diff_multi_family_emits_in_order() {
-        // Spread changes across pool, acl, storage; pinning the
-        // emit order: pool → acl → storage (matches `ClusterState`
-        // field order, matches the iteration order in `diff()`).
+        // Spread changes across pool, acl, storage, backup_job;
+        // pinning the emit order: pool → acl → storage → backup_job
+        // (matches `ClusterState` field order, matches the iteration
+        // order in `diff()`).
         let declared = ClusterState {
             pools: vec![PoolDecl {
                 poolid: "new-pool".into(),
@@ -523,13 +578,141 @@ mod tests {
                 path: "/srv/iso".into(),
                 ..StorageDecl::default()
             }],
+            backup_jobs: vec![BackupJobDecl {
+                id: "new-job".into(),
+                schedule: "daily".into(),
+                storage: "local".into(),
+                ..BackupJobDecl::default()
+            }],
             ..ClusterState::default()
         };
         let d = diff(&declared, &empty());
-        assert_eq!(d.len(), 3);
+        assert_eq!(d.len(), 4);
         assert_eq!(d[0].resource, "pool");
         assert_eq!(d[1].resource, "acl");
         assert_eq!(d[2].resource, "storage");
+        assert_eq!(d[3].resource, "backup_job");
+    }
+
+    #[test]
+    fn diff_backup_job_create() {
+        let declared = ClusterState {
+            backup_jobs: vec![BackupJobDecl {
+                id: "nightly".into(),
+                schedule: "*-*-* 02:00".into(),
+                storage: "pbs".into(),
+                all: true,
+                ..BackupJobDecl::default()
+            }],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &empty());
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Create);
+        assert_eq!(d[0].resource, "backup_job");
+        assert_eq!(d[0].identity, "nightly");
+        assert!(d[0].before.is_none());
+        assert!(d[0].after.is_some());
+    }
+
+    #[test]
+    fn diff_backup_job_delete() {
+        let live = ClusterState {
+            backup_jobs: vec![BackupJobDecl {
+                id: "orphan".into(),
+                schedule: "daily".into(),
+                storage: "local".into(),
+                ..BackupJobDecl::default()
+            }],
+            ..ClusterState::default()
+        };
+        let d = diff(&empty(), &live);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Delete);
+        assert_eq!(d[0].resource, "backup_job");
+        assert_eq!(d[0].identity, "orphan");
+        assert!(d[0].before.is_some());
+        assert!(d[0].after.is_none());
+    }
+
+    #[test]
+    fn diff_backup_job_update_on_schedule_change() {
+        // Same id, different schedule → exactly one Update with the
+        // live value in `before` and declared in `after`.
+        let declared = ClusterState {
+            backup_jobs: vec![BackupJobDecl {
+                id: "j1".into(),
+                schedule: "*-*-* 04:00".into(),
+                storage: "local".into(),
+                ..BackupJobDecl::default()
+            }],
+            ..ClusterState::default()
+        };
+        let live = ClusterState {
+            backup_jobs: vec![BackupJobDecl {
+                id: "j1".into(),
+                schedule: "*-*-* 02:00".into(),
+                storage: "local".into(),
+                ..BackupJobDecl::default()
+            }],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &live);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Update);
+        assert_eq!(d[0].identity, "j1");
+        let before = d[0].before.as_ref().unwrap();
+        let after = d[0].after.as_ref().unwrap();
+        assert_eq!(before.get("schedule").unwrap(), "*-*-* 02:00");
+        assert_eq!(after.get("schedule").unwrap(), "*-*-* 04:00");
+    }
+
+    #[test]
+    fn diff_backup_job_update_on_enabled_flag() {
+        // Flipping `enabled` is the most common drift (operator pauses
+        // a job in the UI); pin that it's detected as an Update.
+        let declared = ClusterState {
+            backup_jobs: vec![BackupJobDecl {
+                id: "j1".into(),
+                schedule: "daily".into(),
+                storage: "local".into(),
+                enabled: false,
+                ..BackupJobDecl::default()
+            }],
+            ..ClusterState::default()
+        };
+        let live = ClusterState {
+            backup_jobs: vec![BackupJobDecl {
+                id: "j1".into(),
+                schedule: "daily".into(),
+                storage: "local".into(),
+                enabled: true,
+                ..BackupJobDecl::default()
+            }],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &live);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Update);
+        assert_eq!(d[0].resource, "backup_job");
+    }
+
+    #[test]
+    fn diff_identical_backup_jobs_produces_no_change() {
+        let j = BackupJobDecl {
+            id: "j1".into(),
+            schedule: "*-*-* 03:00".into(),
+            storage: "pbs".into(),
+            all: true,
+            prune_backups: "keep-last=7".into(),
+            ..BackupJobDecl::default()
+        };
+        let s = ClusterState {
+            backup_jobs: vec![j],
+            ..ClusterState::default()
+        };
+        let d = diff(&s, &s);
+        assert!(d.is_empty());
     }
 
     #[test]

--- a/src/state/export.rs
+++ b/src/state/export.rs
@@ -18,8 +18,10 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::api::types::{AclEntry, ApiVersion, Pool, PoolDetails, PoolMember, StorageDefinition};
-use crate::state::model::{AclDecl, ClusterState, PoolDecl, StateMeta, StorageDecl};
+use crate::api::types::{
+    AclEntry, ApiVersion, BackupJob, Pool, PoolDetails, PoolMember, StorageDefinition,
+};
+use crate::state::model::{AclDecl, BackupJobDecl, ClusterState, PoolDecl, StateMeta, StorageDecl};
 
 /// Which resource families to export. Parsed from the CLI `--resource`
 /// argument. New variants are added per the ladder in epic #74.
@@ -28,6 +30,7 @@ pub enum Resource {
     Pools,
     Acl,
     Storage,
+    BackupJobs,
 }
 
 impl Resource {
@@ -40,11 +43,24 @@ impl Resource {
             "pools" => Ok(vec![Self::Pools]),
             "acl" => Ok(vec![Self::Acl]),
             "storage" => Ok(vec![Self::Storage]),
-            "all" => Ok(vec![Self::Pools, Self::Acl, Self::Storage]),
+            "backup-jobs" => Ok(vec![Self::BackupJobs]),
+            "all" => Ok(Self::all()),
             other => anyhow::bail!(
-                "unknown resource '{other}' (valid: pools | acl | storage | all — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
+                "unknown resource '{other}' (valid: pools | acl | storage | backup-jobs | all — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
             ),
         }
+    }
+
+    /// Every supported resource family, in canonical (struct-field)
+    /// order. The single source of truth for "all families" — used by
+    /// `--resource all` AND by `state diff` / `state apply` to build
+    /// the live snapshot they compare against. Adding a family here
+    /// wires it into the full `GitOps` loop in one place, so the diff/
+    /// apply live-fetch can never silently omit a family (which would
+    /// make that family's declared entries diff as perpetual creates).
+    #[must_use]
+    pub fn all() -> Vec<Self> {
+        vec![Self::Pools, Self::Acl, Self::Storage, Self::BackupJobs]
     }
 
     /// Human-readable name for logs / error messages.
@@ -54,6 +70,7 @@ impl Resource {
             Self::Pools => "pools",
             Self::Acl => "acl",
             Self::Storage => "storage",
+            Self::BackupJobs => "backup-jobs",
         }
     }
 }
@@ -72,6 +89,7 @@ pub trait StateReadView: Send + Sync {
     async fn get_pool_view(&self, poolid: &str) -> Result<PoolDetails>;
     async fn list_acl_view(&self) -> Result<Vec<AclEntry>>;
     async fn list_cluster_storages_view(&self) -> Result<Vec<StorageDefinition>>;
+    async fn list_backup_jobs_view(&self) -> Result<Vec<BackupJob>>;
     async fn get_api_version_view(&self) -> Result<ApiVersion>;
 }
 
@@ -91,6 +109,9 @@ where
     }
     async fn list_cluster_storages_view(&self) -> Result<Vec<StorageDefinition>> {
         crate::api::ProxmoxGateway::list_cluster_storages(self).await
+    }
+    async fn list_backup_jobs_view(&self) -> Result<Vec<BackupJob>> {
+        crate::api::ProxmoxGateway::list_backup_jobs(self).await
     }
     async fn get_api_version_view(&self) -> Result<ApiVersion> {
         crate::api::ProxmoxGateway::get_api_version(self).await
@@ -121,6 +142,7 @@ pub async fn export_state<C: StateReadView + ?Sized>(
         pools: Vec::new(),
         acl: Vec::new(),
         storage: Vec::new(),
+        backup_jobs: Vec::new(),
     };
 
     for r in resources {
@@ -137,6 +159,11 @@ pub async fn export_state<C: StateReadView + ?Sized>(
                 state.storage = export_storage(client)
                     .await
                     .with_context(|| "exporting storage")?;
+            }
+            Resource::BackupJobs => {
+                state.backup_jobs = export_backup_jobs(client)
+                    .await
+                    .with_context(|| "exporting backup-jobs")?;
             }
         }
     }
@@ -246,6 +273,46 @@ async fn export_storage<C: StateReadView + ?Sized>(client: &C) -> Result<Vec<Sto
             username: s.username,
             vgname: s.vgname,
             thinpool: s.thinpool,
+        })
+        .collect())
+}
+
+/// Read every scheduled (recurring) backup job and project to
+/// `Vec<BackupJobDecl>`. Sorted by `id` (the operator/PVE-assigned
+/// job id, unique cluster-wide) for diff-stability.
+///
+/// Two PVE response fields are deliberately dropped:
+/// * `next-run` — scheduler-computed epoch of the next fire. The
+///   backup-job analogue of storage's `digest`: pure derived state
+///   that would churn the TOML on every export even when the job
+///   hasn't changed.
+/// * `mailnotification` — deprecated in PVE 8+ in favour of the
+///   notification-target system; not a field operators manage
+///   declaratively here, so it stays unmanaged rather than being
+///   round-tripped (and possibly rejected) on apply.
+async fn export_backup_jobs<C: StateReadView + ?Sized>(client: &C) -> Result<Vec<BackupJobDecl>> {
+    let mut jobs = client
+        .list_backup_jobs_view()
+        .await
+        .context("listing backup jobs")?;
+    jobs.sort_by(|a, b| a.id.cmp(&b.id));
+
+    Ok(jobs
+        .into_iter()
+        .map(|j| BackupJobDecl {
+            id: j.id,
+            schedule: j.schedule,
+            storage: j.storage,
+            mode: j.mode,
+            enabled: j.enabled,
+            all: j.all,
+            vmid: j.vmid,
+            node: j.node,
+            mailto: j.mailto,
+            compress: j.compress,
+            comment: j.comment,
+            notes_template: j.notes_template,
+            prune_backups: j.prune_backups,
         })
         .collect())
 }
@@ -408,7 +475,53 @@ mod tests {
         // a `--resource all` export hits resources in a deterministic
         // sequence regardless of input ordering.
         let v = Resource::parse("all").unwrap();
-        assert_eq!(v, vec![Resource::Pools, Resource::Acl, Resource::Storage]);
+        assert_eq!(
+            v,
+            vec![
+                Resource::Pools,
+                Resource::Acl,
+                Resource::Storage,
+                Resource::BackupJobs
+            ]
+        );
+        // `parse("all")` and `Resource::all()` must stay in lockstep —
+        // the latter is what `state diff` / `state apply` use to build
+        // the live snapshot. If they diverge, a family could be diffed
+        // but never fetched (perpetual-create bug).
+        assert_eq!(v, Resource::all());
+    }
+
+    #[test]
+    fn resource_all_includes_every_variant() {
+        // Guards the diff/apply live-fetch set: every family the
+        // exporter knows must be in `all()`, or its declared entries
+        // would diff as perpetual creates (they'd never appear in the
+        // live snapshot diff/apply compares against).
+        let all = Resource::all();
+        for r in [
+            Resource::Pools,
+            Resource::Acl,
+            Resource::Storage,
+            Resource::BackupJobs,
+        ] {
+            assert!(all.contains(&r), "Resource::all() is missing {r:?}");
+        }
+    }
+
+    #[test]
+    fn resource_parse_accepts_backup_jobs_hyphenated() {
+        // The CLI value is hyphenated (`backup-jobs`), matching the
+        // `as_str()` round-trip and PVE's own `/cluster/backup`
+        // resource. Case-insensitive like the others.
+        assert_eq!(
+            Resource::parse("backup-jobs").unwrap(),
+            vec![Resource::BackupJobs]
+        );
+        assert_eq!(
+            Resource::parse("Backup-Jobs").unwrap(),
+            vec![Resource::BackupJobs]
+        );
+        assert_eq!(Resource::BackupJobs.as_str(), "backup-jobs");
     }
 
     #[test]
@@ -434,6 +547,7 @@ mod tests {
         details: std::collections::HashMap<String, PoolDetails>,
         acl: Vec<AclEntry>,
         storage: Vec<StorageDefinition>,
+        backup_jobs: Vec<BackupJob>,
     }
 
     #[async_trait]
@@ -452,6 +566,9 @@ mod tests {
         }
         async fn list_cluster_storages_view(&self) -> Result<Vec<StorageDefinition>> {
             Ok(self.storage.clone())
+        }
+        async fn list_backup_jobs_view(&self) -> Result<Vec<BackupJob>> {
+            Ok(self.backup_jobs.clone())
         }
         async fn get_api_version_view(&self) -> Result<ApiVersion> {
             Ok(ApiVersion {
@@ -774,5 +891,81 @@ mod tests {
             !toml_str.contains("abc123"),
             "digest value must not survive export, got:\n{toml_str}"
         );
+    }
+
+    #[tokio::test]
+    async fn export_backup_jobs_sorts_by_id() {
+        // PVE's `/cluster/backup` order is creation order; the export
+        // must canonicalise to alphabetical by `id` so the TOML is
+        // byte-stable across runs.
+        let mut fake = FakeStateView::default();
+        fake.backup_jobs = vec![
+            BackupJob {
+                id: "weekly-prod".into(),
+                schedule: "sun 01:00".into(),
+                storage: "pbs".into(),
+                ..Default::default()
+            },
+            BackupJob {
+                id: "daily-all".into(),
+                schedule: "*-*-* 02:00".into(),
+                storage: "local".into(),
+                ..Default::default()
+            },
+            BackupJob {
+                id: "hourly-db".into(),
+                schedule: "*-*-* *:00".into(),
+                storage: "pbs".into(),
+                ..Default::default()
+            },
+        ];
+        let out = export_backup_jobs(&fake).await.expect("export");
+        let ids: Vec<&str> = out.iter().map(|j| j.id.as_str()).collect();
+        assert_eq!(ids, vec!["daily-all", "hourly-db", "weekly-prod"]);
+    }
+
+    #[tokio::test]
+    async fn export_backup_jobs_drops_next_run_and_mailnotification() {
+        // `next-run` is scheduler-derived (would churn the TOML) and
+        // `mailnotification` is deprecated/unmanaged — neither is a
+        // `BackupJobDecl` field, so neither may survive the export.
+        let mut fake = FakeStateView::default();
+        fake.backup_jobs = vec![BackupJob {
+            id: "nightly".into(),
+            schedule: "*-*-* 03:00".into(),
+            storage: "local".into(),
+            mailnotification: "always".into(),
+            next_run: 1_900_000_000,
+            ..Default::default()
+        }];
+        let out = export_backup_jobs(&fake).await.expect("export");
+        assert_eq!(out.len(), 1);
+        let toml_str = toml::to_string(&out[0]).expect("serialize");
+        assert!(
+            !toml_str.contains("next") && !toml_str.contains("1900000000"),
+            "next-run must not survive export, got:\n{toml_str}"
+        );
+        assert!(
+            !toml_str.contains("mailnotification") && !toml_str.contains("always"),
+            "mailnotification must not survive export, got:\n{toml_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_backup_jobs_preserves_enabled_and_all_selectors() {
+        // The two booleans carry real intent: a disabled job and the
+        // `all`-guests selector. Pin that both survive the projection.
+        let mut fake = FakeStateView::default();
+        fake.backup_jobs = vec![BackupJob {
+            id: "j".into(),
+            schedule: "daily".into(),
+            storage: "local".into(),
+            enabled: false,
+            all: true,
+            ..Default::default()
+        }];
+        let out = export_backup_jobs(&fake).await.expect("export");
+        assert!(!out[0].enabled, "disabled flag must survive");
+        assert!(out[0].all, "all-guests selector must survive");
     }
 }

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -53,6 +53,16 @@ pub struct ClusterState {
     /// pollute the TOML with empty `server=""`/`pool=""` lines.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub storage: Vec<StorageDecl>,
+
+    /// Cluster backup (vzdump) jobs — `GET /cluster/backup`. Identity
+    /// is the `id` field. PVE autogenerates an id when none is given
+    /// on create, but it ALSO accepts a caller-supplied id — so a
+    /// declared state pins a stable `id` (e.g. `nightly-all`) and
+    /// re-apply is idempotent. The volatile `next-run` field is
+    /// deliberately NOT modelled (like storage's `digest`): it's
+    /// scheduler-computed, not desired state, and would churn the TOML.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub backup_jobs: Vec<BackupJobDecl>,
 }
 
 /// Metadata header emitted by the export layer. Captures *which*
@@ -139,6 +149,72 @@ const fn default_true() -> bool {
 #[allow(clippy::trivially_copy_pass_by_ref)]
 const fn is_false(b: &bool) -> bool {
     !*b
+}
+
+/// Companion to [`is_false`] — skip-serialize a bool that defaults to
+/// `true`, so the common case (an *enabled* backup job) omits the line.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_true(b: &bool) -> bool {
+    *b
+}
+
+/// One cluster backup (vzdump) job — `GET /cluster/backup`. The `id`
+/// is the identity; everything else is value.
+///
+/// Modelled fields are the ones an operator manages declaratively.
+/// Deliberately NOT exported:
+/// * `next-run` — scheduler-computed (Unix epoch of the next fire),
+///   the backup-job analogue of storage's `digest`. Including it would
+///   churn the TOML on every export even when the job is unchanged.
+///
+/// Selector semantics: a job targets either ALL guests (`all = true`)
+/// or an explicit `vmid` CSV. The two are mutually exclusive in PVE;
+/// the apply layer sends whichever is set.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BackupJobDecl {
+    /// Job id — the identity. Stable across re-apply. Operators pick a
+    /// readable one (`nightly-all`, `weekly-prod`); PVE accepts it on
+    /// create instead of autogenerating.
+    pub id: String,
+    /// systemd-time schedule expression, e.g. `mon..fri 02:00`,
+    /// `*-*-* 03:30`.
+    pub schedule: String,
+    /// Target storage id (e.g. `local`, `pbs-prod`).
+    pub storage: String,
+    /// `snapshot` (default) | `stop` | `suspend`. Omitted from the
+    /// TOML when empty; the apply layer lets PVE default it.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub mode: String,
+    /// Whether the job runs. Defaults to `true` (PVE's default on
+    /// create), so an enabled job omits the line; a disabled job
+    /// emits `enabled = false`.
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    pub enabled: bool,
+    /// `true` = back up every guest. Mutually exclusive with `vmid`.
+    #[serde(skip_serializing_if = "is_false")]
+    pub all: bool,
+    /// CSV of VMIDs when `all` is false.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub vmid: String,
+    /// Restrict to a single node by name. Empty = cluster-wide.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub node: String,
+    /// Notify destination — single email address. Empty = no mail.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub mailto: String,
+    /// `none` | `lzo` | `gzip` | `zstd`. Empty = PVE default (`zstd`).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub compress: String,
+    /// Free-text job comment.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub comment: String,
+    /// vzdump notes template (`{{guestname}}`, `{{cluster}}`, …).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub notes_template: String,
+    /// Retention DSL: `keep-last=3,keep-daily=7,keep-monthly=12`.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub prune_backups: String,
 }
 
 /// One cluster-wide storage definition — `GET /storage`. The
@@ -243,6 +319,7 @@ mod tests {
             pools: vec![p],
             acl: vec![],
             storage: vec![],
+            backup_jobs: vec![],
         };
         let toml_str = toml::to_string(&s).expect("serialize");
         // No "comment = " line, no "members = " line — only poolid.
@@ -284,6 +361,7 @@ mod tests {
             }),
             acl: vec![],
             storage: vec![],
+            backup_jobs: vec![],
             pools: vec![
                 PoolDecl {
                     poolid: "p1".into(),
@@ -334,6 +412,7 @@ roleid = "PVEVMAdmin"
             pools: vec![],
             acl: vec![entry.clone()],
             storage: vec![],
+            backup_jobs: vec![],
         };
         let toml_str = toml::to_string(&s).expect("serialize");
         let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");
@@ -463,6 +542,7 @@ propagate = false
             pools: vec![],
             acl: vec![],
             storage: entries.clone(),
+            backup_jobs: vec![],
         };
         let toml_str = toml::to_string(&s).expect("serialize");
         let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");

--- a/src/state/preflight.rs
+++ b/src/state/preflight.rs
@@ -19,6 +19,7 @@
 //! | [`StateRisk::StorageDeleteShared`] | Severe — shared storages typically host live guest disks. |
 //! | [`StateRisk::StoragePropertyChange { what }`] | Warning — content-list or path changes can break running guests. |
 //! | [`StateRisk::AclPropagateFlip`]   | Warning — `propagate` change cascades to every descendant path. |
+//! | [`StateRisk::BackupJobDelete`]    | Warning — guests silently stop being backed up; nothing breaks now, the safety net just disappears. |
 //! | [`StateRisk::BulkChangeCount { n }`] | Notice → Warning if `n ≥ 10`, Severe if `n ≥ 50` (very large batches = high attention cost). |
 //!
 //! ## Decision contract
@@ -82,6 +83,11 @@ pub enum StateRisk {
         new_value: bool,
     },
 
+    /// Delete of a scheduled backup job. The guests it covered stop
+    /// being backed up — a silent loss of data protection (no error,
+    /// no immediate breakage, just an absent safety net).
+    BackupJobDelete { id: String },
+
     /// Very-large-batch warning. Increases attention cost
     /// proportionally; defer with `--allow-risk` if intentional.
     BulkChangeCount { n: usize },
@@ -97,7 +103,8 @@ impl StateRisk {
             | Self::StorageDeleteShared { .. } => RiskLevel::Severe,
             Self::StoragePropertyChange { .. }
             | Self::AclPropagateFlip { .. }
-            | Self::AclDeleteAuditor { .. } => RiskLevel::Warning,
+            | Self::AclDeleteAuditor { .. }
+            | Self::BackupJobDelete { .. } => RiskLevel::Warning,
             Self::BulkChangeCount { n } => {
                 if *n >= 50 {
                     RiskLevel::Severe
@@ -144,6 +151,10 @@ impl StateRisk {
             } => format!(
                 "ACL grant on `{path}` for `{ugid}`: propagate → {new_value} — \
                  cascades to every descendant path"
+            ),
+            Self::BackupJobDelete { id } => format!(
+                "delete backup job `{id}` — the guests it covered will \
+                 silently stop being backed up"
             ),
             Self::BulkChangeCount { n } => {
                 format!("{n} changes in one apply — attention cost proportional")
@@ -273,6 +284,14 @@ fn assess_one(change: &Change, live: &ClusterState) -> Vec<StateRisk> {
                 }
             }
         }
+        (ChangeKind::Delete, "backup_job") => {
+            // Deleting a backup job is silent data-protection loss:
+            // no error, nothing breaks now, the covered guests just
+            // stop being backed up. Always warn (identity is the id).
+            out.push(StateRisk::BackupJobDelete {
+                id: change.identity.clone(),
+            });
+        }
         _ => {}
     }
     out
@@ -394,6 +413,7 @@ mod tests {
                     ..Default::default()
                 },
             ],
+            backup_jobs: vec![],
         }
     }
 
@@ -488,6 +508,42 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn backup_job_delete_is_warning() {
+        // Deleting a backup job is silent data-protection loss — it
+        // must surface as a Warning even though the live lookup finds
+        // nothing operationally "broken".
+        let live = sample_live();
+        let changes = vec![delete_change("backup_job", "nightly-all")];
+        let risks = assess(&changes, &live);
+        assert_eq!(risks.len(), 1);
+        assert_eq!(risks[0].level(), RiskLevel::Warning);
+        assert!(matches!(&risks[0], StateRisk::BackupJobDelete { id } if id == "nightly-all"));
+    }
+
+    #[test]
+    fn backup_job_create_and_update_are_clean() {
+        // Adding or editing a job is not a risk at this layer — only
+        // deletion (the safety-net removal) is flagged.
+        let live = sample_live();
+        let create = Change {
+            kind: ChangeKind::Create,
+            resource: "backup_job",
+            identity: "new".to_string(),
+            before: None,
+            after: Some(serde_json::json!({"id": "new"})),
+        };
+        let update = Change {
+            kind: ChangeKind::Update,
+            resource: "backup_job",
+            identity: "new".to_string(),
+            before: Some(serde_json::json!({"schedule": "daily"})),
+            after: Some(serde_json::json!({"schedule": "weekly"})),
+        };
+        assert!(assess(&[create], &live).is_empty());
+        assert!(assess(&[update], &live).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wires **scheduled backup jobs** (`/cluster/backup`) through the full `state` GitOps loop — export, diff, apply (create/update/delete) — so recurring vzdump jobs are managed declaratively alongside pools, ACL grants, and storage definitions. Continues epic #74.

- **model** — `BackupJobDecl` + `ClusterState.backup_jobs`. Drops the scheduler-derived `next-run` and the deprecated `mailnotification` on export so the TOML stays diff-stable; `enabled` defaults true (skip-serialized), `all` XOR `vmid` selector.
- **export** — `state export --resource backup-jobs` (and `all`), sorted by `id` for byte-stable output.
- **diff / apply** — `backup_job` create/update/delete mirroring the storage path; `enabled` always sent as `0/1`, hyphenated `notes-template` / `prune-backups`.
- **preflight** — deleting a backup job is a **Warning**: silent loss of data protection (no error, nothing breaks now, the safety net just disappears).

## Bug fix surfaced by live testing

`state diff` and `state apply` hardcoded their live-fetch set to `pools/acl/storage`, so any declared backup job diffed as a **perpetual create** and updates/deletes were never detected against live. Both now route through a single new `Resource::all()` — a newly-added family can no longer be silently omitted from the comparison snapshot.

## Verification

Verified **end-to-end against PVE 9.1.1** (live `test` cluster):

- `export --resource backup-jobs` / `all` → valid TOML
- `diff` detects create / update / delete
- `apply` create → export confirms → re-diff clean (round-trip stable)
- `apply` update (schedule change) → confirmed live
- `apply --prune` delete → **new Warning fired** + job removed; final round-trip clean
- cluster restored to original state

+21 unit tests (563 lib total). Pre-commit gate **PASSED in 488s** (fmt, clippy(pedantic), audit, deny, release test, 87 live read probes, full mutation lifecycle PASS=47/FAIL=0).

## Test plan

- [x] `cargo test --lib state` (83 pass)
- [x] `cargo clippy --all-targets` clean
- [x] live export → diff → apply create/update/delete against PVE 9.1.1
- [x] full pre-commit gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)