### PR TITLE
feat(state): cluster firewall as a managed resource family (epic #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ SemVer contract:
   field are dropped on export so the TOML stays diff-stable. Deleting a
   backup job is flagged as a **Warning** by the pre-flight gate (silent
   loss of data protection). `--resource all` now includes backup jobs.
+- **`state` now manages the cluster firewall** (epic #74). A new
+  `firewall-cluster` resource family covers the whole writable surface
+  in one selector: the **options** singleton (enable / default policy /
+  ebtables / log-ratelimit), **aliases**, **IP sets** (with nested CIDR
+  membership), and **security groups**. Export is diff-stable (sets +
+  CIDRs sorted; derived `ipversion`/`digest` dropped). Apply handles the
+  awkward PVE semantics: an IP-set comment change has no update endpoint
+  so it's a lossless delete+recreate, while CIDR membership is an
+  incremental add/remove delta; security groups are create/delete only
+  (no PVE update, and their rules are read-only, so a recreate would
+  drop them). Pre-flight gates the dangerous moves: disabling the
+  firewall or deleting a security group are **Severe**; loosening a
+  default policy to ACCEPT and deleting aliases / IP sets are
+  **Warnings**. `--resource all` now includes the firewall.
 
 ## [0.4.0] — 2026-05-21
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -191,7 +191,7 @@ within a major version.
 
 | Command | What it does |
 | :--- | :--- |
-| `proxxx state export [--resource pools\|acl\|storage\|backup-jobs\|all] [--output toml\|json]` | Byte-stable snapshot of cluster state. Default emits TOML; `--output json` for piping. Diff-stable across runs against an unchanged cluster. |
+| `proxxx state export [--resource pools\|acl\|storage\|backup-jobs\|firewall-cluster\|all] [--output toml\|json]` | Byte-stable snapshot of cluster state. Default emits TOML; `--output json` for piping. `firewall-cluster` covers options + aliases + IP sets + security groups. Diff-stable across runs against an unchanged cluster. |
 | `proxxx state diff <declared.toml> [--output text\|json]` | Structural diff of declared vs live. Exit 2 on drift. |
 | `proxxx state apply <declared.toml> [--dry-run] [--prune] [--continue-on-error] [--allow-risk] [--interactive] [--output text\|json]` | Converge live toward declared. Pre-flight risk gate refuses Severe changes (non-empty pool delete, root-role ACL delete, shared-storage delete, batch ≥ 50) without `--allow-risk`. `--interactive` adds per-Severe `[y/N]` stdin prompts. Exit code 6 on refusal. |
 

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -3,8 +3,9 @@
 //! toward declared.
 //!
 //! Resource families covered today: pools, ACL grants, cluster
-//! storage definitions, scheduled backup jobs. Cluster firewall,
-//! notifications, and HA groups land in follow-up PRs tracked by epic
+//! storage definitions, scheduled backup jobs, and the cluster
+//! firewall (options + aliases + IP sets + security groups).
+//! Notifications and HA groups land in follow-up PRs tracked by epic
 //! [#74](https://github.com/fabriziosalmi/proxxx/issues/74). Pre-flight
 //! risk gates + HITL approval per destructive change are wired (shipped
 //! v0.3.0): `state::preflight` refuses Severe changes unless
@@ -39,8 +40,8 @@ pub enum StateCommand {
     /// Export the cluster's mutable state.
     ///
     /// Supported resources: `pools`, `acl`, `storage`, `backup-jobs`,
-    /// `all` (every supported family). More (firewall-cluster,
-    /// notifications, HA groups) land per the ladder in epic #74.
+    /// `firewall-cluster`, `all` (every supported family). More
+    /// (notifications, HA groups) land per the ladder in epic #74.
     ///
     /// The resulting document is byte-stable across runs against an
     /// unchanged cluster — every collection is sorted by its identity
@@ -53,7 +54,8 @@ pub enum StateCommand {
     ///   proxxx state export --output json | jq '.pools[0]'  # programmatic
     Export {
         /// Resource family to export. Valid: `pools`, `acl`, `storage`,
-        /// `backup-jobs`, `all`. More families coming — see issue #74.
+        /// `backup-jobs`, `firewall-cluster`, `all`. More families
+        /// coming — see issue #74.
         #[arg(long, default_value = "pools")]
         resource: String,
 

--- a/src/state/apply.rs
+++ b/src/state/apply.rs
@@ -32,6 +32,10 @@
 //! | ACL | ✓ | ✓ (delete + recreate with new propagate) | ✓ |
 //! | Storage | ✓ | ✓ (mutable fields only) | ✓ |
 //! | Backup job | ✓ | ✓ (all mutable fields) | ✓ |
+//! | Firewall options | — | ✓ (singleton, update-only) | — |
+//! | Firewall alias | ✓ | ✓ (cidr + comment) | ✓ |
+//! | Firewall ipset | ✓ | ✓ (comment → recreate; CIDR delta) | ✓ |
+//! | Firewall group | ✓ | — (no PVE update; rules read-only) | ✓ |
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -39,7 +43,10 @@ use serde::Serialize;
 
 use crate::api::types::{Pool, PoolDetails};
 use crate::state::diff::{Change, ChangeKind};
-use crate::state::model::{AclDecl, BackupJobDecl, PoolDecl, StorageDecl};
+use crate::state::model::{
+    AclDecl, BackupJobDecl, FirewallAliasDecl, FirewallGroupDecl, FirewallIpsetCidrDecl,
+    FirewallIpsetDecl, FirewallOptionsDecl, PoolDecl, StorageDecl,
+};
 
 /// Options controlling apply behaviour.
 #[derive(Debug, Clone, Copy, Default)]
@@ -134,6 +141,26 @@ pub trait StateWriteView: Send + Sync {
     async fn create_backup_job_view(&self, params: &[(&str, &str)]) -> Result<()>;
     async fn update_backup_job_view(&self, id: &str, params: &[(&str, &str)]) -> Result<()>;
     async fn delete_backup_job_view(&self, id: &str) -> Result<()>;
+
+    // ── Cluster-firewall surface ──────────────────────────
+    async fn update_cluster_firewall_options_view(&self, params: &[(&str, &str)]) -> Result<()>;
+    async fn create_cluster_firewall_alias_view(&self, params: &[(&str, &str)]) -> Result<()>;
+    async fn update_cluster_firewall_alias_view(
+        &self,
+        name: &str,
+        params: &[(&str, &str)],
+    ) -> Result<()>;
+    async fn delete_cluster_firewall_alias_view(&self, name: &str) -> Result<()>;
+    async fn create_cluster_firewall_ipset_view(&self, params: &[(&str, &str)]) -> Result<()>;
+    async fn delete_cluster_firewall_ipset_view(&self, name: &str) -> Result<()>;
+    async fn add_cluster_firewall_ipset_cidr_view(
+        &self,
+        name: &str,
+        params: &[(&str, &str)],
+    ) -> Result<()>;
+    async fn remove_cluster_firewall_ipset_cidr_view(&self, name: &str, cidr: &str) -> Result<()>;
+    async fn create_cluster_firewall_group_view(&self, params: &[(&str, &str)]) -> Result<()>;
+    async fn delete_cluster_firewall_group_view(&self, group: &str) -> Result<()>;
 }
 
 #[async_trait]
@@ -195,6 +222,45 @@ where
 
     async fn delete_cluster_storage_view(&self, storage: &str) -> Result<()> {
         crate::api::ProxmoxGateway::delete_cluster_storage(self, storage).await
+    }
+
+    async fn update_cluster_firewall_options_view(&self, params: &[(&str, &str)]) -> Result<()> {
+        crate::api::ProxmoxGateway::update_cluster_firewall_options(self, params).await
+    }
+    async fn create_cluster_firewall_alias_view(&self, params: &[(&str, &str)]) -> Result<()> {
+        crate::api::ProxmoxGateway::create_cluster_firewall_alias(self, params).await
+    }
+    async fn update_cluster_firewall_alias_view(
+        &self,
+        name: &str,
+        params: &[(&str, &str)],
+    ) -> Result<()> {
+        crate::api::ProxmoxGateway::update_cluster_firewall_alias(self, name, params).await
+    }
+    async fn delete_cluster_firewall_alias_view(&self, name: &str) -> Result<()> {
+        crate::api::ProxmoxGateway::delete_cluster_firewall_alias(self, name).await
+    }
+    async fn create_cluster_firewall_ipset_view(&self, params: &[(&str, &str)]) -> Result<()> {
+        crate::api::ProxmoxGateway::create_cluster_firewall_ipset(self, params).await
+    }
+    async fn delete_cluster_firewall_ipset_view(&self, name: &str) -> Result<()> {
+        crate::api::ProxmoxGateway::delete_cluster_firewall_ipset(self, name).await
+    }
+    async fn add_cluster_firewall_ipset_cidr_view(
+        &self,
+        name: &str,
+        params: &[(&str, &str)],
+    ) -> Result<()> {
+        crate::api::ProxmoxGateway::add_cluster_firewall_ipset_cidr(self, name, params).await
+    }
+    async fn remove_cluster_firewall_ipset_cidr_view(&self, name: &str, cidr: &str) -> Result<()> {
+        crate::api::ProxmoxGateway::remove_cluster_firewall_ipset_cidr(self, name, cidr).await
+    }
+    async fn create_cluster_firewall_group_view(&self, params: &[(&str, &str)]) -> Result<()> {
+        crate::api::ProxmoxGateway::create_cluster_firewall_group(self, params).await
+    }
+    async fn delete_cluster_firewall_group_view(&self, group: &str) -> Result<()> {
+        crate::api::ProxmoxGateway::delete_cluster_firewall_group(self, group).await
     }
 }
 
@@ -265,6 +331,15 @@ async fn apply_one<C: StateWriteView + ?Sized>(client: &C, change: &Change) -> A
         ("backup_job", ChangeKind::Create) => apply_backupjob_create(client, change).await,
         ("backup_job", ChangeKind::Update) => apply_backupjob_update(client, change).await,
         ("backup_job", ChangeKind::Delete) => apply_backupjob_delete(client, change).await,
+        ("firewall_options", ChangeKind::Update) => apply_fw_options_update(client, change).await,
+        ("firewall_alias", ChangeKind::Create) => apply_fw_alias_create(client, change).await,
+        ("firewall_alias", ChangeKind::Update) => apply_fw_alias_update(client, change).await,
+        ("firewall_alias", ChangeKind::Delete) => apply_fw_alias_delete(client, change).await,
+        ("firewall_ipset", ChangeKind::Create) => apply_fw_ipset_create(client, change).await,
+        ("firewall_ipset", ChangeKind::Update) => apply_fw_ipset_update(client, change).await,
+        ("firewall_ipset", ChangeKind::Delete) => apply_fw_ipset_delete(client, change).await,
+        ("firewall_group", ChangeKind::Create) => apply_fw_group_create(client, change).await,
+        ("firewall_group", ChangeKind::Delete) => apply_fw_group_delete(client, change).await,
         (resource, kind) => Err(anyhow::anyhow!(
             "unhandled change shape: resource={resource} kind={kind:?}"
         )),
@@ -680,6 +755,223 @@ async fn apply_backupjob_delete<C: StateWriteView + ?Sized>(
     client.delete_backup_job_view(&decl.id).await
 }
 
+// ── Cluster firewall ─────────────────────────────────────────
+
+fn decode<T: serde::de::DeserializeOwned>(v: Option<&serde_json::Value>, what: &str) -> Result<T> {
+    let val = v
+        .cloned()
+        .with_context(|| format!("{what}: missing value"))?;
+    serde_json::from_value(val).with_context(|| format!("decoding {what}"))
+}
+
+fn borrow(params: &[(String, String)]) -> Vec<(&str, &str)> {
+    params
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect()
+}
+
+/// Update the firewall options singleton. `enable` and `ebtables` are
+/// always sent (0/1) — the declared block is authoritative, so an
+/// omitted bool means "off". Policy / ratelimit strings are sent only
+/// when non-empty (empty = leave PVE's current value).
+async fn apply_fw_options_update<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let after: FirewallOptionsDecl = decode(change.after.as_ref(), "firewall options")?;
+    let mut params: Vec<(String, String)> = Vec::new();
+    params.push((
+        "enable".to_string(),
+        if after.enable { "1" } else { "0" }.to_string(),
+    ));
+    params.push((
+        "ebtables".to_string(),
+        if after.ebtables { "1" } else { "0" }.to_string(),
+    ));
+    push_optional(&mut params, "policy_in", &after.policy_in);
+    push_optional(&mut params, "policy_out", &after.policy_out);
+    push_optional(&mut params, "log_ratelimit", &after.log_ratelimit);
+    client
+        .update_cluster_firewall_options_view(&borrow(&params))
+        .await
+}
+
+fn fw_alias_params(decl: &FirewallAliasDecl, include_name: bool) -> Vec<(String, String)> {
+    let mut params: Vec<(String, String)> = Vec::new();
+    if include_name {
+        params.push(("name".to_string(), decl.name.clone()));
+    }
+    params.push(("cidr".to_string(), decl.cidr.clone()));
+    push_optional(&mut params, "comment", &decl.comment);
+    params
+}
+
+async fn apply_fw_alias_create<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: FirewallAliasDecl = decode(change.after.as_ref(), "firewall alias")?;
+    let params = fw_alias_params(&decl, true);
+    client
+        .create_cluster_firewall_alias_view(&borrow(&params))
+        .await
+}
+
+async fn apply_fw_alias_update<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let after: FirewallAliasDecl = decode(change.after.as_ref(), "firewall alias")?;
+    let params = fw_alias_params(&after, false);
+    client
+        .update_cluster_firewall_alias_view(&after.name, &borrow(&params))
+        .await
+}
+
+async fn apply_fw_alias_delete<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: FirewallAliasDecl = decode(change.before.as_ref(), "firewall alias")?;
+    client.delete_cluster_firewall_alias_view(&decl.name).await
+}
+
+fn fw_cidr_params(c: &FirewallIpsetCidrDecl) -> Vec<(String, String)> {
+    let mut params: Vec<(String, String)> = vec![("cidr".to_string(), c.cidr.clone())];
+    push_optional(&mut params, "comment", &c.comment);
+    if c.nomatch {
+        params.push(("nomatch".to_string(), "1".to_string()));
+    }
+    params
+}
+
+/// Create an IP set, then add every declared CIDR. Order: the set must
+/// exist before its members can be attached.
+async fn apply_fw_ipset_create<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: FirewallIpsetDecl = decode(change.after.as_ref(), "firewall ipset")?;
+    let mut set_params: Vec<(String, String)> = vec![("name".to_string(), decl.name.clone())];
+    push_optional(&mut set_params, "comment", &decl.comment);
+    client
+        .create_cluster_firewall_ipset_view(&borrow(&set_params))
+        .await?;
+    for c in &decl.cidrs {
+        let p = fw_cidr_params(c);
+        client
+            .add_cluster_firewall_ipset_cidr_view(&decl.name, &borrow(&p))
+            .await?;
+    }
+    Ok(())
+}
+
+/// Delete an IP set. Members are removed first (some PVE versions
+/// refuse to delete a non-empty set), then the set itself.
+async fn apply_fw_ipset_delete<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: FirewallIpsetDecl = decode(change.before.as_ref(), "firewall ipset")?;
+    for c in &decl.cidrs {
+        client
+            .remove_cluster_firewall_ipset_cidr_view(&decl.name, &c.cidr)
+            .await?;
+    }
+    client.delete_cluster_firewall_ipset_view(&decl.name).await
+}
+
+/// Reconcile an IP set update. A `comment` change forces delete+
+/// recreate (PVE has no set-update endpoint) — the declared CIDRs are
+/// re-added afterwards, so it's lossless. When only the membership
+/// changed, apply the minimal CIDR delta (a changed entry = remove +
+/// re-add, since CIDR entries have no in-place update either).
+async fn apply_fw_ipset_update<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    use std::collections::HashMap;
+    let before: FirewallIpsetDecl = decode(change.before.as_ref(), "firewall ipset")?;
+    let after: FirewallIpsetDecl = decode(change.after.as_ref(), "firewall ipset")?;
+
+    if before.comment != after.comment {
+        // No set-update endpoint: delete (members first) then recreate
+        // with the new comment and re-add every declared CIDR.
+        for c in &before.cidrs {
+            client
+                .remove_cluster_firewall_ipset_cidr_view(&before.name, &c.cidr)
+                .await?;
+        }
+        client
+            .delete_cluster_firewall_ipset_view(&before.name)
+            .await?;
+        let mut set_params: Vec<(String, String)> = vec![("name".to_string(), after.name.clone())];
+        push_optional(&mut set_params, "comment", &after.comment);
+        client
+            .create_cluster_firewall_ipset_view(&borrow(&set_params))
+            .await?;
+        for c in &after.cidrs {
+            let p = fw_cidr_params(c);
+            client
+                .add_cluster_firewall_ipset_cidr_view(&after.name, &borrow(&p))
+                .await?;
+        }
+        return Ok(());
+    }
+
+    // Comment unchanged: incremental CIDR delta keyed on the cidr string.
+    let before_by: HashMap<&str, &FirewallIpsetCidrDecl> =
+        before.cidrs.iter().map(|c| (c.cidr.as_str(), c)).collect();
+    let after_by: HashMap<&str, &FirewallIpsetCidrDecl> =
+        after.cidrs.iter().map(|c| (c.cidr.as_str(), c)).collect();
+
+    // Remove entries that vanished or whose attributes changed.
+    for bc in &before.cidrs {
+        match after_by.get(bc.cidr.as_str()) {
+            Some(ac) if *ac == bc => {}
+            _ => {
+                client
+                    .remove_cluster_firewall_ipset_cidr_view(&before.name, &bc.cidr)
+                    .await?;
+            }
+        }
+    }
+    // Add entries that are new or whose attributes changed (re-added).
+    for ac in &after.cidrs {
+        match before_by.get(ac.cidr.as_str()) {
+            Some(bc) if *bc == ac => {}
+            _ => {
+                let p = fw_cidr_params(ac);
+                client
+                    .add_cluster_firewall_ipset_cidr_view(&after.name, &borrow(&p))
+                    .await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn apply_fw_group_create<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: FirewallGroupDecl = decode(change.after.as_ref(), "firewall group")?;
+    let mut params: Vec<(String, String)> = vec![("group".to_string(), decl.group.clone())];
+    push_optional(&mut params, "comment", &decl.comment);
+    client
+        .create_cluster_firewall_group_view(&borrow(&params))
+        .await
+}
+
+async fn apply_fw_group_delete<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: FirewallGroupDecl = decode(change.before.as_ref(), "firewall group")?;
+    client.delete_cluster_firewall_group_view(&decl.group).await
+}
+
 fn push_optional(params: &mut Vec<(String, String)>, key: &str, value: &str) {
     if !value.is_empty() {
         params.push((key.to_string(), value.to_string()));
@@ -801,6 +1093,52 @@ mod tests {
         }
         async fn delete_backup_job_view(&self, id: &str) -> Result<()> {
             self.record(format!("delete_backup_job({id})")).await
+        }
+        async fn update_cluster_firewall_options_view(
+            &self,
+            params: &[(&str, &str)],
+        ) -> Result<()> {
+            self.record(format!("update_fw_options {params:?}")).await
+        }
+        async fn create_cluster_firewall_alias_view(&self, params: &[(&str, &str)]) -> Result<()> {
+            self.record(format!("create_fw_alias {params:?}")).await
+        }
+        async fn update_cluster_firewall_alias_view(
+            &self,
+            name: &str,
+            params: &[(&str, &str)],
+        ) -> Result<()> {
+            self.record(format!("update_fw_alias({name}) {params:?}"))
+                .await
+        }
+        async fn delete_cluster_firewall_alias_view(&self, name: &str) -> Result<()> {
+            self.record(format!("delete_fw_alias({name})")).await
+        }
+        async fn create_cluster_firewall_ipset_view(&self, params: &[(&str, &str)]) -> Result<()> {
+            self.record(format!("create_fw_ipset {params:?}")).await
+        }
+        async fn delete_cluster_firewall_ipset_view(&self, name: &str) -> Result<()> {
+            self.record(format!("delete_fw_ipset({name})")).await
+        }
+        async fn add_cluster_firewall_ipset_cidr_view(
+            &self,
+            name: &str,
+            params: &[(&str, &str)],
+        ) -> Result<()> {
+            self.record(format!("add_fw_cidr({name}) {params:?}")).await
+        }
+        async fn remove_cluster_firewall_ipset_cidr_view(
+            &self,
+            name: &str,
+            cidr: &str,
+        ) -> Result<()> {
+            self.record(format!("remove_fw_cidr({name}, {cidr})")).await
+        }
+        async fn create_cluster_firewall_group_view(&self, params: &[(&str, &str)]) -> Result<()> {
+            self.record(format!("create_fw_group {params:?}")).await
+        }
+        async fn delete_cluster_firewall_group_view(&self, group: &str) -> Result<()> {
+            self.record(format!("delete_fw_group({group})")).await
         }
     }
 
@@ -1101,5 +1439,283 @@ mod tests {
         .await;
         assert!(matches!(out2[0].result, ApplyResult::Applied));
         assert_eq!(c2.lines().await, vec!["delete_backup_job(old)".to_string()]);
+    }
+
+    // ── Cluster firewall ─────────────────────────────────
+
+    fn fw_change(
+        kind: ChangeKind,
+        resource: &'static str,
+        identity: &str,
+        before: Option<serde_json::Value>,
+        after: Option<serde_json::Value>,
+    ) -> Change {
+        Change {
+            kind,
+            resource,
+            identity: identity.to_string(),
+            before,
+            after,
+        }
+    }
+
+    #[tokio::test]
+    async fn fw_options_update_always_sends_enable_and_ebtables() {
+        let after = FirewallOptionsDecl {
+            enable: true,
+            policy_in: "DROP".into(),
+            ebtables: false,
+            ..FirewallOptionsDecl::default()
+        };
+        let c = RecordingClient::default();
+        let change = fw_change(
+            ChangeKind::Update,
+            "firewall_options",
+            "cluster",
+            Some(serde_json::json!({"enable": false})),
+            Some(serde_json::to_value(&after).unwrap()),
+        );
+        let out = apply(&c, vec![change], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let line = &c.lines().await[0];
+        assert!(line.starts_with("update_fw_options"));
+        assert!(line.contains("\"enable\", \"1\""));
+        assert!(line.contains("\"ebtables\", \"0\""), "ebtables always sent");
+        assert!(line.contains("\"policy_in\", \"DROP\""));
+    }
+
+    #[tokio::test]
+    async fn fw_alias_create_and_delete_dispatch() {
+        let decl = FirewallAliasDecl {
+            name: "web".into(),
+            cidr: "10.0.0.0/8".into(),
+            comment: "web tier".into(),
+        };
+        let c = RecordingClient::default();
+        let create = fw_change(
+            ChangeKind::Create,
+            "firewall_alias",
+            "web",
+            None,
+            Some(serde_json::to_value(&decl).unwrap()),
+        );
+        let out = apply(&c, vec![create], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let line = &c.lines().await[0];
+        assert!(line.starts_with("create_fw_alias"));
+        assert!(line.contains("\"name\", \"web\"") && line.contains("\"cidr\", \"10.0.0.0/8\""));
+
+        // delete requires prune
+        let c2 = RecordingClient::default();
+        let delete = fw_change(
+            ChangeKind::Delete,
+            "firewall_alias",
+            "web",
+            Some(serde_json::to_value(&decl).unwrap()),
+            None,
+        );
+        let out2 = apply(
+            &c2,
+            vec![delete],
+            ApplyOptions {
+                prune: true,
+                ..ApplyOptions::default()
+            },
+        )
+        .await;
+        assert!(matches!(out2[0].result, ApplyResult::Applied));
+        assert_eq!(c2.lines().await, vec!["delete_fw_alias(web)".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn fw_ipset_create_fires_create_then_add_per_cidr() {
+        let decl = FirewallIpsetDecl {
+            name: "blocklist".into(),
+            comment: "bad".into(),
+            cidrs: vec![
+                FirewallIpsetCidrDecl {
+                    cidr: "1.2.3.0/24".into(),
+                    ..Default::default()
+                },
+                FirewallIpsetCidrDecl {
+                    cidr: "5.6.7.8".into(),
+                    nomatch: true,
+                    ..Default::default()
+                },
+            ],
+        };
+        let c = RecordingClient::default();
+        let change = fw_change(
+            ChangeKind::Create,
+            "firewall_ipset",
+            "blocklist",
+            None,
+            Some(serde_json::to_value(&decl).unwrap()),
+        );
+        let out = apply(&c, vec![change], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let lines = c.lines().await;
+        assert_eq!(lines.len(), 3, "create + 2 add_cidr");
+        assert!(lines[0].starts_with("create_fw_ipset"));
+        assert!(lines[1].starts_with("add_fw_cidr(blocklist)") && lines[1].contains("1.2.3.0/24"));
+        assert!(lines[2].contains("5.6.7.8") && lines[2].contains("\"nomatch\", \"1\""));
+    }
+
+    #[tokio::test]
+    async fn fw_ipset_delete_removes_cidrs_then_deletes() {
+        let decl = FirewallIpsetDecl {
+            name: "blocklist".into(),
+            comment: String::new(),
+            cidrs: vec![FirewallIpsetCidrDecl {
+                cidr: "1.2.3.0/24".into(),
+                ..Default::default()
+            }],
+        };
+        let c = RecordingClient::default();
+        let change = fw_change(
+            ChangeKind::Delete,
+            "firewall_ipset",
+            "blocklist",
+            Some(serde_json::to_value(&decl).unwrap()),
+            None,
+        );
+        let out = apply(
+            &c,
+            vec![change],
+            ApplyOptions {
+                prune: true,
+                ..ApplyOptions::default()
+            },
+        )
+        .await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        assert_eq!(
+            c.lines().await,
+            vec![
+                "remove_fw_cidr(blocklist, 1.2.3.0/24)".to_string(),
+                "delete_fw_ipset(blocklist)".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn fw_ipset_update_comment_change_recreates_with_cidrs() {
+        // A comment change has no PVE update endpoint → delete (members
+        // first) + recreate + re-add all declared CIDRs.
+        let cidr = FirewallIpsetCidrDecl {
+            cidr: "1.2.3.0/24".into(),
+            ..Default::default()
+        };
+        let before = FirewallIpsetDecl {
+            name: "s".into(),
+            comment: "old".into(),
+            cidrs: vec![cidr.clone()],
+        };
+        let after = FirewallIpsetDecl {
+            name: "s".into(),
+            comment: "new".into(),
+            cidrs: vec![cidr],
+        };
+        let c = RecordingClient::default();
+        let change = fw_change(
+            ChangeKind::Update,
+            "firewall_ipset",
+            "s",
+            Some(serde_json::to_value(&before).unwrap()),
+            Some(serde_json::to_value(&after).unwrap()),
+        );
+        let out = apply(&c, vec![change], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let lines = c.lines().await;
+        assert_eq!(
+            lines,
+            vec![
+                "remove_fw_cidr(s, 1.2.3.0/24)".to_string(),
+                "delete_fw_ipset(s)".to_string(),
+                "create_fw_ipset [(\"name\", \"s\"), (\"comment\", \"new\")]".to_string(),
+                "add_fw_cidr(s) [(\"cidr\", \"1.2.3.0/24\")]".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn fw_ipset_update_cidr_delta_is_minimal() {
+        // Comment unchanged → only the CIDR delta is applied: add the
+        // new one, remove the gone one, leave the unchanged one alone.
+        let mk = |c: &str| FirewallIpsetCidrDecl {
+            cidr: c.into(),
+            ..Default::default()
+        };
+        let before = FirewallIpsetDecl {
+            name: "s".into(),
+            comment: "same".into(),
+            cidrs: vec![mk("1.1.1.0/24"), mk("2.2.2.0/24")],
+        };
+        let after = FirewallIpsetDecl {
+            name: "s".into(),
+            comment: "same".into(),
+            cidrs: vec![mk("1.1.1.0/24"), mk("3.3.3.0/24")],
+        };
+        let c = RecordingClient::default();
+        let change = fw_change(
+            ChangeKind::Update,
+            "firewall_ipset",
+            "s",
+            Some(serde_json::to_value(&before).unwrap()),
+            Some(serde_json::to_value(&after).unwrap()),
+        );
+        let out = apply(&c, vec![change], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let lines = c.lines().await;
+        // No delete_fw_ipset / create_fw_ipset — set stays put.
+        assert!(!lines.iter().any(|l| l.contains("delete_fw_ipset")));
+        assert!(lines.iter().any(|l| l == "remove_fw_cidr(s, 2.2.2.0/24)"));
+        assert!(lines
+            .iter()
+            .any(|l| l.starts_with("add_fw_cidr(s)") && l.contains("3.3.3.0/24")));
+        // 1.1.1.0/24 was unchanged → neither added nor removed.
+        assert!(!lines.iter().any(|l| l.contains("1.1.1.0/24")));
+    }
+
+    #[tokio::test]
+    async fn fw_group_create_and_delete_dispatch() {
+        let decl = FirewallGroupDecl {
+            group: "web-tier".into(),
+            comment: "frontend".into(),
+        };
+        let c = RecordingClient::default();
+        let create = fw_change(
+            ChangeKind::Create,
+            "firewall_group",
+            "web-tier",
+            None,
+            Some(serde_json::to_value(&decl).unwrap()),
+        );
+        let out = apply(&c, vec![create], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        assert!(c.lines().await[0].starts_with("create_fw_group"));
+
+        let c2 = RecordingClient::default();
+        let delete = fw_change(
+            ChangeKind::Delete,
+            "firewall_group",
+            "web-tier",
+            Some(serde_json::to_value(&decl).unwrap()),
+            None,
+        );
+        let out2 = apply(
+            &c2,
+            vec![delete],
+            ApplyOptions {
+                prune: true,
+                ..ApplyOptions::default()
+            },
+        )
+        .await;
+        assert!(matches!(out2[0].result, ApplyResult::Applied));
+        assert_eq!(
+            c2.lines().await,
+            vec!["delete_fw_group(web-tier)".to_string()]
+        );
     }
 }

--- a/src/state/diff.rs
+++ b/src/state/diff.rs
@@ -33,7 +33,10 @@
 
 use serde::Serialize;
 
-use crate::state::model::{AclDecl, BackupJobDecl, ClusterState, PoolDecl, StorageDecl};
+use crate::state::model::{
+    AclDecl, BackupJobDecl, ClusterState, FirewallAliasDecl, FirewallGroupDecl, FirewallIpsetDecl,
+    FirewallOptionsDecl, PoolDecl, StorageDecl,
+};
 
 /// Kind of mutation a change represents. `Create` + `Delete` are
 /// self-evident; `Update` is "identity matches, value differs".
@@ -76,10 +79,12 @@ pub struct Change {
 /// to enforce `--prune` semantics.
 ///
 /// The output order is stable: changes for `pool` first, then `acl`,
-/// then `storage`, then `backup_job`, each family sorted by identity.
-/// Within a family the order is `Delete` (so apply-with-prune teardown
-/// runs before create), then `Update`, then `Create` — but the apply
-/// layer re-orders by dependency where needed.
+/// then `storage`, then `backup_job`, then the firewall families
+/// (`firewall_options`, `firewall_alias`, `firewall_ipset`,
+/// `firewall_group`), each sorted by identity. Within a family the
+/// order is `Delete` (so apply-with-prune teardown runs before create),
+/// then `Update`, then `Create` — but the apply layer re-orders by
+/// dependency where needed.
 #[must_use]
 pub fn diff(declared: &ClusterState, live: &ClusterState) -> Vec<Change> {
     let mut out = Vec::new();
@@ -87,6 +92,14 @@ pub fn diff(declared: &ClusterState, live: &ClusterState) -> Vec<Change> {
     diff_acl(&declared.acl, &live.acl, &mut out);
     diff_storage(&declared.storage, &live.storage, &mut out);
     diff_backup_jobs(&declared.backup_jobs, &live.backup_jobs, &mut out);
+    diff_firewall_options(
+        declared.firewall_options.as_ref(),
+        live.firewall_options.as_ref(),
+        &mut out,
+    );
+    diff_firewall_aliases(&declared.firewall_aliases, &live.firewall_aliases, &mut out);
+    diff_firewall_ipsets(&declared.firewall_ipsets, &live.firewall_ipsets, &mut out);
+    diff_firewall_groups(&declared.firewall_groups, &live.firewall_groups, &mut out);
     out
 }
 
@@ -325,6 +338,196 @@ fn diff_backup_jobs(declared: &[BackupJobDecl], live: &[BackupJobDecl], out: &mu
     }
 }
 
+/// Diff the firewall options singleton. Unlike the list families this
+/// has no create/delete — the firewall always has exactly one options
+/// object. A `None` declared value means "don't manage" (no change). A
+/// `Some` declared value that differs from live yields one `Update`
+/// (identity `"cluster"`).
+fn diff_firewall_options(
+    declared: Option<&FirewallOptionsDecl>,
+    live: Option<&FirewallOptionsDecl>,
+    out: &mut Vec<Change>,
+) {
+    let Some(decl) = declared else {
+        return;
+    };
+    if live == Some(decl) {
+        return;
+    }
+    out.push(Change {
+        kind: ChangeKind::Update,
+        resource: "firewall_options",
+        identity: "cluster".to_string(),
+        before: live.and_then(|l| serde_json::to_value(l).ok()),
+        after: serde_json::to_value(decl).ok(),
+    });
+}
+
+fn diff_firewall_aliases(
+    declared: &[FirewallAliasDecl],
+    live: &[FirewallAliasDecl],
+    out: &mut Vec<Change>,
+) {
+    use std::collections::HashMap;
+    let live_by: HashMap<&str, &FirewallAliasDecl> =
+        live.iter().map(|a| (a.name.as_str(), a)).collect();
+    let decl_by: HashMap<&str, &FirewallAliasDecl> =
+        declared.iter().map(|a| (a.name.as_str(), a)).collect();
+
+    let mut deletes: Vec<_> = live_by
+        .keys()
+        .filter(|k| !decl_by.contains_key(*k))
+        .collect();
+    deletes.sort_unstable();
+    for k in deletes {
+        out.push(Change {
+            kind: ChangeKind::Delete,
+            resource: "firewall_alias",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: None,
+        });
+    }
+
+    let mut updates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| live_by.get(*k).is_some_and(|l| *l != decl_by[*k]))
+        .collect();
+    updates.sort_unstable();
+    for k in updates {
+        out.push(Change {
+            kind: ChangeKind::Update,
+            resource: "firewall_alias",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+
+    let mut creates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| !live_by.contains_key(*k))
+        .collect();
+    creates.sort_unstable();
+    for k in creates {
+        out.push(Change {
+            kind: ChangeKind::Create,
+            resource: "firewall_alias",
+            identity: (*k).to_string(),
+            before: None,
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+}
+
+/// Diff IP sets by `name`. An `Update` carries the full before/after
+/// ipset (comment + CIDR membership); the apply layer decodes both to
+/// compute the minimal API calls (comment change → delete+recreate;
+/// CIDR delta → incremental add/remove).
+fn diff_firewall_ipsets(
+    declared: &[FirewallIpsetDecl],
+    live: &[FirewallIpsetDecl],
+    out: &mut Vec<Change>,
+) {
+    use std::collections::HashMap;
+    let live_by: HashMap<&str, &FirewallIpsetDecl> =
+        live.iter().map(|s| (s.name.as_str(), s)).collect();
+    let decl_by: HashMap<&str, &FirewallIpsetDecl> =
+        declared.iter().map(|s| (s.name.as_str(), s)).collect();
+
+    let mut deletes: Vec<_> = live_by
+        .keys()
+        .filter(|k| !decl_by.contains_key(*k))
+        .collect();
+    deletes.sort_unstable();
+    for k in deletes {
+        out.push(Change {
+            kind: ChangeKind::Delete,
+            resource: "firewall_ipset",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: None,
+        });
+    }
+
+    let mut updates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| live_by.get(*k).is_some_and(|l| *l != decl_by[*k]))
+        .collect();
+    updates.sort_unstable();
+    for k in updates {
+        out.push(Change {
+            kind: ChangeKind::Update,
+            resource: "firewall_ipset",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+
+    let mut creates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| !live_by.contains_key(*k))
+        .collect();
+    creates.sort_unstable();
+    for k in creates {
+        out.push(Change {
+            kind: ChangeKind::Create,
+            resource: "firewall_ipset",
+            identity: (*k).to_string(),
+            before: None,
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+}
+
+/// Diff security groups by `group`. **Create + Delete only** — PVE has
+/// no group-update endpoint and the group's rules are read-only here,
+/// so a comment-only drift on an existing group is deliberately NOT
+/// emitted (applying it would mean delete+recreate, silently dropping
+/// the group's rules). See [`ClusterState::firewall_groups`].
+fn diff_firewall_groups(
+    declared: &[FirewallGroupDecl],
+    live: &[FirewallGroupDecl],
+    out: &mut Vec<Change>,
+) {
+    use std::collections::HashMap;
+    let live_by: HashMap<&str, &FirewallGroupDecl> =
+        live.iter().map(|g| (g.group.as_str(), g)).collect();
+    let decl_by: HashMap<&str, &FirewallGroupDecl> =
+        declared.iter().map(|g| (g.group.as_str(), g)).collect();
+
+    let mut deletes: Vec<_> = live_by
+        .keys()
+        .filter(|k| !decl_by.contains_key(*k))
+        .collect();
+    deletes.sort_unstable();
+    for k in deletes {
+        out.push(Change {
+            kind: ChangeKind::Delete,
+            resource: "firewall_group",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: None,
+        });
+    }
+
+    let mut creates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| !live_by.contains_key(*k))
+        .collect();
+    creates.sort_unstable();
+    for k in creates {
+        out.push(Change {
+            kind: ChangeKind::Create,
+            resource: "firewall_group",
+            identity: (*k).to_string(),
+            before: None,
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+}
+
 /// Human-readable single-line summary of one change. Used by the
 /// CLI's default output mode. Keep it grep-friendly:
 /// `<sigil> <resource>: <identity>`.
@@ -345,7 +548,10 @@ pub fn summary_line(c: &Change) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::model::{AclDecl, BackupJobDecl, ClusterState, PoolDecl, StorageDecl};
+    use crate::state::model::{
+        AclDecl, BackupJobDecl, ClusterState, FirewallAliasDecl, FirewallGroupDecl,
+        FirewallIpsetCidrDecl, FirewallIpsetDecl, FirewallOptionsDecl, PoolDecl, StorageDecl,
+    };
 
     fn empty() -> ClusterState {
         ClusterState::default()
@@ -713,6 +919,172 @@ mod tests {
         };
         let d = diff(&s, &s);
         assert!(d.is_empty());
+    }
+
+    // ── Firewall options (singleton) ──────────────────────
+
+    #[test]
+    fn diff_firewall_options_none_declared_is_no_change() {
+        // A declared state without a [firewall_options] block must not
+        // touch the live firewall, even if live has one.
+        let live = ClusterState {
+            firewall_options: Some(FirewallOptionsDecl {
+                enable: true,
+                policy_in: "DROP".into(),
+                ..FirewallOptionsDecl::default()
+            }),
+            ..ClusterState::default()
+        };
+        let d = diff(&empty(), &live);
+        assert!(d.is_empty(), "None declared = unmanaged, got {d:?}");
+    }
+
+    #[test]
+    fn diff_firewall_options_differing_is_single_update() {
+        let declared = ClusterState {
+            firewall_options: Some(FirewallOptionsDecl {
+                enable: true,
+                policy_in: "DROP".into(),
+                ..FirewallOptionsDecl::default()
+            }),
+            ..ClusterState::default()
+        };
+        let live = ClusterState {
+            firewall_options: Some(FirewallOptionsDecl {
+                enable: false,
+                policy_in: "ACCEPT".into(),
+                ..FirewallOptionsDecl::default()
+            }),
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &live);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Update);
+        assert_eq!(d[0].resource, "firewall_options");
+        assert_eq!(d[0].identity, "cluster");
+    }
+
+    #[test]
+    fn diff_firewall_options_equal_is_no_change() {
+        let o = FirewallOptionsDecl {
+            enable: true,
+            policy_in: "DROP".into(),
+            policy_out: "ACCEPT".into(),
+            ..FirewallOptionsDecl::default()
+        };
+        let s = ClusterState {
+            firewall_options: Some(o),
+            ..ClusterState::default()
+        };
+        assert!(diff(&s, &s).is_empty());
+    }
+
+    // ── Firewall aliases (full CRUD) ──────────────────────
+
+    #[test]
+    fn diff_firewall_alias_create_update_delete() {
+        let mk = |cidr: &str| FirewallAliasDecl {
+            name: "web".into(),
+            cidr: cidr.into(),
+            comment: String::new(),
+        };
+        // create
+        let declared = ClusterState {
+            firewall_aliases: vec![mk("10.0.0.0/8")],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &empty());
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Create);
+        assert_eq!(d[0].resource, "firewall_alias");
+        assert_eq!(d[0].identity, "web");
+        // delete
+        let d = diff(&empty(), &declared);
+        assert_eq!(d[0].kind, ChangeKind::Delete);
+        // update (cidr change)
+        let live = ClusterState {
+            firewall_aliases: vec![mk("192.168.0.0/16")],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &live);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Update);
+    }
+
+    // ── Firewall IP sets (CRUD; update carries full value) ──
+
+    #[test]
+    fn diff_firewall_ipset_update_on_cidr_membership() {
+        let with = |cidrs: Vec<&str>| FirewallIpsetDecl {
+            name: "blocklist".into(),
+            comment: "bad actors".into(),
+            cidrs: cidrs
+                .into_iter()
+                .map(|c| FirewallIpsetCidrDecl {
+                    cidr: c.into(),
+                    ..FirewallIpsetCidrDecl::default()
+                })
+                .collect(),
+        };
+        let declared = ClusterState {
+            firewall_ipsets: vec![with(vec!["1.2.3.0/24", "5.6.7.0/24"])],
+            ..ClusterState::default()
+        };
+        let live = ClusterState {
+            firewall_ipsets: vec![with(vec!["1.2.3.0/24"])],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &live);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Update);
+        assert_eq!(d[0].resource, "firewall_ipset");
+        // before + after both carry the full ipset (apply computes the delta).
+        assert!(d[0].before.is_some() && d[0].after.is_some());
+    }
+
+    // ── Firewall groups (create/delete only — no update) ──
+
+    #[test]
+    fn diff_firewall_group_comment_drift_is_not_an_update() {
+        // PVE has no group-update endpoint and rules are read-only, so
+        // a comment-only change must NOT produce a (destructive) change.
+        let declared = ClusterState {
+            firewall_groups: vec![FirewallGroupDecl {
+                group: "web-tier".into(),
+                comment: "new comment".into(),
+            }],
+            ..ClusterState::default()
+        };
+        let live = ClusterState {
+            firewall_groups: vec![FirewallGroupDecl {
+                group: "web-tier".into(),
+                comment: "old comment".into(),
+            }],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &live);
+        assert!(
+            d.is_empty(),
+            "group comment drift must not emit a change, got {d:?}"
+        );
+    }
+
+    #[test]
+    fn diff_firewall_group_create_and_delete() {
+        let declared = ClusterState {
+            firewall_groups: vec![FirewallGroupDecl {
+                group: "web-tier".into(),
+                comment: String::new(),
+            }],
+            ..ClusterState::default()
+        };
+        let create = diff(&declared, &empty());
+        assert_eq!(create.len(), 1);
+        assert_eq!(create[0].kind, ChangeKind::Create);
+        assert_eq!(create[0].resource, "firewall_group");
+        let delete = diff(&empty(), &declared);
+        assert_eq!(delete.len(), 1);
+        assert_eq!(delete[0].kind, ChangeKind::Delete);
     }
 
     #[test]

--- a/src/state/export.rs
+++ b/src/state/export.rs
@@ -19,9 +19,14 @@ use async_trait::async_trait;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::api::types::{
-    AclEntry, ApiVersion, BackupJob, Pool, PoolDetails, PoolMember, StorageDefinition,
+    AclEntry, ApiVersion, BackupJob, FirewallAlias, FirewallIpset, FirewallIpsetCidr,
+    FirewallOptions, FirewallSecurityGroup, Pool, PoolDetails, PoolMember, StorageDefinition,
 };
-use crate::state::model::{AclDecl, BackupJobDecl, ClusterState, PoolDecl, StateMeta, StorageDecl};
+use crate::state::model::{
+    AclDecl, BackupJobDecl, ClusterState, FirewallAliasDecl, FirewallGroupDecl,
+    FirewallIpsetCidrDecl, FirewallIpsetDecl, FirewallOptionsDecl, PoolDecl, StateMeta,
+    StorageDecl,
+};
 
 /// Which resource families to export. Parsed from the CLI `--resource`
 /// argument. New variants are added per the ladder in epic #74.
@@ -31,6 +36,12 @@ pub enum Resource {
     Acl,
     Storage,
     BackupJobs,
+    /// The whole cluster-firewall surface in one selector: options
+    /// (singleton) + aliases + IP sets + security groups. Exporting
+    /// them together keeps the `--resource firewall-cluster` UX simple
+    /// (operators don't juggle four sub-selectors) and matches how the
+    /// pieces are reasoned about as a unit.
+    FirewallCluster,
 }
 
 impl Resource {
@@ -44,9 +55,10 @@ impl Resource {
             "acl" => Ok(vec![Self::Acl]),
             "storage" => Ok(vec![Self::Storage]),
             "backup-jobs" => Ok(vec![Self::BackupJobs]),
+            "firewall-cluster" => Ok(vec![Self::FirewallCluster]),
             "all" => Ok(Self::all()),
             other => anyhow::bail!(
-                "unknown resource '{other}' (valid: pools | acl | storage | backup-jobs | all — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
+                "unknown resource '{other}' (valid: pools | acl | storage | backup-jobs | firewall-cluster | all — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
             ),
         }
     }
@@ -60,7 +72,13 @@ impl Resource {
     /// make that family's declared entries diff as perpetual creates).
     #[must_use]
     pub fn all() -> Vec<Self> {
-        vec![Self::Pools, Self::Acl, Self::Storage, Self::BackupJobs]
+        vec![
+            Self::Pools,
+            Self::Acl,
+            Self::Storage,
+            Self::BackupJobs,
+            Self::FirewallCluster,
+        ]
     }
 
     /// Human-readable name for logs / error messages.
@@ -71,6 +89,7 @@ impl Resource {
             Self::Acl => "acl",
             Self::Storage => "storage",
             Self::BackupJobs => "backup-jobs",
+            Self::FirewallCluster => "firewall-cluster",
         }
     }
 }
@@ -90,6 +109,14 @@ pub trait StateReadView: Send + Sync {
     async fn list_acl_view(&self) -> Result<Vec<AclEntry>>;
     async fn list_cluster_storages_view(&self) -> Result<Vec<StorageDefinition>>;
     async fn list_backup_jobs_view(&self) -> Result<Vec<BackupJob>>;
+    async fn get_cluster_firewall_options_view(&self) -> Result<FirewallOptions>;
+    async fn list_cluster_firewall_aliases_view(&self) -> Result<Vec<FirewallAlias>>;
+    async fn list_cluster_firewall_ipsets_view(&self) -> Result<Vec<FirewallIpset>>;
+    async fn list_cluster_firewall_ipset_cidrs_view(
+        &self,
+        name: &str,
+    ) -> Result<Vec<FirewallIpsetCidr>>;
+    async fn list_cluster_firewall_groups_view(&self) -> Result<Vec<FirewallSecurityGroup>>;
     async fn get_api_version_view(&self) -> Result<ApiVersion>;
 }
 
@@ -112,6 +139,24 @@ where
     }
     async fn list_backup_jobs_view(&self) -> Result<Vec<BackupJob>> {
         crate::api::ProxmoxGateway::list_backup_jobs(self).await
+    }
+    async fn get_cluster_firewall_options_view(&self) -> Result<FirewallOptions> {
+        crate::api::ProxmoxGateway::get_cluster_firewall_options(self).await
+    }
+    async fn list_cluster_firewall_aliases_view(&self) -> Result<Vec<FirewallAlias>> {
+        crate::api::ProxmoxGateway::list_cluster_firewall_aliases(self).await
+    }
+    async fn list_cluster_firewall_ipsets_view(&self) -> Result<Vec<FirewallIpset>> {
+        crate::api::ProxmoxGateway::list_cluster_firewall_ipsets(self).await
+    }
+    async fn list_cluster_firewall_ipset_cidrs_view(
+        &self,
+        name: &str,
+    ) -> Result<Vec<FirewallIpsetCidr>> {
+        crate::api::ProxmoxGateway::list_cluster_firewall_ipset_cidrs(self, name).await
+    }
+    async fn list_cluster_firewall_groups_view(&self) -> Result<Vec<FirewallSecurityGroup>> {
+        crate::api::ProxmoxGateway::list_cluster_firewall_groups(self).await
     }
     async fn get_api_version_view(&self) -> Result<ApiVersion> {
         crate::api::ProxmoxGateway::get_api_version(self).await
@@ -143,6 +188,10 @@ pub async fn export_state<C: StateReadView + ?Sized>(
         acl: Vec::new(),
         storage: Vec::new(),
         backup_jobs: Vec::new(),
+        firewall_options: None,
+        firewall_aliases: Vec::new(),
+        firewall_ipsets: Vec::new(),
+        firewall_groups: Vec::new(),
     };
 
     for r in resources {
@@ -164,6 +213,22 @@ pub async fn export_state<C: StateReadView + ?Sized>(
                 state.backup_jobs = export_backup_jobs(client)
                     .await
                     .with_context(|| "exporting backup-jobs")?;
+            }
+            Resource::FirewallCluster => {
+                state.firewall_options = Some(
+                    export_firewall_options(client)
+                        .await
+                        .with_context(|| "exporting firewall options")?,
+                );
+                state.firewall_aliases = export_firewall_aliases(client)
+                    .await
+                    .with_context(|| "exporting firewall aliases")?;
+                state.firewall_ipsets = export_firewall_ipsets(client)
+                    .await
+                    .with_context(|| "exporting firewall ipsets")?;
+                state.firewall_groups = export_firewall_groups(client)
+                    .await
+                    .with_context(|| "exporting firewall groups")?;
             }
         }
     }
@@ -313,6 +378,103 @@ async fn export_backup_jobs<C: StateReadView + ?Sized>(client: &C) -> Result<Vec
             comment: j.comment,
             notes_template: j.notes_template,
             prune_backups: j.prune_backups,
+        })
+        .collect())
+}
+
+/// Read the cluster firewall options singleton and project to
+/// `FirewallOptionsDecl`. The `digest` stale-check token is dropped
+/// (it would churn the TOML on every export).
+async fn export_firewall_options<C: StateReadView + ?Sized>(
+    client: &C,
+) -> Result<FirewallOptionsDecl> {
+    let o = client
+        .get_cluster_firewall_options_view()
+        .await
+        .context("reading firewall options")?;
+    Ok(FirewallOptionsDecl {
+        enable: o.enable,
+        policy_in: o.policy_in,
+        policy_out: o.policy_out,
+        ebtables: o.ebtables,
+        log_ratelimit: o.log_ratelimit,
+    })
+}
+
+/// Read every cluster firewall alias and project to
+/// `Vec<FirewallAliasDecl>`, sorted by `name`. The derived `ipversion`
+/// (inferred from the CIDR) and the `digest` token are dropped.
+async fn export_firewall_aliases<C: StateReadView + ?Sized>(
+    client: &C,
+) -> Result<Vec<FirewallAliasDecl>> {
+    let mut aliases = client
+        .list_cluster_firewall_aliases_view()
+        .await
+        .context("listing firewall aliases")?;
+    aliases.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(aliases
+        .into_iter()
+        .map(|a| FirewallAliasDecl {
+            name: a.name,
+            cidr: a.cidr,
+            comment: a.comment,
+        })
+        .collect())
+}
+
+/// Read every cluster firewall IP set + its CIDR membership and
+/// project to `Vec<FirewallIpsetDecl>`. IP sets sorted by `name`,
+/// CIDRs within each set sorted by `cidr`, both for diff-stability.
+/// The per-set and per-CIDR `digest` tokens are dropped.
+async fn export_firewall_ipsets<C: StateReadView + ?Sized>(
+    client: &C,
+) -> Result<Vec<FirewallIpsetDecl>> {
+    let mut ipsets = client
+        .list_cluster_firewall_ipsets_view()
+        .await
+        .context("listing firewall ipsets")?;
+    ipsets.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut out = Vec::with_capacity(ipsets.len());
+    for s in ipsets {
+        let mut cidrs = client
+            .list_cluster_firewall_ipset_cidrs_view(&s.name)
+            .await
+            .with_context(|| format!("listing CIDRs of ipset '{}'", s.name))?;
+        cidrs.sort_by(|a, b| a.cidr.cmp(&b.cidr));
+        out.push(FirewallIpsetDecl {
+            name: s.name,
+            comment: s.comment,
+            cidrs: cidrs
+                .into_iter()
+                .map(|c| FirewallIpsetCidrDecl {
+                    cidr: c.cidr,
+                    comment: c.comment,
+                    nomatch: c.nomatch,
+                })
+                .collect(),
+        });
+    }
+    Ok(out)
+}
+
+/// Read every cluster firewall security group and project to
+/// `Vec<FirewallGroupDecl>`, sorted by `group`. The group's *rules*
+/// are not read here (they're read-only in the state model); only the
+/// group's existence + comment is captured. The `digest` is dropped.
+async fn export_firewall_groups<C: StateReadView + ?Sized>(
+    client: &C,
+) -> Result<Vec<FirewallGroupDecl>> {
+    let mut groups = client
+        .list_cluster_firewall_groups_view()
+        .await
+        .context("listing firewall groups")?;
+    groups.sort_by(|a, b| a.group.cmp(&b.group));
+    Ok(groups
+        .into_iter()
+        .map(|g| FirewallGroupDecl {
+            group: g.group,
+            comment: g.comment,
         })
         .collect())
 }
@@ -481,7 +643,8 @@ mod tests {
                 Resource::Pools,
                 Resource::Acl,
                 Resource::Storage,
-                Resource::BackupJobs
+                Resource::BackupJobs,
+                Resource::FirewallCluster,
             ]
         );
         // `parse("all")` and `Resource::all()` must stay in lockstep —
@@ -503,6 +666,7 @@ mod tests {
             Resource::Acl,
             Resource::Storage,
             Resource::BackupJobs,
+            Resource::FirewallCluster,
         ] {
             assert!(all.contains(&r), "Resource::all() is missing {r:?}");
         }
@@ -548,6 +712,11 @@ mod tests {
         acl: Vec<AclEntry>,
         storage: Vec<StorageDefinition>,
         backup_jobs: Vec<BackupJob>,
+        fw_options: FirewallOptions,
+        fw_aliases: Vec<FirewallAlias>,
+        fw_ipsets: Vec<FirewallIpset>,
+        fw_ipset_cidrs: std::collections::HashMap<String, Vec<FirewallIpsetCidr>>,
+        fw_groups: Vec<FirewallSecurityGroup>,
     }
 
     #[async_trait]
@@ -569,6 +738,24 @@ mod tests {
         }
         async fn list_backup_jobs_view(&self) -> Result<Vec<BackupJob>> {
             Ok(self.backup_jobs.clone())
+        }
+        async fn get_cluster_firewall_options_view(&self) -> Result<FirewallOptions> {
+            Ok(self.fw_options.clone())
+        }
+        async fn list_cluster_firewall_aliases_view(&self) -> Result<Vec<FirewallAlias>> {
+            Ok(self.fw_aliases.clone())
+        }
+        async fn list_cluster_firewall_ipsets_view(&self) -> Result<Vec<FirewallIpset>> {
+            Ok(self.fw_ipsets.clone())
+        }
+        async fn list_cluster_firewall_ipset_cidrs_view(
+            &self,
+            name: &str,
+        ) -> Result<Vec<FirewallIpsetCidr>> {
+            Ok(self.fw_ipset_cidrs.get(name).cloned().unwrap_or_default())
+        }
+        async fn list_cluster_firewall_groups_view(&self) -> Result<Vec<FirewallSecurityGroup>> {
+            Ok(self.fw_groups.clone())
         }
         async fn get_api_version_view(&self) -> Result<ApiVersion> {
             Ok(ApiVersion {
@@ -967,5 +1154,136 @@ mod tests {
         let out = export_backup_jobs(&fake).await.expect("export");
         assert!(!out[0].enabled, "disabled flag must survive");
         assert!(out[0].all, "all-guests selector must survive");
+    }
+
+    // ── Firewall ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn export_firewall_options_drops_digest() {
+        let mut fake = FakeStateView::default();
+        fake.fw_options = FirewallOptions {
+            enable: true,
+            policy_in: "DROP".into(),
+            policy_out: "ACCEPT".into(),
+            ebtables: true,
+            log_ratelimit: "enable=1".into(),
+            digest: "abc123".into(),
+        };
+        let o = export_firewall_options(&fake).await.expect("export");
+        assert!(o.enable && o.ebtables);
+        assert_eq!(o.policy_in, "DROP");
+        let toml_str = toml::to_string(&o).expect("serialize");
+        assert!(!toml_str.contains("digest") && !toml_str.contains("abc123"));
+    }
+
+    #[tokio::test]
+    async fn export_firewall_aliases_sorts_and_drops_derived_fields() {
+        let mut fake = FakeStateView::default();
+        fake.fw_aliases = vec![
+            FirewallAlias {
+                name: "z-net".into(),
+                cidr: "10.0.0.0/8".into(),
+                ipversion: 4,
+                digest: "d1".into(),
+                ..Default::default()
+            },
+            FirewallAlias {
+                name: "a-net".into(),
+                cidr: "192.168.0.0/16".into(),
+                ipversion: 4,
+                digest: "d2".into(),
+                ..Default::default()
+            },
+        ];
+        let out = export_firewall_aliases(&fake).await.expect("export");
+        let names: Vec<&str> = out.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(names, vec!["a-net", "z-net"]);
+        let toml_str = toml::to_string(&out[0]).expect("serialize");
+        assert!(!toml_str.contains("ipversion"), "derived ipversion dropped");
+        assert!(!toml_str.contains("digest"));
+    }
+
+    #[tokio::test]
+    async fn export_firewall_ipsets_sorts_sets_and_cidrs() {
+        let mut fake = FakeStateView::default();
+        fake.fw_ipsets = vec![
+            FirewallIpset {
+                name: "z-set".into(),
+                comment: "z".into(),
+                digest: "d".into(),
+            },
+            FirewallIpset {
+                name: "a-set".into(),
+                comment: "a".into(),
+                digest: "d".into(),
+            },
+        ];
+        fake.fw_ipset_cidrs.insert(
+            "a-set".into(),
+            vec![
+                FirewallIpsetCidr {
+                    cidr: "9.9.9.0/24".into(),
+                    ..Default::default()
+                },
+                FirewallIpsetCidr {
+                    cidr: "1.1.1.0/24".into(),
+                    ..Default::default()
+                },
+            ],
+        );
+        let out = export_firewall_ipsets(&fake).await.expect("export");
+        let names: Vec<&str> = out.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["a-set", "z-set"], "sets sorted by name");
+        let cidrs: Vec<&str> = out[0].cidrs.iter().map(|c| c.cidr.as_str()).collect();
+        assert_eq!(cidrs, vec!["1.1.1.0/24", "9.9.9.0/24"], "cidrs sorted");
+    }
+
+    #[tokio::test]
+    async fn export_firewall_groups_sorts_by_group() {
+        let mut fake = FakeStateView::default();
+        fake.fw_groups = vec![
+            FirewallSecurityGroup {
+                group: "web".into(),
+                comment: String::new(),
+                digest: "d".into(),
+            },
+            FirewallSecurityGroup {
+                group: "db".into(),
+                comment: String::new(),
+                digest: "d".into(),
+            },
+        ];
+        let out = export_firewall_groups(&fake).await.expect("export");
+        let names: Vec<&str> = out.iter().map(|g| g.group.as_str()).collect();
+        assert_eq!(names, vec!["db", "web"]);
+    }
+
+    #[tokio::test]
+    async fn export_state_firewall_cluster_populates_all_four() {
+        let mut fake = FakeStateView::default();
+        fake.fw_options = FirewallOptions {
+            enable: true,
+            ..Default::default()
+        };
+        fake.fw_aliases = vec![FirewallAlias {
+            name: "a".into(),
+            cidr: "1.2.3.0/24".into(),
+            ..Default::default()
+        }];
+        fake.fw_ipsets = vec![FirewallIpset {
+            name: "s".into(),
+            ..Default::default()
+        }];
+        fake.fw_groups = vec![FirewallSecurityGroup {
+            group: "g".into(),
+            ..Default::default()
+        }];
+        let s = export_state(&fake, &[Resource::FirewallCluster], "p")
+            .await
+            .expect("export");
+        assert!(s.firewall_options.is_some());
+        assert_eq!(s.firewall_aliases.len(), 1);
+        assert_eq!(s.firewall_ipsets.len(), 1);
+        assert_eq!(s.firewall_groups.len(), 1);
     }
 }

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -63,6 +63,40 @@ pub struct ClusterState {
     /// scheduler-computed, not desired state, and would churn the TOML.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub backup_jobs: Vec<BackupJobDecl>,
+
+    /// Cluster-wide firewall options — `GET /cluster/firewall/options`.
+    /// A singleton (the firewall always has exactly one options object),
+    /// so this is an `Option`, not a `Vec`: `None` means "don't manage
+    /// the firewall switch / default policy" and apply leaves it
+    /// untouched. `Some` means converge live options toward it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub firewall_options: Option<FirewallOptionsDecl>,
+
+    /// Cluster firewall CIDR aliases — `GET /cluster/firewall/aliases`.
+    /// Identity is `name`. Aliases are reusable named CIDRs referenced
+    /// from rules as `+name`. Full CRUD (PVE exposes create/update/
+    /// delete). The derived `ipversion` and `digest` fields are not
+    /// modelled — `ipversion` is inferred from the CIDR, `digest` is a
+    /// stale-check token.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub firewall_aliases: Vec<FirewallAliasDecl>,
+
+    /// Cluster firewall IP sets — `GET /cluster/firewall/ipset` plus the
+    /// per-set CIDR membership. Identity is `name`. PVE has no update
+    /// endpoint for the set itself, so a `comment` change forces a
+    /// delete+recreate (the modelled CIDRs are re-added, so it's
+    /// lossless); CIDR membership changes are applied as incremental
+    /// add/remove.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub firewall_ipsets: Vec<FirewallIpsetDecl>,
+
+    /// Cluster firewall security groups — `GET /cluster/firewall/groups`.
+    /// Identity is `group`. Only create/delete are modelled: PVE has no
+    /// group-update endpoint and the group's *rules* are read-only here,
+    /// so a delete+recreate would silently drop them. Comment drift on
+    /// an existing group is therefore NOT applied (documented limitation).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub firewall_groups: Vec<FirewallGroupDecl>,
 }
 
 /// Metadata header emitted by the export layer. Captures *which*
@@ -217,6 +251,93 @@ pub struct BackupJobDecl {
     pub prune_backups: String,
 }
 
+/// Cluster firewall options — the global switch + default policy.
+/// `GET|PUT /cluster/firewall/options`. A singleton; the `digest`
+/// stale-check token from PVE's response is not modelled (it would
+/// churn the TOML). Bools are always serialised (the on/off state is
+/// the whole point); the policy / ratelimit strings are skipped when
+/// empty so a minimal block can set just `enable`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FirewallOptionsDecl {
+    /// Master switch. `false` disables the entire cluster firewall.
+    pub enable: bool,
+    /// Default inbound action with no matching rule: `ACCEPT` |
+    /// `REJECT` | `DROP`. Empty = leave PVE's current value.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub policy_in: String,
+    /// Default outbound action. Empty = leave current.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub policy_out: String,
+    /// Whether ebtables (L2) hooks are wired alongside iptables.
+    #[serde(skip_serializing_if = "is_false")]
+    pub ebtables: bool,
+    /// Encoded ratelimit sub-spec, e.g. `enable=1,burst=5,rate=1/second`.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub log_ratelimit: String,
+}
+
+/// One cluster firewall CIDR alias. `name` is the identity; `cidr` +
+/// `comment` are the value. PVE infers `ipversion` from the CIDR, so
+/// it's not modelled (a derived field would round-trip-drift).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FirewallAliasDecl {
+    /// Alias name — referenced from rules as `+name`. The identity.
+    pub name: String,
+    /// The CIDR this alias resolves to (e.g. `10.0.0.0/8`, `1.2.3.4`).
+    pub cidr: String,
+    /// Free-text comment.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub comment: String,
+}
+
+/// One cluster firewall IP set: a named collection of CIDRs.
+/// `name` is the identity; `comment` + the `cidrs` membership are the
+/// value. CIDRs are sorted by `cidr` on export for diff-stability.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FirewallIpsetDecl {
+    /// IP set name — referenced from rules as `+name`. The identity.
+    pub name: String,
+    /// Free-text comment.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub comment: String,
+    /// Member CIDRs. Empty is valid (an empty set).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cidrs: Vec<FirewallIpsetCidrDecl>,
+}
+
+/// One CIDR entry within an IP set. `cidr` is the identity within the
+/// set; `comment` + `nomatch` are the value. `nomatch` inverts
+/// membership for this entry (carve an exception out of a range).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FirewallIpsetCidrDecl {
+    /// The CIDR or address (e.g. `10.0.0.0/24`, `1.2.3.4`).
+    pub cidr: String,
+    /// Free-text comment.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub comment: String,
+    /// Invert membership for this entry.
+    #[serde(skip_serializing_if = "is_false")]
+    pub nomatch: bool,
+}
+
+/// One cluster firewall security group. `group` is the identity;
+/// `comment` is the value. The group's rules are NOT modelled (the
+/// rules endpoint is read-only here), so only create/delete are
+/// applied — see [`ClusterState::firewall_groups`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FirewallGroupDecl {
+    /// Group name — referenced from `group`-direction rules. Identity.
+    pub group: String,
+    /// Free-text comment.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub comment: String,
+}
+
 /// One cluster-wide storage definition — `GET /storage`. The
 /// `storage` field is the identity; everything else is value.
 ///
@@ -317,9 +438,7 @@ mod tests {
         let s = ClusterState {
             meta: None,
             pools: vec![p],
-            acl: vec![],
-            storage: vec![],
-            backup_jobs: vec![],
+            ..Default::default()
         };
         let toml_str = toml::to_string(&s).expect("serialize");
         // No "comment = " line, no "members = " line — only poolid.
@@ -359,9 +478,6 @@ mod tests {
                 exported_from_proxxx: "0.2.1".into(),
                 pve_version: "9.1.9".into(),
             }),
-            acl: vec![],
-            storage: vec![],
-            backup_jobs: vec![],
             pools: vec![
                 PoolDecl {
                     poolid: "p1".into(),
@@ -374,6 +490,7 @@ mod tests {
                     members: vec![],
                 },
             ],
+            ..Default::default()
         };
         let toml_str = toml::to_string(&s).expect("serialize");
         let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");
@@ -409,10 +526,8 @@ roleid = "PVEVMAdmin"
         };
         let s = ClusterState {
             meta: None,
-            pools: vec![],
             acl: vec![entry.clone()],
-            storage: vec![],
-            backup_jobs: vec![],
+            ..Default::default()
         };
         let toml_str = toml::to_string(&s).expect("serialize");
         let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");
@@ -539,10 +654,8 @@ propagate = false
         ];
         let s = ClusterState {
             meta: None,
-            pools: vec![],
-            acl: vec![],
             storage: entries.clone(),
-            backup_jobs: vec![],
+            ..Default::default()
         };
         let toml_str = toml::to_string(&s).expect("serialize");
         let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");
@@ -565,5 +678,67 @@ members = ["qemu/100", "storage/ceph-rbd"]
         assert_eq!(s.pools.len(), 1);
         assert_eq!(s.pools[0].poolid, "team-platform");
         assert_eq!(s.pools[0].members.len(), 2);
+    }
+
+    #[test]
+    fn firewall_families_round_trip_through_toml() {
+        // The firewall families (singleton options + nested-CIDR ipsets)
+        // are the trickiest serde shapes in the model. Pin a full
+        // round-trip: serialize → deserialize → equal.
+        let s = ClusterState {
+            firewall_options: Some(FirewallOptionsDecl {
+                enable: true,
+                policy_in: "DROP".into(),
+                policy_out: "ACCEPT".into(),
+                ebtables: true,
+                log_ratelimit: "enable=1,rate=1/second".into(),
+            }),
+            firewall_aliases: vec![FirewallAliasDecl {
+                name: "web".into(),
+                cidr: "10.0.0.0/8".into(),
+                comment: "web tier".into(),
+            }],
+            firewall_ipsets: vec![FirewallIpsetDecl {
+                name: "blocklist".into(),
+                comment: "bad actors".into(),
+                cidrs: vec![
+                    FirewallIpsetCidrDecl {
+                        cidr: "1.2.3.0/24".into(),
+                        comment: "spam".into(),
+                        nomatch: false,
+                    },
+                    FirewallIpsetCidrDecl {
+                        cidr: "1.2.3.4".into(),
+                        comment: String::new(),
+                        nomatch: true,
+                    },
+                ],
+            }],
+            firewall_groups: vec![FirewallGroupDecl {
+                group: "web-tier".into(),
+                comment: "frontend".into(),
+            }],
+            ..Default::default()
+        };
+        let toml_str = toml::to_string(&s).expect("serialize");
+        let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");
+        assert_eq!(parsed, s);
+    }
+
+    #[test]
+    fn firewall_ipset_cidr_skips_empty_comment_and_false_nomatch() {
+        // A minimal CIDR entry must serialise to just `cidr = "…"`.
+        let decl = FirewallIpsetDecl {
+            name: "s".into(),
+            comment: String::new(),
+            cidrs: vec![FirewallIpsetCidrDecl {
+                cidr: "1.2.3.0/24".into(),
+                comment: String::new(),
+                nomatch: false,
+            }],
+        };
+        let toml_str = toml::to_string(&decl).expect("serialize");
+        assert!(!toml_str.contains("comment"), "empty comment skipped");
+        assert!(!toml_str.contains("nomatch"), "false nomatch skipped");
     }
 }

--- a/src/state/preflight.rs
+++ b/src/state/preflight.rs
@@ -20,6 +20,10 @@
 //! | [`StateRisk::StoragePropertyChange { what }`] | Warning — content-list or path changes can break running guests. |
 //! | [`StateRisk::AclPropagateFlip`]   | Warning — `propagate` change cascades to every descendant path. |
 //! | [`StateRisk::BackupJobDelete`]    | Warning — guests silently stop being backed up; nothing breaks now, the safety net just disappears. |
+//! | [`StateRisk::FirewallDisabled`]   | Severe — flips the cluster firewall master switch off; all enforcement stops at once. |
+//! | [`StateRisk::FirewallPolicyLoosened`] | Warning — a default policy goes to ACCEPT; every unmatched packet in that direction now passes. |
+//! | [`StateRisk::FirewallAliasDelete`] / [`StateRisk::FirewallIpsetDelete`] | Warning — rules referencing `+name` break. |
+//! | [`StateRisk::FirewallGroupDelete`] | Severe — drops the group's rules (not modelled, so unrecoverable) and breaks group-direction rules. |
 //! | [`StateRisk::BulkChangeCount { n }`] | Notice → Warning if `n ≥ 10`, Severe if `n ≥ 50` (very large batches = high attention cost). |
 //!
 //! ## Decision contract
@@ -88,6 +92,26 @@ pub enum StateRisk {
     /// no immediate breakage, just an absent safety net).
     BackupJobDelete { id: String },
 
+    /// The cluster firewall master switch is being turned off
+    /// (`enable` true→false). Disables ALL enforcement at once.
+    FirewallDisabled,
+
+    /// A default firewall policy is being loosened to `ACCEPT` (from
+    /// `REJECT`/`DROP`). Every unmatched packet in that direction
+    /// now passes.
+    FirewallPolicyLoosened { direction: &'static str },
+
+    /// Delete of a firewall alias. Any rule referencing `+name` breaks.
+    FirewallAliasDelete { name: String },
+
+    /// Delete of a firewall IP set. Any rule referencing `+name` breaks.
+    FirewallIpsetDelete { name: String },
+
+    /// Delete of a security group. Drops the group's rules (not
+    /// modelled here, so unrecoverable via apply) and breaks any
+    /// group-direction rule that references it.
+    FirewallGroupDelete { group: String },
+
     /// Very-large-batch warning. Increases attention cost
     /// proportionally; defer with `--allow-risk` if intentional.
     BulkChangeCount { n: usize },
@@ -100,11 +124,16 @@ impl StateRisk {
         match self {
             Self::PoolDeleteNonEmpty { .. }
             | Self::AclDeleteRootRole { .. }
-            | Self::StorageDeleteShared { .. } => RiskLevel::Severe,
+            | Self::StorageDeleteShared { .. }
+            | Self::FirewallDisabled
+            | Self::FirewallGroupDelete { .. } => RiskLevel::Severe,
             Self::StoragePropertyChange { .. }
             | Self::AclPropagateFlip { .. }
             | Self::AclDeleteAuditor { .. }
-            | Self::BackupJobDelete { .. } => RiskLevel::Warning,
+            | Self::BackupJobDelete { .. }
+            | Self::FirewallPolicyLoosened { .. }
+            | Self::FirewallAliasDelete { .. }
+            | Self::FirewallIpsetDelete { .. } => RiskLevel::Warning,
             Self::BulkChangeCount { n } => {
                 if *n >= 50 {
                     RiskLevel::Severe
@@ -155,6 +184,25 @@ impl StateRisk {
             Self::BackupJobDelete { id } => format!(
                 "delete backup job `{id}` — the guests it covered will \
                  silently stop being backed up"
+            ),
+            Self::FirewallDisabled => "disable the cluster firewall (enable → false) — ALL \
+                 enforcement stops cluster-wide"
+                .to_string(),
+            Self::FirewallPolicyLoosened { direction } => format!(
+                "loosen firewall {direction} default policy to ACCEPT — \
+                 every unmatched packet in that direction now passes"
+            ),
+            Self::FirewallAliasDelete { name } => format!(
+                "delete firewall alias `{name}` — rules referencing \
+                 `+{name}` will break"
+            ),
+            Self::FirewallIpsetDelete { name } => format!(
+                "delete firewall IP set `{name}` — rules referencing \
+                 `+{name}` will break"
+            ),
+            Self::FirewallGroupDelete { group } => format!(
+                "delete security group `{group}` — drops its rules \
+                 (unrecoverable here) and breaks rules that reference it"
             ),
             Self::BulkChangeCount { n } => {
                 format!("{n} changes in one apply — attention cost proportional")
@@ -292,6 +340,40 @@ fn assess_one(change: &Change, live: &ClusterState) -> Vec<StateRisk> {
                 id: change.identity.clone(),
             });
         }
+        (ChangeKind::Update, "firewall_options") => {
+            // Two distinct dangers hide in an options update: flipping
+            // the master switch off, and loosening a default policy to
+            // ACCEPT. Detect each by diffing before/after JSON.
+            if let (Some(before), Some(after)) = (change.before.as_ref(), change.after.as_ref()) {
+                let was_on = before.get("enable").and_then(serde_json::Value::as_bool);
+                let now_off = after.get("enable").and_then(serde_json::Value::as_bool);
+                if was_on == Some(true) && now_off == Some(false) {
+                    out.push(StateRisk::FirewallDisabled);
+                }
+                for direction in ["policy_in", "policy_out"] {
+                    let before_v = before.get(direction).and_then(serde_json::Value::as_str);
+                    let after_v = after.get(direction).and_then(serde_json::Value::as_str);
+                    if after_v == Some("ACCEPT") && before_v != Some("ACCEPT") {
+                        out.push(StateRisk::FirewallPolicyLoosened { direction });
+                    }
+                }
+            }
+        }
+        (ChangeKind::Delete, "firewall_alias") => {
+            out.push(StateRisk::FirewallAliasDelete {
+                name: change.identity.clone(),
+            });
+        }
+        (ChangeKind::Delete, "firewall_ipset") => {
+            out.push(StateRisk::FirewallIpsetDelete {
+                name: change.identity.clone(),
+            });
+        }
+        (ChangeKind::Delete, "firewall_group") => {
+            out.push(StateRisk::FirewallGroupDelete {
+                group: change.identity.clone(),
+            });
+        }
         _ => {}
     }
     out
@@ -413,7 +495,7 @@ mod tests {
                     ..Default::default()
                 },
             ],
-            backup_jobs: vec![],
+            ..Default::default()
         }
     }
 
@@ -616,5 +698,82 @@ mod tests {
         };
         let v = serde_json::to_value(&r).unwrap();
         assert_eq!(v["kind"], "pool_delete_non_empty");
+    }
+
+    // ── Firewall ──────────────────────────────────────────
+
+    fn fw_options_update(before: serde_json::Value, after: serde_json::Value) -> Change {
+        Change {
+            kind: ChangeKind::Update,
+            resource: "firewall_options",
+            identity: "cluster".to_string(),
+            before: Some(before),
+            after: Some(after),
+        }
+    }
+
+    #[test]
+    fn firewall_disable_is_severe() {
+        let live = sample_live();
+        let change = fw_options_update(
+            serde_json::json!({"enable": true}),
+            serde_json::json!({"enable": false}),
+        );
+        let risks = assess(&[change], &live);
+        assert!(risks
+            .iter()
+            .any(|r| matches!(r, StateRisk::FirewallDisabled)));
+        assert_eq!(
+            risks
+                .iter()
+                .find(|r| matches!(r, StateRisk::FirewallDisabled))
+                .unwrap()
+                .level(),
+            RiskLevel::Severe
+        );
+    }
+
+    #[test]
+    fn firewall_policy_loosened_to_accept_is_warning() {
+        let live = sample_live();
+        let change = fw_options_update(
+            serde_json::json!({"enable": true, "policy_in": "DROP"}),
+            serde_json::json!({"enable": true, "policy_in": "ACCEPT"}),
+        );
+        let risks = assess(&[change], &live);
+        let r = risks
+            .iter()
+            .find(|r| matches!(r, StateRisk::FirewallPolicyLoosened { .. }))
+            .expect("expected policy-loosened risk");
+        assert_eq!(r.level(), RiskLevel::Warning);
+        // Tightening (ACCEPT → DROP) must NOT flag.
+        let tighten = fw_options_update(
+            serde_json::json!({"enable": true, "policy_in": "ACCEPT"}),
+            serde_json::json!({"enable": true, "policy_in": "DROP"}),
+        );
+        assert!(assess(&[tighten], &live).is_empty());
+    }
+
+    #[test]
+    fn firewall_alias_and_ipset_delete_are_warnings() {
+        let live = sample_live();
+        let a = assess(&[delete_change("firewall_alias", "web")], &live);
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].level(), RiskLevel::Warning);
+        assert!(matches!(&a[0], StateRisk::FirewallAliasDelete { name } if name == "web"));
+
+        let i = assess(&[delete_change("firewall_ipset", "blocklist")], &live);
+        assert_eq!(i[0].level(), RiskLevel::Warning);
+        assert!(matches!(&i[0], StateRisk::FirewallIpsetDelete { .. }));
+    }
+
+    #[test]
+    fn firewall_group_delete_is_severe() {
+        // Deleting a group drops its (unmodelled, unrecoverable) rules.
+        let live = sample_live();
+        let g = assess(&[delete_change("firewall_group", "web-tier")], &live);
+        assert_eq!(g.len(), 1);
+        assert_eq!(g[0].level(), RiskLevel::Severe);
+        assert!(matches!(&g[0], StateRisk::FirewallGroupDelete { group } if group == "web-tier"));
     }
 }


### PR DESCRIPTION
## Summary

Wires the whole **writable cluster-firewall surface** through the `state` GitOps loop under one `--resource firewall-cluster` selector — continuing epic #74 after backup-jobs ([#112](https://github.com/fabriziosalmi/proxxx/pull/112)).

Four families, one selector:
- **options** singleton — `enable`, `policy_in/out`, `ebtables`, `log_ratelimit`
- **aliases** — `name` → `cidr` + `comment` (full CRUD)
- **IP sets** — `name` + `comment` + nested CIDR membership (`cidr`/`comment`/`nomatch`)
- **security groups** — `group` + `comment` (create/delete only)

## Honest handling of PVE's awkward semantics

- **options is update-only** (the firewall always has exactly one). A declared `[firewall_options]` block is authoritative; omitting it leaves the live firewall untouched (`None` = unmanaged).
- **IP sets have no update endpoint**: a `comment` change is a lossless **delete+recreate** (declared CIDRs are re-added), while CIDR membership is an **incremental add/remove delta** when the comment is unchanged. Changed CIDR attributes (`nomatch`) = remove + re-add.
- **security groups are create/delete only** — PVE has no group-update endpoint and their *rules* are read-only here, so a recreate would silently drop them. Comment drift on an existing group is deliberately **not** applied (documented limitation).

## Pre-flight risk gates

| Move | Level |
| :--- | :--- |
| Disable firewall (`enable` → false) | **Severe** |
| Delete security group (drops its rules) | **Severe** |
| Loosen default policy to `ACCEPT` | Warning |
| Delete alias / IP set | Warning |

Rules are read-only (no PVE CRUD), so they're out of scope for apply.

## Bug-class guard carried over

Both new and existing families flow through the single `Resource::all()` (the diff/apply live-fetch set), so the firewall can't diff as a perpetual create — pinned by the `resource_all_includes_every_variant` test.

## Verification

Verified **end-to-end against PVE 9.1.1**, cluster restored to its original state afterward:

- export of all four families → diff → apply **create** (alias, IP set with nested CIDRs + `nomatch`, group) → round-trip stable
- **update**: alias cidr; IP set CIDR-delta (incremental); IP set comment-change → delete+recreate with CIDRs surviving
- **pre-flight**: `--prune` refused at **exit 6** (Severe group delete) with 2 Warnings + 1 Severe listed; `--allow-risk` overrode and cleaned up
- the live firewall master switch was never touched (options block kept verbatim)

+25 unit tests (588 lib total). Pre-commit gate **PASSED in 403s** (fmt, clippy(pedantic), audit, deny, release test, live mutation lifecycle). 

## Test plan

- [x] `cargo test --lib state` (108 pass)
- [x] `cargo clippy --all-targets` clean
- [x] live export → diff → apply create/update/delete for all four families against PVE 9.1.1
- [x] IP set CIDR-delta + comment-recreate paths verified live
- [x] pre-flight refusal → `--allow-risk` override verified live
- [x] full pre-commit gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)