### PR TITLE
feat(state): notification matchers as a managed resource family (epic #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ SemVer contract:
   firewall or deleting a security group are **Severe**; loosening a
   default policy to ACCEPT and deleting aliases / IP sets are
   **Warnings**. `--resource all` now includes the firewall.
+- **`state` now manages notification matchers** (epic #74). A new
+  `notifications` resource family brings PVE's native notification
+  *matchers* (routing rules) into the GitOps loop with full CRUD:
+  `state export --resource notifications` snapshots every matcher
+  (`/cluster/notifications/matchers`) sorted by `name` (list fields
+  canonicalised, `origin` dropped), `diff` detects drift, `apply`
+  converges. Matcher updates use PVE's `delete` param to clear emptied
+  fields so a stripped-down matcher actually converges. Deleting a
+  matcher is a pre-flight **Warning** (events it routed go silently
+  unrouted). Notification *endpoints* are intentionally out of scope —
+  they carry secrets PVE never returns on `GET`, so they can't
+  round-trip export→apply; operators provision endpoints out-of-band
+  and `state` manages the routing rules that reference them by name.
+  `--resource all` now includes notifications.
 
 ## [0.4.0] — 2026-05-21
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -191,7 +191,7 @@ within a major version.
 
 | Command | What it does |
 | :--- | :--- |
-| `proxxx state export [--resource pools\|acl\|storage\|backup-jobs\|firewall-cluster\|all] [--output toml\|json]` | Byte-stable snapshot of cluster state. Default emits TOML; `--output json` for piping. `firewall-cluster` covers options + aliases + IP sets + security groups. Diff-stable across runs against an unchanged cluster. |
+| `proxxx state export [--resource pools\|acl\|storage\|backup-jobs\|firewall-cluster\|notifications\|all] [--output toml\|json]` | Byte-stable snapshot of cluster state. Default emits TOML; `--output json` for piping. `firewall-cluster` covers options + aliases + IP sets + security groups; `notifications` covers matchers (routing rules; endpoints are out-of-band — they carry secrets PVE won't disclose). Diff-stable across runs against an unchanged cluster. |
 | `proxxx state diff <declared.toml> [--output text\|json]` | Structural diff of declared vs live. Exit 2 on drift. |
 | `proxxx state apply <declared.toml> [--dry-run] [--prune] [--continue-on-error] [--allow-risk] [--interactive] [--output text\|json]` | Converge live toward declared. Pre-flight risk gate refuses Severe changes (non-empty pool delete, root-role ACL delete, shared-storage delete, batch ≥ 50) without `--allow-risk`. `--interactive` adds per-Severe `[y/N]` stdin prompts. Exit code 6 on refusal. |
 

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -3,9 +3,9 @@
 //! toward declared.
 //!
 //! Resource families covered today: pools, ACL grants, cluster
-//! storage definitions, scheduled backup jobs, and the cluster
-//! firewall (options + aliases + IP sets + security groups).
-//! Notifications and HA groups land in follow-up PRs tracked by epic
+//! storage definitions, scheduled backup jobs, the cluster firewall
+//! (options + aliases + IP sets + security groups), and notification
+//! matchers. HA groups land in a follow-up PR tracked by epic
 //! [#74](https://github.com/fabriziosalmi/proxxx/issues/74). Pre-flight
 //! risk gates + HITL approval per destructive change are wired (shipped
 //! v0.3.0): `state::preflight` refuses Severe changes unless
@@ -40,8 +40,8 @@ pub enum StateCommand {
     /// Export the cluster's mutable state.
     ///
     /// Supported resources: `pools`, `acl`, `storage`, `backup-jobs`,
-    /// `firewall-cluster`, `all` (every supported family). More
-    /// (notifications, HA groups) land per the ladder in epic #74.
+    /// `firewall-cluster`, `notifications`, `all` (every supported
+    /// family). HA groups land per the ladder in epic #74.
     ///
     /// The resulting document is byte-stable across runs against an
     /// unchanged cluster — every collection is sorted by its identity
@@ -54,8 +54,8 @@ pub enum StateCommand {
     ///   proxxx state export --output json | jq '.pools[0]'  # programmatic
     Export {
         /// Resource family to export. Valid: `pools`, `acl`, `storage`,
-        /// `backup-jobs`, `firewall-cluster`, `all`. More families
-        /// coming — see issue #74.
+        /// `backup-jobs`, `firewall-cluster`, `notifications`, `all`.
+        /// More families coming — see issue #74.
         #[arg(long, default_value = "pools")]
         resource: String,
 

--- a/src/state/apply.rs
+++ b/src/state/apply.rs
@@ -36,6 +36,7 @@
 //! | Firewall alias | ✓ | ✓ (cidr + comment) | ✓ |
 //! | Firewall ipset | ✓ | ✓ (comment → recreate; CIDR delta) | ✓ |
 //! | Firewall group | ✓ | — (no PVE update; rules read-only) | ✓ |
+//! | Notification matcher | ✓ | ✓ (all fields) | ✓ |
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -45,7 +46,7 @@ use crate::api::types::{Pool, PoolDetails};
 use crate::state::diff::{Change, ChangeKind};
 use crate::state::model::{
     AclDecl, BackupJobDecl, FirewallAliasDecl, FirewallGroupDecl, FirewallIpsetCidrDecl,
-    FirewallIpsetDecl, FirewallOptionsDecl, PoolDecl, StorageDecl,
+    FirewallIpsetDecl, FirewallOptionsDecl, NotificationMatcherDecl, PoolDecl, StorageDecl,
 };
 
 /// Options controlling apply behaviour.
@@ -161,6 +162,15 @@ pub trait StateWriteView: Send + Sync {
     async fn remove_cluster_firewall_ipset_cidr_view(&self, name: &str, cidr: &str) -> Result<()>;
     async fn create_cluster_firewall_group_view(&self, params: &[(&str, &str)]) -> Result<()>;
     async fn delete_cluster_firewall_group_view(&self, group: &str) -> Result<()>;
+
+    // ── Notification matchers ─────────────────────────────
+    async fn create_notification_matcher_view(&self, params: &[(&str, &str)]) -> Result<()>;
+    async fn update_notification_matcher_view(
+        &self,
+        name: &str,
+        params: &[(&str, &str)],
+    ) -> Result<()>;
+    async fn delete_notification_matcher_view(&self, name: &str) -> Result<()>;
 }
 
 #[async_trait]
@@ -262,6 +272,20 @@ where
     async fn delete_cluster_firewall_group_view(&self, group: &str) -> Result<()> {
         crate::api::ProxmoxGateway::delete_cluster_firewall_group(self, group).await
     }
+
+    async fn create_notification_matcher_view(&self, params: &[(&str, &str)]) -> Result<()> {
+        crate::api::ProxmoxGateway::create_notification_matcher(self, params).await
+    }
+    async fn update_notification_matcher_view(
+        &self,
+        name: &str,
+        params: &[(&str, &str)],
+    ) -> Result<()> {
+        crate::api::ProxmoxGateway::update_notification_matcher(self, name, params).await
+    }
+    async fn delete_notification_matcher_view(&self, name: &str) -> Result<()> {
+        crate::api::ProxmoxGateway::delete_notification_matcher(self, name).await
+    }
 }
 
 /// Apply a list of changes, in order, against a live cluster.
@@ -340,6 +364,15 @@ async fn apply_one<C: StateWriteView + ?Sized>(client: &C, change: &Change) -> A
         ("firewall_ipset", ChangeKind::Delete) => apply_fw_ipset_delete(client, change).await,
         ("firewall_group", ChangeKind::Create) => apply_fw_group_create(client, change).await,
         ("firewall_group", ChangeKind::Delete) => apply_fw_group_delete(client, change).await,
+        ("notification_matcher", ChangeKind::Create) => {
+            apply_notif_matcher_create(client, change).await
+        }
+        ("notification_matcher", ChangeKind::Update) => {
+            apply_notif_matcher_update(client, change).await
+        }
+        ("notification_matcher", ChangeKind::Delete) => {
+            apply_notif_matcher_delete(client, change).await
+        }
         (resource, kind) => Err(anyhow::anyhow!(
             "unhandled change shape: resource={resource} kind={kind:?}"
         )),
@@ -972,6 +1005,99 @@ async fn apply_fw_group_delete<C: StateWriteView + ?Sized>(
     client.delete_cluster_firewall_group_view(&decl.group).await
 }
 
+// ── Notification matchers ────────────────────────────────────
+
+/// Build the `POST`/`PUT /cluster/notifications/matchers` param set.
+/// The three list fields go as repeated form keys (PVE's array
+/// convention). `invert-match` + `disable` are always sent (0/1) so an
+/// update that flips them off actually takes effect. `include_name` is
+/// true for create (name is a body param) and false for update (name is
+/// the URL segment).
+fn notif_matcher_params(
+    decl: &NotificationMatcherDecl,
+    include_name: bool,
+) -> Vec<(String, String)> {
+    let mut params: Vec<(String, String)> = Vec::new();
+    if include_name {
+        params.push(("name".to_string(), decl.name.clone()));
+    }
+    push_optional(&mut params, "comment", &decl.comment);
+    for t in &decl.target {
+        params.push(("target".to_string(), t.clone()));
+    }
+    for m in &decl.match_field {
+        params.push(("match-field".to_string(), m.clone()));
+    }
+    for s in &decl.match_severity {
+        params.push(("match-severity".to_string(), s.clone()));
+    }
+    push_optional(&mut params, "mode", &decl.mode);
+    params.push((
+        "invert-match".to_string(),
+        if decl.invert_match { "1" } else { "0" }.to_string(),
+    ));
+    params.push((
+        "disable".to_string(),
+        if decl.disable { "1" } else { "0" }.to_string(),
+    ));
+    params
+}
+
+async fn apply_notif_matcher_create<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: NotificationMatcherDecl = decode(change.after.as_ref(), "notification matcher")?;
+    let params = notif_matcher_params(&decl, true);
+    client
+        .create_notification_matcher_view(&borrow(&params))
+        .await
+}
+
+async fn apply_notif_matcher_update<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let after: NotificationMatcherDecl = decode(change.after.as_ref(), "notification matcher")?;
+    let mut params = notif_matcher_params(&after, false);
+    // PVE keeps an optional field's old value unless explicitly told to
+    // unset it. So any field the declared state leaves empty is sent in
+    // `delete` — otherwise "clear all match-fields" would never converge
+    // (the diff would show a perpetual Update). The matchers endpoint
+    // wants `delete` as REPEATED keys (`delete=a&delete=b`), not a CSV —
+    // a CSV is rejected as one malformed config-id (verified live).
+    let mut del: Vec<&str> = Vec::new();
+    if after.comment.is_empty() {
+        del.push("comment");
+    }
+    if after.target.is_empty() {
+        del.push("target");
+    }
+    if after.match_field.is_empty() {
+        del.push("match-field");
+    }
+    if after.match_severity.is_empty() {
+        del.push("match-severity");
+    }
+    if after.mode.is_empty() {
+        del.push("mode");
+    }
+    for key in del {
+        params.push(("delete".to_string(), key.to_string()));
+    }
+    client
+        .update_notification_matcher_view(&after.name, &borrow(&params))
+        .await
+}
+
+async fn apply_notif_matcher_delete<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: NotificationMatcherDecl = decode(change.before.as_ref(), "notification matcher")?;
+    client.delete_notification_matcher_view(&decl.name).await
+}
+
 fn push_optional(params: &mut Vec<(String, String)>, key: &str, value: &str) {
     if !value.is_empty() {
         params.push((key.to_string(), value.to_string()));
@@ -1139,6 +1265,20 @@ mod tests {
         }
         async fn delete_cluster_firewall_group_view(&self, group: &str) -> Result<()> {
             self.record(format!("delete_fw_group({group})")).await
+        }
+        async fn create_notification_matcher_view(&self, params: &[(&str, &str)]) -> Result<()> {
+            self.record(format!("create_matcher {params:?}")).await
+        }
+        async fn update_notification_matcher_view(
+            &self,
+            name: &str,
+            params: &[(&str, &str)],
+        ) -> Result<()> {
+            self.record(format!("update_matcher({name}) {params:?}"))
+                .await
+        }
+        async fn delete_notification_matcher_view(&self, name: &str) -> Result<()> {
+            self.record(format!("delete_matcher({name})")).await
         }
     }
 
@@ -1717,5 +1857,109 @@ mod tests {
             c2.lines().await,
             vec!["delete_fw_group(web-tier)".to_string()]
         );
+    }
+
+    // ── Notification matchers ─────────────────────────────
+
+    #[test]
+    fn matcher_params_arrays_repeat_and_bools_always_sent() {
+        let decl = NotificationMatcherDecl {
+            name: "oncall".into(),
+            target: vec!["gotify".into(), "email".into()],
+            match_field: vec!["exact:type=vzdump".into()],
+            match_severity: vec!["error".into(), "warning".into()],
+            mode: "any".into(),
+            invert_match: true,
+            disable: false,
+            ..NotificationMatcherDecl::default()
+        };
+        let p = notif_matcher_params(&decl, true);
+        // name only on create
+        assert!(p.iter().any(|(k, v)| k == "name" && v == "oncall"));
+        // arrays as repeated keys
+        assert_eq!(p.iter().filter(|(k, _)| k == "target").count(), 2);
+        assert_eq!(p.iter().filter(|(k, _)| k == "match-severity").count(), 2);
+        assert!(p
+            .iter()
+            .any(|(k, v)| k == "match-field" && v == "exact:type=vzdump"));
+        assert!(p.iter().any(|(k, v)| k == "mode" && v == "any"));
+        // bools always present
+        assert!(p.iter().any(|(k, v)| k == "invert-match" && v == "1"));
+        assert!(p.iter().any(|(k, v)| k == "disable" && v == "0"));
+        // update omits name
+        assert!(!notif_matcher_params(&decl, false)
+            .iter()
+            .any(|(k, _)| k == "name"));
+    }
+
+    #[tokio::test]
+    async fn matcher_update_sends_delete_for_emptied_fields() {
+        // A matcher stripped down to just a target must `delete` the
+        // fields it no longer sets, or PVE keeps the stale values.
+        let after = NotificationMatcherDecl {
+            name: "m".into(),
+            target: vec!["gotify".into()],
+            // comment, match_field, match_severity, mode all empty
+            ..NotificationMatcherDecl::default()
+        };
+        let c = RecordingClient::default();
+        let change = Change {
+            kind: ChangeKind::Update,
+            resource: "notification_matcher",
+            identity: "m".into(),
+            before: Some(serde_json::json!({"name": "m", "match_severity": ["error"]})),
+            after: Some(serde_json::to_value(&after).unwrap()),
+        };
+        let out = apply(&c, vec![change], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let line = &c.lines().await[0];
+        assert!(line.starts_with("update_matcher(m)"));
+        assert!(line.contains("\"delete\""), "delete CSV present: {line}");
+        assert!(
+            line.contains("comment")
+                && line.contains("match-field")
+                && line.contains("match-severity")
+                && line.contains("mode")
+        );
+    }
+
+    #[tokio::test]
+    async fn matcher_create_and_delete_dispatch() {
+        let decl = NotificationMatcherDecl {
+            name: "oncall".into(),
+            target: vec!["gotify".into()],
+            ..NotificationMatcherDecl::default()
+        };
+        let c = RecordingClient::default();
+        let create = Change {
+            kind: ChangeKind::Create,
+            resource: "notification_matcher",
+            identity: "oncall".into(),
+            before: None,
+            after: Some(serde_json::to_value(&decl).unwrap()),
+        };
+        let out = apply(&c, vec![create], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        assert!(c.lines().await[0].starts_with("create_matcher"));
+
+        let c2 = RecordingClient::default();
+        let delete = Change {
+            kind: ChangeKind::Delete,
+            resource: "notification_matcher",
+            identity: "oncall".into(),
+            before: Some(serde_json::to_value(&decl).unwrap()),
+            after: None,
+        };
+        let out2 = apply(
+            &c2,
+            vec![delete],
+            ApplyOptions {
+                prune: true,
+                ..ApplyOptions::default()
+            },
+        )
+        .await;
+        assert!(matches!(out2[0].result, ApplyResult::Applied));
+        assert_eq!(c2.lines().await, vec!["delete_matcher(oncall)".to_string()]);
     }
 }

--- a/src/state/diff.rs
+++ b/src/state/diff.rs
@@ -35,7 +35,7 @@ use serde::Serialize;
 
 use crate::state::model::{
     AclDecl, BackupJobDecl, ClusterState, FirewallAliasDecl, FirewallGroupDecl, FirewallIpsetDecl,
-    FirewallOptionsDecl, PoolDecl, StorageDecl,
+    FirewallOptionsDecl, NotificationMatcherDecl, PoolDecl, StorageDecl,
 };
 
 /// Kind of mutation a change represents. `Create` + `Delete` are
@@ -81,10 +81,10 @@ pub struct Change {
 /// The output order is stable: changes for `pool` first, then `acl`,
 /// then `storage`, then `backup_job`, then the firewall families
 /// (`firewall_options`, `firewall_alias`, `firewall_ipset`,
-/// `firewall_group`), each sorted by identity. Within a family the
-/// order is `Delete` (so apply-with-prune teardown runs before create),
-/// then `Update`, then `Create` — but the apply layer re-orders by
-/// dependency where needed.
+/// `firewall_group`), then `notification_matcher`, each sorted by
+/// identity. Within a family the order is `Delete` (so apply-with-prune
+/// teardown runs before create), then `Update`, then `Create` — but the
+/// apply layer re-orders by dependency where needed.
 #[must_use]
 pub fn diff(declared: &ClusterState, live: &ClusterState) -> Vec<Change> {
     let mut out = Vec::new();
@@ -100,6 +100,11 @@ pub fn diff(declared: &ClusterState, live: &ClusterState) -> Vec<Change> {
     diff_firewall_aliases(&declared.firewall_aliases, &live.firewall_aliases, &mut out);
     diff_firewall_ipsets(&declared.firewall_ipsets, &live.firewall_ipsets, &mut out);
     diff_firewall_groups(&declared.firewall_groups, &live.firewall_groups, &mut out);
+    diff_notification_matchers(
+        &declared.notification_matchers,
+        &live.notification_matchers,
+        &mut out,
+    );
     out
 }
 
@@ -528,6 +533,66 @@ fn diff_firewall_groups(
     }
 }
 
+/// Diff notification matchers by `name` — standard create/update/
+/// delete. The full matcher (targets + match clauses + flags) is the
+/// value; touching any field is an `Update`.
+fn diff_notification_matchers(
+    declared: &[NotificationMatcherDecl],
+    live: &[NotificationMatcherDecl],
+    out: &mut Vec<Change>,
+) {
+    use std::collections::HashMap;
+    let live_by: HashMap<&str, &NotificationMatcherDecl> =
+        live.iter().map(|m| (m.name.as_str(), m)).collect();
+    let decl_by: HashMap<&str, &NotificationMatcherDecl> =
+        declared.iter().map(|m| (m.name.as_str(), m)).collect();
+
+    let mut deletes: Vec<_> = live_by
+        .keys()
+        .filter(|k| !decl_by.contains_key(*k))
+        .collect();
+    deletes.sort_unstable();
+    for k in deletes {
+        out.push(Change {
+            kind: ChangeKind::Delete,
+            resource: "notification_matcher",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: None,
+        });
+    }
+
+    let mut updates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| live_by.get(*k).is_some_and(|l| *l != decl_by[*k]))
+        .collect();
+    updates.sort_unstable();
+    for k in updates {
+        out.push(Change {
+            kind: ChangeKind::Update,
+            resource: "notification_matcher",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+
+    let mut creates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| !live_by.contains_key(*k))
+        .collect();
+    creates.sort_unstable();
+    for k in creates {
+        out.push(Change {
+            kind: ChangeKind::Create,
+            resource: "notification_matcher",
+            identity: (*k).to_string(),
+            before: None,
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+}
+
 /// Human-readable single-line summary of one change. Used by the
 /// CLI's default output mode. Keep it grep-friendly:
 /// `<sigil> <resource>: <identity>`.
@@ -550,7 +615,8 @@ mod tests {
     use super::*;
     use crate::state::model::{
         AclDecl, BackupJobDecl, ClusterState, FirewallAliasDecl, FirewallGroupDecl,
-        FirewallIpsetCidrDecl, FirewallIpsetDecl, FirewallOptionsDecl, PoolDecl, StorageDecl,
+        FirewallIpsetCidrDecl, FirewallIpsetDecl, FirewallOptionsDecl, NotificationMatcherDecl,
+        PoolDecl, StorageDecl,
     };
 
     fn empty() -> ClusterState {
@@ -1085,6 +1151,55 @@ mod tests {
         let delete = diff(&empty(), &declared);
         assert_eq!(delete.len(), 1);
         assert_eq!(delete[0].kind, ChangeKind::Delete);
+    }
+
+    // ── Notification matchers ─────────────────────────────
+
+    #[test]
+    fn diff_notification_matcher_create_update_delete() {
+        let mk = |targets: Vec<&str>| NotificationMatcherDecl {
+            name: "oncall".into(),
+            target: targets.into_iter().map(String::from).collect(),
+            mode: "all".into(),
+            ..NotificationMatcherDecl::default()
+        };
+        // create
+        let declared = ClusterState {
+            notification_matchers: vec![mk(vec!["gotify"])],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &empty());
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Create);
+        assert_eq!(d[0].resource, "notification_matcher");
+        assert_eq!(d[0].identity, "oncall");
+        // delete
+        let d = diff(&empty(), &declared);
+        assert_eq!(d[0].kind, ChangeKind::Delete);
+        // update (target set changes)
+        let live = ClusterState {
+            notification_matchers: vec![mk(vec!["email"])],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &live);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Update);
+    }
+
+    #[test]
+    fn diff_identical_matchers_produces_no_change() {
+        let m = NotificationMatcherDecl {
+            name: "m".into(),
+            target: vec!["gotify".into()],
+            match_severity: vec!["error".into()],
+            disable: true,
+            ..NotificationMatcherDecl::default()
+        };
+        let s = ClusterState {
+            notification_matchers: vec![m],
+            ..ClusterState::default()
+        };
+        assert!(diff(&s, &s).is_empty());
     }
 
     #[test]

--- a/src/state/export.rs
+++ b/src/state/export.rs
@@ -20,12 +20,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::api::types::{
     AclEntry, ApiVersion, BackupJob, FirewallAlias, FirewallIpset, FirewallIpsetCidr,
-    FirewallOptions, FirewallSecurityGroup, Pool, PoolDetails, PoolMember, StorageDefinition,
+    FirewallOptions, FirewallSecurityGroup, NotificationMatcher, Pool, PoolDetails, PoolMember,
+    StorageDefinition,
 };
 use crate::state::model::{
     AclDecl, BackupJobDecl, ClusterState, FirewallAliasDecl, FirewallGroupDecl,
-    FirewallIpsetCidrDecl, FirewallIpsetDecl, FirewallOptionsDecl, PoolDecl, StateMeta,
-    StorageDecl,
+    FirewallIpsetCidrDecl, FirewallIpsetDecl, FirewallOptionsDecl, NotificationMatcherDecl,
+    PoolDecl, StateMeta, StorageDecl,
 };
 
 /// Which resource families to export. Parsed from the CLI `--resource`
@@ -42,6 +43,10 @@ pub enum Resource {
     /// (operators don't juggle four sub-selectors) and matches how the
     /// pieces are reasoned about as a unit.
     FirewallCluster,
+    /// Notification matchers (routing rules). Endpoints are excluded by
+    /// design — they carry secrets PVE won't disclose on `GET`, so they
+    /// can't round-trip; see [`ClusterState::notification_matchers`].
+    Notifications,
 }
 
 impl Resource {
@@ -56,9 +61,10 @@ impl Resource {
             "storage" => Ok(vec![Self::Storage]),
             "backup-jobs" => Ok(vec![Self::BackupJobs]),
             "firewall-cluster" => Ok(vec![Self::FirewallCluster]),
+            "notifications" => Ok(vec![Self::Notifications]),
             "all" => Ok(Self::all()),
             other => anyhow::bail!(
-                "unknown resource '{other}' (valid: pools | acl | storage | backup-jobs | firewall-cluster | all — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
+                "unknown resource '{other}' (valid: pools | acl | storage | backup-jobs | firewall-cluster | notifications | all — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
             ),
         }
     }
@@ -78,6 +84,7 @@ impl Resource {
             Self::Storage,
             Self::BackupJobs,
             Self::FirewallCluster,
+            Self::Notifications,
         ]
     }
 
@@ -90,6 +97,7 @@ impl Resource {
             Self::Storage => "storage",
             Self::BackupJobs => "backup-jobs",
             Self::FirewallCluster => "firewall-cluster",
+            Self::Notifications => "notifications",
         }
     }
 }
@@ -117,6 +125,7 @@ pub trait StateReadView: Send + Sync {
         name: &str,
     ) -> Result<Vec<FirewallIpsetCidr>>;
     async fn list_cluster_firewall_groups_view(&self) -> Result<Vec<FirewallSecurityGroup>>;
+    async fn list_notification_matchers_view(&self) -> Result<Vec<NotificationMatcher>>;
     async fn get_api_version_view(&self) -> Result<ApiVersion>;
 }
 
@@ -158,6 +167,9 @@ where
     async fn list_cluster_firewall_groups_view(&self) -> Result<Vec<FirewallSecurityGroup>> {
         crate::api::ProxmoxGateway::list_cluster_firewall_groups(self).await
     }
+    async fn list_notification_matchers_view(&self) -> Result<Vec<NotificationMatcher>> {
+        crate::api::ProxmoxGateway::list_notification_matchers(self).await
+    }
     async fn get_api_version_view(&self) -> Result<ApiVersion> {
         crate::api::ProxmoxGateway::get_api_version(self).await
     }
@@ -192,6 +204,7 @@ pub async fn export_state<C: StateReadView + ?Sized>(
         firewall_aliases: Vec::new(),
         firewall_ipsets: Vec::new(),
         firewall_groups: Vec::new(),
+        notification_matchers: Vec::new(),
     };
 
     for r in resources {
@@ -229,6 +242,11 @@ pub async fn export_state<C: StateReadView + ?Sized>(
                 state.firewall_groups = export_firewall_groups(client)
                     .await
                     .with_context(|| "exporting firewall groups")?;
+            }
+            Resource::Notifications => {
+                state.notification_matchers = export_notification_matchers(client)
+                    .await
+                    .with_context(|| "exporting notification matchers")?;
             }
         }
     }
@@ -479,6 +497,44 @@ async fn export_firewall_groups<C: StateReadView + ?Sized>(
         .collect())
 }
 
+/// Read every notification matcher and project to
+/// `Vec<NotificationMatcherDecl>`, sorted by `name`. The three list
+/// fields (`target` / `match_field` / `match_severity`) are sorted
+/// too — order is not semantically meaningful for `all`/`any` matching,
+/// and sorting keeps the TOML byte-stable across runs. The derived
+/// `origin` provenance field is dropped.
+async fn export_notification_matchers<C: StateReadView + ?Sized>(
+    client: &C,
+) -> Result<Vec<NotificationMatcherDecl>> {
+    let mut matchers = client
+        .list_notification_matchers_view()
+        .await
+        .context("listing notification matchers")?;
+    matchers.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(matchers
+        .into_iter()
+        .map(|m| {
+            let mut target = m.target;
+            let mut match_field = m.match_field;
+            let mut match_severity = m.match_severity;
+            target.sort();
+            match_field.sort();
+            match_severity.sort();
+            NotificationMatcherDecl {
+                name: m.name,
+                comment: m.comment,
+                target,
+                match_field,
+                match_severity,
+                mode: m.mode,
+                invert_match: m.invert_match,
+                disable: m.disable,
+            }
+        })
+        .collect())
+}
+
 /// Sort the comma-separated tokens of a CSV-style PVE field. Empty
 /// input maps to empty output. Whitespace around commas is preserved
 /// (PVE doesn't emit any; if it ever does, we'd reformat on round-
@@ -645,6 +701,7 @@ mod tests {
                 Resource::Storage,
                 Resource::BackupJobs,
                 Resource::FirewallCluster,
+                Resource::Notifications,
             ]
         );
         // `parse("all")` and `Resource::all()` must stay in lockstep —
@@ -667,6 +724,7 @@ mod tests {
             Resource::Storage,
             Resource::BackupJobs,
             Resource::FirewallCluster,
+            Resource::Notifications,
         ] {
             assert!(all.contains(&r), "Resource::all() is missing {r:?}");
         }
@@ -717,6 +775,7 @@ mod tests {
         fw_ipsets: Vec<FirewallIpset>,
         fw_ipset_cidrs: std::collections::HashMap<String, Vec<FirewallIpsetCidr>>,
         fw_groups: Vec<FirewallSecurityGroup>,
+        notif_matchers: Vec<NotificationMatcher>,
     }
 
     #[async_trait]
@@ -756,6 +815,9 @@ mod tests {
         }
         async fn list_cluster_firewall_groups_view(&self) -> Result<Vec<FirewallSecurityGroup>> {
             Ok(self.fw_groups.clone())
+        }
+        async fn list_notification_matchers_view(&self) -> Result<Vec<NotificationMatcher>> {
+            Ok(self.notif_matchers.clone())
         }
         async fn get_api_version_view(&self) -> Result<ApiVersion> {
             Ok(ApiVersion {
@@ -1285,5 +1347,41 @@ mod tests {
         assert_eq!(s.firewall_aliases.len(), 1);
         assert_eq!(s.firewall_ipsets.len(), 1);
         assert_eq!(s.firewall_groups.len(), 1);
+    }
+
+    // ── Notification matchers ─────────────────────────────
+
+    #[tokio::test]
+    async fn export_notification_matchers_sorts_and_canonicalises() {
+        // Matchers sorted by name; the list fields sorted within each;
+        // `origin` dropped.
+        let mut fake = FakeStateView::default();
+        fake.notif_matchers = vec![
+            NotificationMatcher {
+                name: "z-oncall".into(),
+                target: vec!["gotify".into(), "email".into()],
+                match_severity: vec!["warning".into(), "error".into()],
+                origin: "user-created".into(),
+                ..Default::default()
+            },
+            NotificationMatcher {
+                name: "a-default".into(),
+                origin: "builtin".into(),
+                ..Default::default()
+            },
+        ];
+        let out = export_notification_matchers(&fake).await.expect("export");
+        let names: Vec<&str> = out.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, vec!["a-default", "z-oncall"], "matchers sorted");
+        // z-oncall's list fields canonicalised (sorted).
+        let z = &out[1];
+        assert_eq!(z.target, vec!["email", "gotify"]);
+        assert_eq!(z.match_severity, vec!["error", "warning"]);
+        // origin is not a Decl field; serialised TOML must not carry it.
+        let toml_str = toml::to_string(&out[0]).expect("serialize");
+        assert!(
+            !toml_str.contains("origin"),
+            "origin dropped, got:\n{toml_str}"
+        );
     }
 }

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -97,6 +97,21 @@ pub struct ClusterState {
     /// an existing group is therefore NOT applied (documented limitation).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub firewall_groups: Vec<FirewallGroupDecl>,
+
+    /// Notification matchers — `GET /cluster/notifications/matchers`.
+    /// Identity is `name`. These are the PVE-native routing rules
+    /// ("send vzdump failures to gotify-oncall"); full CRUD.
+    ///
+    /// Scope note: the notification *endpoints* (sendmail/smtp/gotify/
+    /// webhook) are deliberately NOT modelled — they carry secrets
+    /// (gotify tokens, SMTP passwords) that PVE never returns on `GET`,
+    /// so an export→apply round-trip could not recreate them. Operators
+    /// provision endpoints out-of-band (web UI / `proxxx notifications
+    /// endpoint`); state manages the routing rules that reference them
+    /// by name. A matcher whose `target` names a missing endpoint will
+    /// fail at apply with PVE's own error.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub notification_matchers: Vec<NotificationMatcherDecl>,
 }
 
 /// Metadata header emitted by the export layer. Captures *which*
@@ -336,6 +351,45 @@ pub struct FirewallGroupDecl {
     /// Free-text comment.
     #[serde(skip_serializing_if = "String::is_empty")]
     pub comment: String,
+}
+
+/// One notification matcher — a PVE-native routing rule. `name` is the
+/// identity; everything else is value. The `origin` field
+/// (`builtin`/`modified-builtin`/`user-created`) from PVE's response is
+/// not modelled — it's derived provenance, not desired state.
+///
+/// The three list fields are sorted on export for diff-stability;
+/// order is not semantically meaningful for `all`/`any` matching.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NotificationMatcherDecl {
+    /// Matcher name. The identity. Operators pick a readable one
+    /// (`vzdump-failures`, `oncall`); PVE accepts it on create.
+    pub name: String,
+    /// Free-text comment.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub comment: String,
+    /// Delivery target names (endpoints or groups) matching events are
+    /// routed to. Empty = matched events are dropped (a valid config).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub target: Vec<String>,
+    /// Per-field match clauses, e.g. `exact:type=vzdump`,
+    /// `regex:hostname=^pve-.*`. Empty = match every event.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub match_field: Vec<String>,
+    /// Severity filters, e.g. `error`, `warning`. Empty = any severity.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub match_severity: Vec<String>,
+    /// `all` (default) | `any` — how multiple clauses combine. Empty
+    /// lets PVE default it to `all`.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub mode: String,
+    /// Invert the overall match decision.
+    #[serde(skip_serializing_if = "is_false")]
+    pub invert_match: bool,
+    /// `true` = matcher is kept but inactive (no routing).
+    #[serde(skip_serializing_if = "is_false")]
+    pub disable: bool,
 }
 
 /// One cluster-wide storage definition — `GET /storage`. The
@@ -740,5 +794,43 @@ members = ["qemu/100", "storage/ceph-rbd"]
         let toml_str = toml::to_string(&decl).expect("serialize");
         assert!(!toml_str.contains("comment"), "empty comment skipped");
         assert!(!toml_str.contains("nomatch"), "false nomatch skipped");
+    }
+
+    #[test]
+    fn notification_matcher_round_trips_through_toml() {
+        let s = ClusterState {
+            notification_matchers: vec![NotificationMatcherDecl {
+                name: "vzdump-failures".into(),
+                comment: "page oncall on backup failure".into(),
+                target: vec!["gotify-oncall".into(), "mail-to-root".into()],
+                match_field: vec!["exact:type=vzdump".into()],
+                match_severity: vec!["error".into()],
+                mode: "all".into(),
+                invert_match: false,
+                disable: false,
+            }],
+            ..Default::default()
+        };
+        let toml_str = toml::to_string(&s).expect("serialize");
+        let parsed: ClusterState = toml::from_str(&toml_str).expect("deserialize");
+        assert_eq!(parsed, s);
+    }
+
+    #[test]
+    fn notification_matcher_minimal_skips_empty_fields() {
+        // A match-everything matcher with one target is just name +
+        // target + the two always-false bools (which skip).
+        let m = NotificationMatcherDecl {
+            name: "catch-all".into(),
+            target: vec!["mail-to-root".into()],
+            ..Default::default()
+        };
+        let toml_str = toml::to_string(&m).expect("serialize");
+        assert!(!toml_str.contains("comment"));
+        assert!(!toml_str.contains("match_field"));
+        assert!(!toml_str.contains("match_severity"));
+        assert!(!toml_str.contains("mode"));
+        assert!(!toml_str.contains("invert_match"));
+        assert!(!toml_str.contains("disable"));
     }
 }

--- a/src/state/preflight.rs
+++ b/src/state/preflight.rs
@@ -24,6 +24,7 @@
 //! | [`StateRisk::FirewallPolicyLoosened`] | Warning — a default policy goes to ACCEPT; every unmatched packet in that direction now passes. |
 //! | [`StateRisk::FirewallAliasDelete`] / [`StateRisk::FirewallIpsetDelete`] | Warning — rules referencing `+name` break. |
 //! | [`StateRisk::FirewallGroupDelete`] | Severe — drops the group's rules (not modelled, so unrecoverable) and breaks group-direction rules. |
+//! | [`StateRisk::NotificationMatcherDelete`] | Warning — events that matched it stop being routed; alerting silently goes quiet. |
 //! | [`StateRisk::BulkChangeCount { n }`] | Notice → Warning if `n ≥ 10`, Severe if `n ≥ 50` (very large batches = high attention cost). |
 //!
 //! ## Decision contract
@@ -112,6 +113,11 @@ pub enum StateRisk {
     /// group-direction rule that references it.
     FirewallGroupDelete { group: String },
 
+    /// Delete of a notification matcher. Events that matched it stop
+    /// being routed to their targets — alerting silently goes quiet
+    /// (no error, the notifications just stop arriving).
+    NotificationMatcherDelete { name: String },
+
     /// Very-large-batch warning. Increases attention cost
     /// proportionally; defer with `--allow-risk` if intentional.
     BulkChangeCount { n: usize },
@@ -133,7 +139,8 @@ impl StateRisk {
             | Self::BackupJobDelete { .. }
             | Self::FirewallPolicyLoosened { .. }
             | Self::FirewallAliasDelete { .. }
-            | Self::FirewallIpsetDelete { .. } => RiskLevel::Warning,
+            | Self::FirewallIpsetDelete { .. }
+            | Self::NotificationMatcherDelete { .. } => RiskLevel::Warning,
             Self::BulkChangeCount { n } => {
                 if *n >= 50 {
                     RiskLevel::Severe
@@ -203,6 +210,10 @@ impl StateRisk {
             Self::FirewallGroupDelete { group } => format!(
                 "delete security group `{group}` — drops its rules \
                  (unrecoverable here) and breaks rules that reference it"
+            ),
+            Self::NotificationMatcherDelete { name } => format!(
+                "delete notification matcher `{name}` — events it matched \
+                 will silently stop being routed"
             ),
             Self::BulkChangeCount { n } => {
                 format!("{n} changes in one apply — attention cost proportional")
@@ -372,6 +383,11 @@ fn assess_one(change: &Change, live: &ClusterState) -> Vec<StateRisk> {
         (ChangeKind::Delete, "firewall_group") => {
             out.push(StateRisk::FirewallGroupDelete {
                 group: change.identity.clone(),
+            });
+        }
+        (ChangeKind::Delete, "notification_matcher") => {
+            out.push(StateRisk::NotificationMatcherDelete {
+                name: change.identity.clone(),
             });
         }
         _ => {}
@@ -775,5 +791,15 @@ mod tests {
         assert_eq!(g.len(), 1);
         assert_eq!(g[0].level(), RiskLevel::Severe);
         assert!(matches!(&g[0], StateRisk::FirewallGroupDelete { group } if group == "web-tier"));
+    }
+
+    #[test]
+    fn notification_matcher_delete_is_warning() {
+        // Deleting a matcher silently stops routing matched events.
+        let live = sample_live();
+        let r = assess(&[delete_change("notification_matcher", "oncall")], &live);
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].level(), RiskLevel::Warning);
+        assert!(matches!(&r[0], StateRisk::NotificationMatcherDelete { name } if name == "oncall"));
     }
 }


### PR DESCRIPTION
## Summary

Brings PVE's native notification **matchers** (routing rules) into the `state` GitOps loop under `--resource notifications`, with full export / diff / apply (create / update / delete). Continues epic #74 after firewall-cluster ([#113](https://github.com/fabriziosalmi/proxxx/pull/113)).

- `name` is the identity; `target` / `match-field` / `match-severity` are sorted on export for diff-stability (order isn't meaningful for `all`/`any` matching); the derived `origin` field is dropped.
- Apply sends the three list fields as **repeated form keys**, always sends `invert-match`/`disable` (0/1) so an update that flips them off takes effect, and uses PVE's `delete` param to clear fields the declared state leaves empty — so a stripped-down matcher actually converges instead of showing a perpetual Update.
- Deleting a matcher is a pre-flight **Warning** (the events it routed go silently unrouted).

## Endpoints are out of scope (by design)

Notification *endpoints* (sendmail/smtp/gotify/webhook) carry secrets — gotify tokens, SMTP passwords — that **PVE never returns on `GET`**, so an export→apply round-trip can't recreate them. Operators provision endpoints out-of-band (web UI / `proxxx notifications endpoint`); `state` manages the routing rules that reference them by name. A matcher whose `target` names a missing endpoint fails at apply with PVE's own error.

## Bug caught by live testing

PVE's matcher endpoint rejects `delete=a,b,c` as a CSV — it parses the whole string as one malformed config-id (`delete[0]` 400). The `delete` param must be sent as **repeated keys** (`delete=a&delete=b`). The first live apply hit a 400; fixed to push repeated keys and re-verified the field-clearing path converges. Pure-unit testing wouldn't have surfaced this (no schema for the wire format).

## Verification

Verified **end-to-end against PVE 9.1.1**, builtin `default-matcher` untouched throughout, cluster restored:

- export (drops `origin`, sorts list fields) → diff → apply **create** → round-trip stable
- **update** incl. the field-clearing path (repeated `delete` keys) → re-diff clean
- `--prune` **delete** → matcher-delete **Warning** fired, matcher removed, `default-matcher` intact

+9 unit tests (597 lib total). Pre-commit gate **PASSED in 419s** (fmt, clippy(pedantic), audit, deny, release test, live mutation lifecycle).

## Test plan

- [x] `cargo test --lib state` (117 pass)
- [x] `cargo clippy --all-targets` clean
- [x] live export → diff → apply create/update/delete against PVE 9.1.1
- [x] field-clearing via repeated `delete` keys verified live
- [x] matcher-delete Warning verified live; `default-matcher` preserved
- [x] full pre-commit gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)