### PR TITLE
fix(patch): reject max_concurrent>1 loudly instead of silent serial downgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,16 @@ SemVer contract:
   and `state` manages the routing rules that reference them by name.
   `--resource all` now includes notifications.
 
+### Changed
+- **`patch apply` now rejects `max_concurrent > 1` with a loud error**
+  instead of silently downgrading to serial. Patch execution is serial
+  by design (a node upgrade is a non-atomic apt dist-upgrade + reboot;
+  concurrent reboots risk HA quorum loss), so a parallel request that
+  was quietly ignored misled the caller. It now fails fast with a
+  message pointing at the workaround — multiple invocations over
+  disjoint node sets. No CLI flag sets it above 1 today, so this only
+  affects programmatic callers constructing `PatchStrategy`.
+
 ## [0.4.0] — 2026-05-21
 
 Headline: **post-v0.3.0 debug pass** — a code-wide hunt fixed

--- a/src/app/patch.rs
+++ b/src/app/patch.rs
@@ -11,10 +11,13 @@
 //! That's an intentional design choice on their side ("pull, don't push"
 //! mirror trust). The orchestrator inherits SSH layer for the upgrade phase.
 //!
-//! Concurrency: hard cap of `max_concurrent` nodes mid-upgrade (default 1).
-//! "Mid-upgrade" = phase ∈ {Upgrade, Reboot, `WaitReboot`}. The orchestrator
-//! itself runs serially through the plan; if you want parallelism, multiple
-//! plans can run side-by-side, each capped.
+//! Concurrency: execution is **serial by design** (`max_concurrent`
+//! must be 1). Patching a node is a non-atomic apt dist-upgrade +
+//! reboot; running several at once risks HA quorum loss or losing
+//! multiple nodes to one bad upgrade. A `max_concurrent > 1` request is
+//! REJECTED by [`Orchestrator::apply`] (a loud error), not silently
+//! downgraded. For parallelism, run multiple invocations side-by-side,
+//! each scoped to a disjoint node set.
 //!
 //! Abort semantics: any node failure stops the rest of the plan. Already-
 //! completed nodes stay completed; the partially-failed node is left in
@@ -54,6 +57,14 @@ pub enum RebootPolicy {
 
 #[derive(Debug, Clone)]
 pub struct PatchStrategy {
+    /// Nodes patched at once. **Must be 1** — execution is serial by
+    /// design (concurrent node reboots risk HA quorum loss). [`apply`]
+    /// rejects any other value rather than silently downgrading to
+    /// serial. For parallelism, run multiple invocations over disjoint
+    /// node sets. Kept as a field (not a constant) so the contract is
+    /// explicit and a future parallel implementation has a home.
+    ///
+    /// [`apply`]: Orchestrator::apply
     pub max_concurrent: u32,
     pub reboot_policy: RebootPolicy,
     /// Hard timeout for the apt upgrade phase. Default 1800s (30 min) —
@@ -313,12 +324,20 @@ impl Orchestrator {
     where
         P: FnMut(&str, &Phase) + Send,
     {
-        // Concurrency: we run sequentially in this MVP. A future iteration
-        // can use a JoinSet bounded by max_concurrent — but the failure
-        // model gets harder (do you abort siblings?). One thing at a time.
+        // Concurrency: execution is serial **by design** — patching a
+        // node is a non-atomic apt dist-upgrade + reboot, and running
+        // several at once risks taking out HA quorum or losing more than
+        // one node to a bad upgrade simultaneously. So rather than
+        // silently downgrade a `max_concurrent > 1` request to serial
+        // (which misleads the caller into thinking they got parallelism),
+        // we reject it loudly. Parallelism across nodes is achieved by
+        // running multiple `proxxx patch apply` invocations, each scoped
+        // to a disjoint node set.
         if self.strategy.max_concurrent != 1 {
-            warn!(
-                "max_concurrent={} requested; MVP only supports serial execution",
+            anyhow::bail!(
+                "max_concurrent={} is not supported: patch execution is serial by design \
+                 (concurrent node reboots risk HA quorum loss). Use max_concurrent=1, or run \
+                 multiple `proxxx patch apply` invocations over disjoint node sets for parallelism.",
                 self.strategy.max_concurrent
             );
         }
@@ -1885,6 +1904,37 @@ mod tests {
             matches!(p2.status, Phase::Pending),
             "pve2 must be untouched after pve1 fail, was {:?}",
             p2.status
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_rejects_max_concurrent_above_one() {
+        // Serial-by-design: a `max_concurrent > 1` request must be a loud
+        // error, NOT a silent downgrade to serial (which would mislead a
+        // caller into thinking concurrent reboots are happening).
+        let mut api = MockApi::default();
+        api.nodes = vec![online("pve1")];
+        api.upgradable
+            .insert("pve1".into(), vec![upg("vim", "9.0", "9.1")]);
+        let ssh = Arc::new(MockSsh::default());
+        let orch = Orchestrator::new(
+            Arc::new(api),
+            ssh as Arc<dyn SshGateway>,
+            PatchStrategy {
+                max_concurrent: 2,
+                ..Default::default()
+            },
+        );
+        let plan = orch.plan(None).await.unwrap();
+        let err = orch
+            .apply(plan, |_, _| {})
+            .await
+            .expect_err("max_concurrent=2 must be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("max_concurrent=2"), "msg: {msg}");
+        assert!(
+            msg.contains("serial"),
+            "error should explain the serial-by-design contract: {msg}"
         );
     }
 


### PR DESCRIPTION
## Summary

`Orchestrator::apply` accepted `max_concurrent > 1` but only `warn!`d (a log line invisible to CLI users) and then ran serially anyway — silently giving the caller the *opposite* of what they asked for.

Patch execution is **serial by design**: a node upgrade is a non-atomic `apt dist-upgrade` + reboot, and running several at once risks HA quorum loss or losing multiple nodes to one bad upgrade. So the correct fix is to fail fast, not pretend. `apply` now bails with a clear error on any `max_concurrent != 1`, pointing at the supported path for parallelism (multiple invocations over disjoint node sets). The field + module docs now state the serial-by-design contract explicitly.

No CLI flag sets `max_concurrent` above 1 today (the patch command builds the strategy with `..Default::default()`), so this only affects programmatic callers of `PatchStrategy` — but it turns a silent, misleading downgrade into an honest error.

## Why error, not implement parallelism

The module deliberately runs serial for safety (documented). Implementing concurrent node reboots would contradict that safety call and has a genuinely harder failure model (abort siblings on one failure?). The cheapest *correct* fix is the loud error.

## Test plan

- [x] `cargo test --lib` — new `apply_rejects_max_concurrent_above_one` (asserts Err + message mentions `max_concurrent=2` and `serial`)
- [x] `cargo clippy --all-targets` clean
- [x] full pre-commit gate green (443s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)