### PR TITLE
feat(tui): interactive SSH key-passphrase prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ SemVer contract:
 ## [Unreleased]
 
 ### Added
+- **TUI prompts for an SSH key passphrase interactively.** When a guest
+  SSH session uses an encrypted OpenSSH key and no passphrase is set
+  (neither `PROXXX_SSH_KEY_PASSPHRASE` nor a prior prompt), the TUI now
+  shows a masked passphrase prompt before connecting instead of failing.
+  The entered passphrase is cached for the rest of the session (prompted
+  at most once), rendered as bullets (never echoed), and Esc cancels.
+  Detection is a metadata-only check of the key file — no connection
+  attempt is wasted.
 - **`pbs restore --pattern` — single-file / selective restore.** The
   restore command now takes one or more `--pattern <glob>` flags
   (repeatable), wiring `proxmox-backup-client restore`'s own pattern

--- a/src/app.rs
+++ b/src/app.rs
@@ -155,6 +155,15 @@ pub enum AppMode {
     SshSession {
         vmid: u32,
     },
+    /// Interactive SSH key-passphrase prompt, shown when the configured
+    /// key is an encrypted OpenSSH key and no passphrase is set (neither
+    /// `PROXXX_SSH_KEY_PASSPHRASE` nor a prior prompt). The typed
+    /// passphrase accumulates in `command_input` and is rendered masked.
+    /// `vmid` is the guest whose session we're about to open once the
+    /// passphrase is supplied. Esc cancels; Enter submits.
+    SshPassphrase {
+        vmid: u32,
+    },
     /// Profile picker overlay. `profiles` is the sorted list of named
     /// profiles from config; `selected` is the cursor row.
     ProfilePicker {
@@ -390,6 +399,18 @@ pub enum Action {
         vmid: u32,
         error: String,
     },
+    /// Enter the interactive passphrase prompt for guest `vmid`'s SSH
+    /// session (the key is encrypted and no passphrase is set yet).
+    SshPassphrasePrompt {
+        vmid: u32,
+    },
+    /// A keystroke in the passphrase prompt — carries the full buffer so
+    /// far (same shape as `CommandInput`, but does not change mode).
+    SshPassphraseInput(String),
+    /// Submit the typed passphrase: cache it and (re)open the session.
+    SshPassphraseSubmit,
+    /// Abandon the passphrase prompt (Esc) — pops back to the prior view.
+    SshPassphraseCancel,
 
     // Broadcast
     PromptBroadcastCommand,
@@ -1322,6 +1343,37 @@ pub fn update(state: &mut AppState, action: Action) -> Option<SideEffect> {
             state.error = Some(format!("SSH to {vmid} failed: {error}"));
             state.error_time = Some(std::time::Instant::now());
         }
+        Action::SshPassphrasePrompt { vmid } => {
+            // OpenGuestSsh already pushed View::GuestSshSession and set
+            // SshSession mode; overlay the passphrase prompt on top. The
+            // buffer starts empty.
+            state.command_input.clear();
+            state.mode = AppMode::SshPassphrase { vmid };
+        }
+        Action::SshPassphraseInput(input) => {
+            // Only meaningful while prompting; ignore otherwise (a stray
+            // keystroke shouldn't hijack `command_input`).
+            if matches!(state.mode, AppMode::SshPassphrase { .. }) {
+                state.command_input = input;
+            }
+        }
+        Action::SshPassphraseSubmit => {
+            if let AppMode::SshPassphrase { vmid } = state.mode {
+                let passphrase = state.command_input.clone();
+                state.command_input.clear();
+                // Back to session mode — the GuestSshSession view is
+                // still on the stack from OpenGuestSsh.
+                state.mode = AppMode::SshSession { vmid };
+                return Some(SideEffect::SetSshPassphraseAndOpen { vmid, passphrase });
+            }
+        }
+        Action::SshPassphraseCancel => {
+            state.command_input.clear();
+            state.mode = AppMode::Normal;
+            if matches!(state.current_view(), View::GuestSshSession { .. }) {
+                state.pop_view();
+            }
+        }
 
         // Compare
         Action::CompareGuests => {
@@ -1710,6 +1762,12 @@ pub enum SideEffect {
     OpenSshSession {
         vmid: u32,
     },
+    /// Cache the passphrase the operator just typed at the prompt, then
+    /// open the session — the retry's key load now has the passphrase.
+    SetSshPassphraseAndOpen {
+        vmid: u32,
+        passphrase: String,
+    },
     /// Tell the TUI loop to drop the active `PtySession`.
     CloseSshSession,
 
@@ -1899,5 +1957,73 @@ pub fn parse_command_action(cmd: &str) -> Option<Action> {
             })
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod ssh_passphrase_tests {
+    use super::*;
+
+    #[test]
+    fn prompt_enters_masked_mode_and_clears_buffer() {
+        let mut state = AppState::new();
+        state.command_input = "leftover".into();
+        let eff = update(&mut state, Action::SshPassphrasePrompt { vmid: 100 });
+        assert!(eff.is_none(), "prompt produces no side effect");
+        assert_eq!(state.mode, AppMode::SshPassphrase { vmid: 100 });
+        assert!(
+            state.command_input.is_empty(),
+            "buffer reset for the prompt"
+        );
+    }
+
+    #[test]
+    fn input_appends_only_while_prompting() {
+        let mut state = AppState::new();
+        // Outside the prompt, a stray input action must not hijack the buffer.
+        update(&mut state, Action::SshPassphraseInput("x".into()));
+        assert!(state.command_input.is_empty());
+        // Inside the prompt, it accumulates.
+        update(&mut state, Action::SshPassphrasePrompt { vmid: 7 });
+        update(&mut state, Action::SshPassphraseInput("hunter2".into()));
+        assert_eq!(state.command_input, "hunter2");
+    }
+
+    #[test]
+    fn submit_caches_passphrase_and_reopens() {
+        let mut state = AppState::new();
+        update(&mut state, Action::SshPassphrasePrompt { vmid: 42 });
+        update(&mut state, Action::SshPassphraseInput("s3cret".into()));
+        let eff = update(&mut state, Action::SshPassphraseSubmit);
+        match eff {
+            Some(SideEffect::SetSshPassphraseAndOpen { vmid, passphrase }) => {
+                assert_eq!(vmid, 42);
+                assert_eq!(passphrase, "s3cret");
+            }
+            _ => panic!("expected SetSshPassphraseAndOpen side effect"),
+        }
+        // Back to session mode; the secret is wiped from the input buffer.
+        assert_eq!(state.mode, AppMode::SshSession { vmid: 42 });
+        assert!(
+            state.command_input.is_empty(),
+            "passphrase cleared after submit"
+        );
+    }
+
+    #[test]
+    fn cancel_pops_the_session_view_and_resets() {
+        let mut state = AppState::new();
+        // Mirror OpenGuestSsh: push the session view, then prompt.
+        state.push_view(View::GuestSshSession { vmid: 9 });
+        update(&mut state, Action::SshPassphrasePrompt { vmid: 9 });
+        update(&mut state, Action::SshPassphraseInput("typed".into()));
+        let eff = update(&mut state, Action::SshPassphraseCancel);
+        assert!(eff.is_none());
+        assert_eq!(state.mode, AppMode::Normal);
+        assert!(state.command_input.is_empty());
+        assert!(
+            !matches!(state.current_view(), View::GuestSshSession { .. }),
+            "the connecting view is popped on cancel"
+        );
     }
 }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -399,6 +399,24 @@ pub fn map_key(key: KeyEvent, state: &crate::app::AppState) -> Option<crate::app
         // PtySession). map_key never sees these keys in practice — but
         // we cover it here so the match is exhaustive.
         AppMode::SshSession { .. } => None,
+        // SSH key-passphrase prompt: same text-entry shape as InputTag,
+        // but its own actions (the buffer is rendered masked and must
+        // not flip the mode the way `CommandInput` does).
+        AppMode::SshPassphrase { .. } => match key.code {
+            KeyCode::Esc => Some(Action::SshPassphraseCancel),
+            KeyCode::Enter => Some(Action::SshPassphraseSubmit),
+            KeyCode::Char(c) => {
+                let mut q = state.command_input.clone();
+                q.push(c);
+                Some(Action::SshPassphraseInput(q))
+            }
+            KeyCode::Backspace => {
+                let mut q = state.command_input.clone();
+                q.pop();
+                Some(Action::SshPassphraseInput(q))
+            }
+            _ => None,
+        },
         // Help is handled by the early-return at the top of map_key so
         // any key dismisses the overlay; this arm is unreachable under
         // normal flow but the match must be exhaustive.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -554,24 +554,30 @@ pub async fn run(
                                         break;
                                     }
                                     Some(SideEffect::OpenSshSession { vmid }) => {
-                                        let h = Arc::clone(&ssh_handler);
-                                        let tx_c = data_tx.clone();
-                                        let area = terminal.size().unwrap_or_default();
-                                        let cols = area.width.max(20);
-                                        let rows = area.height.saturating_sub(2).max(5);
-                                        crate::util::spawn_traced::spawn_traced(
-                                            "ssh_session_open",
-                                            async move {
-                                                let res = h.open(vmid, cols, rows).await;
-                                                let error = res.err().map(|e| format!("{e:#}"));
-                                                let _ = tx_c
-                                                    .send(DataMsg::SshSessionOpenResult {
-                                                        vmid,
-                                                        error,
-                                                    })
-                                                    .await;
-                                            },
-                                        );
+                                        // Encrypted key + no passphrase yet → prompt
+                                        // interactively instead of connecting (which
+                                        // would just fail). The prompt's submit
+                                        // re-enters here via SetSshPassphraseAndOpen.
+                                        if ssh_handler.needs_passphrase() {
+                                            app::update(
+                                                &mut state,
+                                                Action::SshPassphrasePrompt { vmid },
+                                            );
+                                        } else {
+                                            spawn_ssh_open(
+                                                &ssh_handler,
+                                                &data_tx,
+                                                terminal,
+                                                vmid,
+                                            );
+                                        }
+                                    }
+                                    Some(SideEffect::SetSshPassphraseAndOpen {
+                                        vmid,
+                                        passphrase,
+                                    }) => {
+                                        ssh_handler.set_passphrase(passphrase);
+                                        spawn_ssh_open(&ssh_handler, &data_tx, terminal, vmid);
                                     }
                                     Some(SideEffect::CloseSshSession) => {
                                         ssh_handler.close();
@@ -935,6 +941,30 @@ where
             };
         }
     }
+}
+
+/// Spawn the async SSH `open` for `vmid`, sizing the PTY from the
+/// current terminal and reporting the outcome back via `DataMsg`. Shared
+/// by the direct-open path and the post-passphrase-prompt retry so the
+/// two stay in lockstep.
+fn spawn_ssh_open<B: ratatui::backend::Backend>(
+    ssh_handler: &Arc<ssh_handler::SshSessionHandler>,
+    data_tx: &mpsc::Sender<DataMsg>,
+    terminal: &ratatui::Terminal<B>,
+    vmid: u32,
+) {
+    let h = Arc::clone(ssh_handler);
+    let tx_c = data_tx.clone();
+    let area = terminal.size().unwrap_or_default();
+    let cols = area.width.max(20);
+    let rows = area.height.saturating_sub(2).max(5);
+    crate::util::spawn_traced::spawn_traced("ssh_session_open", async move {
+        let res = h.open(vmid, cols, rows).await;
+        let error = res.err().map(|e| format!("{e:#}"));
+        let _ = tx_c
+            .send(DataMsg::SshSessionOpenResult { vmid, error })
+            .await;
+    });
 }
 
 /// Dispatch a side effect to the API. Async because most arms await
@@ -1563,7 +1593,9 @@ async fn dispatch_side_effect(
                 }
             });
         }
-        SideEffect::OpenSshSession { .. } | SideEffect::CloseSshSession => {
+        SideEffect::OpenSshSession { .. }
+        | SideEffect::SetSshPassphraseAndOpen { .. }
+        | SideEffect::CloseSshSession => {
             // SSH session lifecycle is handled directly in the run loop
             // because it owns the SshSessionHandler. Reaching here means
             // the dispatch was invoked from a path that shouldn't —
@@ -2002,8 +2034,10 @@ fn draw(f: &mut Frame, state: &AppState, ssh: &ssh_handler::SshSessionHandler) {
         widgets::modal::draw_help_overlay(f, area);
     } else if matches!(&state.mode, app::AppMode::Search) {
         views::search::draw(f, area, state);
-    } else if let app::AppMode::Command | app::AppMode::InputTag | app::AppMode::InputBroadcast =
-        &state.mode
+    } else if let app::AppMode::Command
+    | app::AppMode::InputTag
+    | app::AppMode::InputBroadcast
+    | app::AppMode::SshPassphrase { .. } = &state.mode
     {
         widgets::input_bar::draw_input_bar(f, area, &state.mode, &state.command_input);
     } else if let app::AppMode::ProfilePicker { profiles, selected } = &state.mode {

--- a/src/tui/ssh_handler.rs
+++ b/src/tui/ssh_handler.rs
@@ -28,11 +28,12 @@ pub struct SshSessionHandler {
     profile: ProfileConfig,
     known: Arc<TokioRwLock<KnownHosts>>,
     verifier: Arc<dyn HostKeyVerifier>,
-    /// SSH key passphrase (read once at startup from env). For now we
-    /// don't prompt interactively — passphrase-protected keys must be
-    /// either unlocked by ssh-agent (not yet supported here) or have
-    /// `PROXXX_SSH_KEY_PASSPHRASE` set in the environment.
-    passphrase: Option<String>,
+    /// SSH key passphrase. Seeded at startup from
+    /// `PROXXX_SSH_KEY_PASSPHRASE` (if set), and otherwise filled in at
+    /// runtime by the interactive TUI prompt (see [`Self::needs_passphrase`]
+    /// / [`Self::set_passphrase`]). Behind a `Mutex` so the prompt can
+    /// set it on the shared `Arc<SshSessionHandler>` without `&mut`.
+    passphrase: Mutex<Option<String>>,
     active: Mutex<Option<Arc<PtySession>>>,
 }
 
@@ -66,9 +67,48 @@ impl SshSessionHandler {
             profile,
             known,
             verifier,
-            passphrase,
+            passphrase: Mutex::new(passphrase),
             active: Mutex::new(None),
         }
+    }
+
+    fn passphrase(&self) -> Option<String> {
+        match self.passphrase.lock() {
+            Ok(g) => g.clone(),
+            Err(p) => p.into_inner().clone(),
+        }
+    }
+
+    /// Store a passphrase entered via the interactive prompt. Reused for
+    /// every subsequent connection this session, so the operator is
+    /// prompted at most once.
+    pub fn set_passphrase(&self, passphrase: String) {
+        match self.passphrase.lock() {
+            Ok(mut g) => *g = Some(passphrase),
+            Err(p) => *p.into_inner() = Some(passphrase),
+        }
+    }
+
+    /// True when opening a session would need a passphrase we don't have
+    /// yet: the configured key file is an encrypted OpenSSH key AND no
+    /// passphrase is currently set (neither env nor a prior prompt). The
+    /// TUI checks this before connecting and, if true, prompts first.
+    #[must_use]
+    pub fn needs_passphrase(&self) -> bool {
+        if self.passphrase().is_some() {
+            return false;
+        }
+        let Some(ssh) = self.profile.ssh.as_ref() else {
+            return false;
+        };
+        // Profile-level key (tilde-expanded). A per-guest key override is
+        // rare; if one is encrypted and the profile key isn't, the worst
+        // case is the old behaviour (connect surfaces the encrypted-key
+        // error) rather than a prompt — acceptable for the heuristic.
+        let Some(key_path) = ssh.key_path_resolved() else {
+            return false;
+        };
+        key_file_is_encrypted(&key_path)
     }
 
     /// Open a new PTY session. Closes any existing one first.
@@ -97,10 +137,11 @@ impl SshSessionHandler {
             anyhow::anyhow!("guest {vmid} not configured under [profiles.X.ssh.guests.\"{vmid}\"]")
         })?;
 
+        let pass = self.passphrase();
         let session = PtySession::open(
             vmid,
             target,
-            self.passphrase.as_deref(),
+            pass.as_deref(),
             Arc::clone(&self.known),
             Arc::clone(&self.verifier),
             cols,
@@ -190,5 +231,41 @@ impl SshSessionHandler {
     #[must_use]
     pub fn active_user(&self) -> Option<String> {
         self.snapshot().map(|s| s.user.clone())
+    }
+}
+
+/// Whether `key_path` is an *encrypted* OpenSSH private key (one that
+/// needs a passphrase to load). Reads metadata only — no passphrase
+/// required to answer. Returns `false` if the file is missing,
+/// unreadable, not an OpenSSH key, or an unencrypted key: in every such
+/// case we let the normal `load_secret_key` path run and surface any
+/// real error at connect time, rather than prompting spuriously.
+fn key_file_is_encrypted(key_path: &std::path::Path) -> bool {
+    use russh::keys::ssh_key::PrivateKey;
+    std::fs::read_to_string(key_path)
+        .ok()
+        .and_then(|pem| PrivateKey::from_openssh(&pem).ok())
+        .is_some_and(|k| k.is_encrypted())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::key_file_is_encrypted;
+    use std::io::Write;
+
+    #[test]
+    fn encrypted_check_false_for_missing_file() {
+        let p = std::path::Path::new("/nonexistent/proxxx/no-such-key");
+        assert!(!key_file_is_encrypted(p));
+    }
+
+    #[test]
+    fn encrypted_check_false_for_non_key_content() {
+        // A file that isn't an OpenSSH key must read as "not encrypted"
+        // (false) so we don't prompt — the real error surfaces at
+        // connect time instead.
+        let mut f = tempfile::NamedTempFile::new().expect("tempfile");
+        writeln!(f, "this is not a private key").expect("write");
+        assert!(!key_file_is_encrypted(f.path()));
     }
 }

--- a/src/tui/widgets/input_bar.rs
+++ b/src/tui/widgets/input_bar.rs
@@ -9,12 +9,26 @@ use ratatui::{
 };
 
 pub fn draw_input_bar(f: &mut Frame, area: Rect, mode: &AppMode, query: &str) {
-    let (prefix, title) = match mode {
-        AppMode::Search => ("/", " Fuzzy Search "),
-        AppMode::Command => (":", " Command "),
-        AppMode::InputTag => ("tag: ", " Select By Tag "),
+    // `mask` hides the typed text behind bullets — used for the SSH key
+    // passphrase so it never renders on screen (or in a screen-share).
+    let (prefix, title, mask) = match mode {
+        AppMode::Search => ("/", " Fuzzy Search ", false),
+        AppMode::Command => (":", " Command ", false),
+        AppMode::InputTag => ("tag: ", " Select By Tag ", false),
+        AppMode::SshPassphrase { .. } => (
+            "passphrase: ",
+            " Unlock SSH key — Enter to connect, Esc to cancel ",
+            true,
+        ),
         _ => return,
     };
+    // Render bullets, not the secret, when masking.
+    let displayed = if mask {
+        "•".repeat(query.chars().count())
+    } else {
+        query.to_string()
+    };
+    let query = displayed.as_str();
 
     // Place the input bar at the bottom — single divider line above
     // the input, no side/bottom chrome (the prefix `/` `:` glyph carries

--- a/src/tui/widgets/status_footer.rs
+++ b/src/tui/widgets/status_footer.rs
@@ -80,6 +80,7 @@ const fn mode_label_for(mode: &AppMode) -> &'static str {
         AppMode::ConfigGrep => "config grep",
         AppMode::Confirm { .. } => "confirm",
         AppMode::SshSession { .. } => "ssh",
+        AppMode::SshPassphrase { .. } => "ssh passphrase",
         AppMode::Help => "help",
         AppMode::ProfilePicker { .. } => "profile",
     }
@@ -93,6 +94,9 @@ fn bindings_for(view: &View, mode: &AppMode) -> Vec<(&'static str, &'static str)
     }
     if matches!(mode, AppMode::SshSession { .. }) {
         return vec![("Ctrl+]", "exit SSH")];
+    }
+    if matches!(mode, AppMode::SshPassphrase { .. }) {
+        return vec![("Enter", "connect"), ("Esc", "cancel")];
     }
     if matches!(mode, AppMode::ProfilePicker { .. }) {
         return vec![("j/k", "nav"), ("Enter", "switch"), ("Esc", "cancel")];


### PR DESCRIPTION
## Summary

When a guest SSH session in the TUI uses an **encrypted** OpenSSH key and no passphrase is available (neither `PROXXX_SSH_KEY_PASSPHRASE` nor one entered earlier this session), the TUI now **prompts for it** instead of failing the connect with an opaque error.

**Flow:** before opening, the run loop asks `SshSessionHandler::needs_passphrase()` — a **metadata-only** check (`PrivateKey::from_openssh(...).is_encrypted()`), so no connection attempt is wasted. If true, it enters a new `AppMode::SshPassphrase`; the typed passphrase accumulates in the shared input buffer, renders as **bullets** (never echoed — safe on a screen-share), and on **Enter** is cached on the handler and the session (re)opens. **Esc** cancels and pops back. The passphrase is wiped from the input buffer on submit/cancel and reused for the rest of the session, so the operator is prompted **at most once**.

The handler's `passphrase` field moves behind a `Mutex` so the prompt can set it on the shared `Arc<SshSessionHandler>`.

## Why this shape

This was billed "low effort" but the SSH auth path (`load_secret_key(path, passphrase) → authenticate_publickey`) plus the TUI raw-mode terminal make it a real state-machine change. Detecting encryption up front (rather than threading the deep `load_secret_key` error back through the async spawn) keeps the trigger simple and testable.

## Verification

- **Unit-tested** (the testable core, +6 tests, 611 lib total):
  - reducer state machine — prompt enters masked mode + clears buffer; input accumulates only while prompting; submit emits `SetSshPassphraseAndOpen` + restores session mode + wipes the buffer; cancel pops the connecting view.
  - encrypted-key detection safe paths — missing file / non-key file → no spurious prompt.
- **Manual-verify** for the full interactive flow: there's no TUI-input harness and it needs an actual encrypted key + terminal. As discussed when picking this option, the live TUI interaction is verified by hand, not in CI.

## Test plan

- [x] `cargo test --lib` (611 pass; 6 new)
- [x] `cargo clippy --all-targets` clean
- [x] full pre-commit gate green (422s)
- [ ] manual: open a guest SSH session with an encrypted key → masked prompt → connect (needs an encrypted key on a real setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)