### PR TITLE
chore(release): v0.5.0 — GitOps state expansion + cloud-init templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ SemVer contract:
 
 ## [Unreleased]
 
+_no entries yet._
+
+## [0.5.0] — 2026-05-22
+
+Headline: **GitOps state expansion + cloud-init templates.** Three new
+declaratively-managed resource families — scheduled backup jobs, the
+cluster firewall (options + aliases + IP sets + security groups), and
+notification matchers — carry epic #74 to 5 of 6 writable families
+(HA groups deferred: PVE 9's node-affinity `/cluster/ha/rules` has no
+write gateway yet). Plus one-command cloud-init **template** provisioning
+(`cloud-img provision`), PBS single-file restore (`pbs restore
+--pattern`), an interactive TUI SSH-key passphrase prompt, and a
+correctness fix turning `patch`'s silent serial downgrade into a loud
+error. Seven PRs (#112–#118); every state family and `cloud-img
+provision` verified end-to-end against the live PVE 9.1.1 cluster.
+
 ### Added
 - **TUI prompts for an SSH key passphrase interactively.** When a guest
   SSH session uses an encrypted OpenSSH key and no passphrase is set

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,7 @@ onMounted(() => {
 
 <div class="status-row">
   <span><span class="ok">●</span> <strong>main</strong> · gate green</span>
-  <span><strong>v0.4.0</strong></span>
+  <span><strong>v0.5.0</strong></span>
   <span><strong>full mutation lifecycle</strong> · LXC + cluster + QEMU + QGA</span>
   <span><strong>0</strong> system deps · rustls only</span>
   <span><strong>MIT</strong></span>

--- a/src/cli/cloudimg.rs
+++ b/src/cli/cloudimg.rs
@@ -7,7 +7,7 @@
 //! `app::iso_library::LIBRARY`; this module extends the same
 //! discipline to cloud images.
 //!
-//! ## What this MVP covers (per #65)
+//! ## What this module covers (per #65)
 //!
 //! - **Bundled registry** of cloud-image manifests. Checksum-pinned
 //!   per release (SHA-256 for Ubuntu/Fedora, SHA-512 for Debian/Alpine

--- a/src/state/diff.rs
+++ b/src/state/diff.rs
@@ -24,6 +24,11 @@
 //!   `"<path>:<kind>/<ugid>/<roleid>"` for display
 //! * Storage — `storage` (the operator-chosen id)
 //! * Backup job — `id` (the job id, operator- or PVE-assigned)
+//! * Firewall options — singleton (rendered identity `"cluster"`);
+//!   only ever an Update, never create/delete
+//! * Firewall alias / IP set — `name`
+//! * Firewall security group — `group` (create/delete only)
+//! * Notification matcher — `name`
 //!
 //! Update detection compares the full `*Decl` value with `PartialEq`
 //! — every non-identity field is part of the value. Touching any

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -4,12 +4,14 @@
 //! — the path toward declaratively-versioned Proxmox clusters tracked
 //! in epic [#74](https://github.com/fabriziosalmi/proxxx/issues/74).
 //!
-//! Today this module covers **pools, ACL, and storage definitions**
-//! across the full export → diff → apply loop. Cluster firewall,
-//! backup jobs, notifications, and HA groups land in follow-up PRs
-//! tracked by the epic. Pre-flight risk gates + HITL approval per
-//! destructive apply change are tracked separately and will wrap
-//! the dispatch layer without changing it.
+//! Today this module covers **pools, ACL grants, storage definitions,
+//! scheduled backup jobs, the cluster firewall (options + aliases + IP
+//! sets + security groups), and notification matchers** across the full
+//! export → diff → apply loop. HA groups are the one remaining family
+//! from the epic, deferred while PVE 9's node-affinity `/cluster/ha/rules`
+//! lacks a write gateway. Pre-flight risk gates + HITL approval per
+//! destructive apply change (shipped v0.3.0) wrap the dispatch layer in
+//! [`preflight`] without changing it.
 //!
 //! ## Layered design
 //!


### PR DESCRIPTION
## v0.5.0 (minor)

Cuts **v0.5.0** and bundles a draconian post-batch audit of everything since v0.4.0.

### Release content — 7 PRs (#112–#118)
- **state**: `backup-jobs`, `firewall-cluster`, and `notifications` (matchers) resource families → epic #74 at **5/6** writable families (HA deferred: PVE 9's `/cluster/ha/rules` has no write gateway yet).
- **`cloud-img provision`**: one-command cloud-init template orchestration (#65).
- **`pbs restore --pattern`**: single-file / selective restore.
- **`patch`**: reject `max_concurrent>1` loudly (was a silent serial downgrade).
- **tui**: interactive SSH key-passphrase prompt.

### Audit pass (this commit)
- **Cross-family consistency** — verified every one of the 9 `ClusterState` collections is wired through `Resource::all()`, `export_state`, `diff()`, `apply_one`, and (where applicable) `preflight`. No family missing from any list → the "perpetual create" bug class is absent.
- **Live re-verification** — `state export --resource all` (all 6 families) round-trips to a **clean diff** against PVE 9.1.1.
- **Stale-doc fixes** — `state/mod.rs` listed shipped families as "follow-up PRs"; `diff.rs` identity-key list omitted the firewall + notification families; `cloud-img` dropped the now-inaccurate "MVP" framing.
- Version bump (`0.4.0 → 0.5.0`, Cargo.toml + Cargo.lock + docs badge); CHANGELOG `[Unreleased] → [0.5.0]`.

### Verification
- Pre-commit gate **PASSED in 526s** (fmt, clippy(pedantic), audit, deny, release test, 87 live read probes, full mutation lifecycle).
- 611 lib tests green.

Merging this, then tagging **v0.5.0** to fire the 3-target signed build + SBOM (`release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)