### PR TITLE
feat(state): HA-rules GitOps state family — close epic #74 at 6/6

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -2501,6 +2501,33 @@ impl ProxmoxGateway for PxClient {
         Ok(())
     }
 
+    // ── PVE 9 HA rules — node-affinity + resource-affinity ─
+
+    async fn list_ha_rules(&self) -> Result<Vec<crate::api::types::HaRule>> {
+        let resp: ApiResponse<Vec<crate::api::types::HaRule>> =
+            self.get("/cluster/ha/rules").await?;
+        Ok(resp.data)
+    }
+
+    async fn create_ha_rule(&self, params: &[(&str, &str)]) -> Result<()> {
+        let _resp: ApiResponse<Option<String>> = self.post("/cluster/ha/rules", params).await?;
+        Ok(())
+    }
+
+    async fn update_ha_rule(&self, rule: &str, params: &[(&str, &str)]) -> Result<()> {
+        let _resp: ApiResponse<Option<String>> = self
+            .put(&format!("/cluster/ha/rules/{}", urlenc(rule)), params)
+            .await?;
+        Ok(())
+    }
+
+    async fn delete_ha_rule(&self, rule: &str) -> Result<()> {
+        let _resp: ApiResponse<Option<String>> = self
+            .delete(&format!("/cluster/ha/rules/{}", urlenc(rule)))
+            .await?;
+        Ok(())
+    }
+
     // ── PVE 8+ notifications impls ─────────────────────────
 
     async fn list_notification_endpoints(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1048,6 +1048,34 @@ pub trait ProxmoxGateway: Send + Sync {
     async fn update_ha_group(&self, group: &str, params: &[(&str, &str)]) -> Result<()>;
     async fn delete_ha_group(&self, group: &str) -> Result<()>;
 
+    // ── PVE 9 HA rules — node-affinity + resource-affinity (epic #74)
+
+    /// List HA rules — node-affinity + resource-affinity, mixed in one
+    /// array. PVE 9+ only; PVE 8 has no `/cluster/ha/rules` endpoint.
+    /// Read-only — `/cluster/ha/rules`.
+    async fn list_ha_rules(&self) -> Result<Vec<crate::api::types::HaRule>>;
+
+    /// Create an HA rule. `params` must include `type` (one of
+    /// `node-affinity` / `resource-affinity`) and `rule` (the id), plus
+    /// the plugin-specific fields (`nodes`+`strict` for node-affinity,
+    /// `affinity` for resource-affinity). Common fields (`resources`,
+    /// `comment`, `disable`) are accepted by both plugins. Requires
+    /// `Sys.Console` on `/`. POST `/cluster/ha/rules`.
+    async fn create_ha_rule(&self, params: &[(&str, &str)]) -> Result<()>;
+
+    /// Update one HA rule. The rule's `type` is immutable (PVE rejects
+    /// changes); to switch types, delete + create. Plugin-specific
+    /// fields apply per the existing rule's type. PVE keeps unspecified
+    /// fields at their old values — pass them in `delete` (repeated keys
+    /// per the matchers lesson) to clear them. PUT
+    /// `/cluster/ha/rules/{rule}`. Sys.Console on `/`.
+    async fn update_ha_rule(&self, rule: &str, params: &[(&str, &str)]) -> Result<()>;
+
+    /// Delete an HA rule. Resources it constrained revert to the global
+    /// HA defaults (no node preference, no affinity). DELETE
+    /// `/cluster/ha/rules/{rule}`. Sys.Console on `/`.
+    async fn delete_ha_rule(&self, rule: &str) -> Result<()>;
+
     // ── PVE 8+ notification system (cluster.notifications.*) ──
 
     async fn list_notification_endpoints(

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -2005,6 +2005,114 @@ impl HaGroup {
     }
 }
 
+/// One HA placement rule. Returned by `GET /cluster/ha/rules` (PVE 9+).
+///
+/// PVE 9 split the legacy `/cluster/ha/groups` "preferred-nodes-per-VM-set"
+/// concept into a plugin architecture under `/cluster/ha/rules` with two
+/// rule types today (more may land upstream):
+///
+/// * **`node-affinity`** — replaces what HA groups did: pin a set of HA
+///   resources to a set of nodes, optionally with `:priority` suffixes
+///   (`pve1:5,pve2`), optionally `strict` (no fallback to other nodes).
+/// * **`resource-affinity`** — `positive` keeps a set of resources on
+///   the SAME node (collocation); `negative` keeps them on DIFFERENT
+///   nodes (anti-affinity / spread). No `nodes` field — placement is
+///   computed relative to the set itself.
+///
+/// `digest` is server-generated and only relevant on PUT (optimistic
+/// concurrency — pass it back to detect a racing edit). On GET it's
+/// returned for inspection.
+///
+/// Plugin-specific fields not relevant to a given `rule_type` are simply
+/// absent in the response; serde's `default` makes the deserialize lossy
+/// across rule shapes without ad-hoc enum gymnastics — the consumer
+/// reads only the fields meaningful for `rule_type`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HaRule {
+    /// Rule identifier (the URL last-segment). Operator-chosen on create
+    /// — readable names like `keep-db-on-pve1`, `web-spread-cluster-a`.
+    pub rule: String,
+    /// `"node-affinity"` or `"resource-affinity"`. Future PVE versions
+    /// may add more; consumers should default-handle unknown types.
+    #[serde(rename = "type")]
+    pub rule_type: String,
+    /// Comma-separated HA SIDs the rule binds, e.g. `"vm:100,ct:200"`.
+    /// Parse with `parse_resource_list()` for structured access.
+    #[serde(default)]
+    pub resources: String,
+    /// Free-text comment.
+    #[serde(default)]
+    pub comment: String,
+    /// 1 = rule defined but inactive (CRM ignores it).
+    #[serde(default, deserialize_with = "deserialize_bool_from_int")]
+    pub disable: bool,
+    /// Server-generated config digest. Used as the `digest=` param on PUT
+    /// for optimistic concurrency; empty (or default) means "don't check".
+    #[serde(default)]
+    pub digest: String,
+
+    // ── node-affinity specific ─────────────────────────────────────
+    /// Target-node list, comma-separated with optional `:priority`
+    /// suffixes (`pve1:5,pve2`). Only meaningful when
+    /// `rule_type == "node-affinity"`. Parse with
+    /// `parse_priority_list()` for structured access.
+    #[serde(default)]
+    pub nodes: String,
+    /// 1 = resources must run on `nodes` (no fallback). 0 = `nodes` is a
+    /// preference; other nodes can host on failure. Only meaningful for
+    /// `node-affinity`.
+    #[serde(default, deserialize_with = "deserialize_bool_from_int")]
+    pub strict: bool,
+
+    // ── resource-affinity specific ─────────────────────────────────
+    /// `"positive"` (collocate) or `"negative"` (anti-collocate). Only
+    /// meaningful for `rule_type == "resource-affinity"`.
+    #[serde(default)]
+    pub affinity: String,
+}
+
+impl HaRule {
+    /// Parse `resources` (`"vm:100,ct:200"`) into a sorted, de-duplicated
+    /// `Vec<String>`. Empty input → empty Vec.
+    #[must_use]
+    pub fn parse_resource_list(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .resources
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect();
+        out.sort();
+        out.dedup();
+        out
+    }
+
+    /// Parse `nodes` (`"pve1:5,pve2,pve3:2"`) into `(name, priority)`
+    /// pairs (priority defaults to 0 when no suffix), sorted by
+    /// descending priority then name — same ordering as `HaGroup`.
+    #[must_use]
+    pub fn parse_priority_list(&self) -> Vec<(String, i32)> {
+        let mut out: Vec<(String, i32)> = self
+            .nodes
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|piece| {
+                if let Some((n, p)) = piece.split_once(':') {
+                    let prio = p.trim().parse::<i32>().unwrap_or(0);
+                    (n.trim().to_string(), prio)
+                } else {
+                    (piece.to_string(), 0)
+                }
+            })
+            .collect();
+        out.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+        out
+    }
+}
+
 /// One HA-managed resource (VM or CT). Returned by
 /// `GET /cluster/ha/resources`.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]

--- a/src/app/patch.rs
+++ b/src/app/patch.rs
@@ -1454,6 +1454,18 @@ mod tests {
         async fn delete_ha_group(&self, _: &str) -> Result<()> {
             anyhow::bail!("unused")
         }
+        async fn list_ha_rules(&self) -> Result<Vec<crate::api::types::HaRule>> {
+            Ok(vec![])
+        }
+        async fn create_ha_rule(&self, _: &[(&str, &str)]) -> Result<()> {
+            anyhow::bail!("unused")
+        }
+        async fn update_ha_rule(&self, _: &str, _: &[(&str, &str)]) -> Result<()> {
+            anyhow::bail!("unused")
+        }
+        async fn delete_ha_rule(&self, _: &str) -> Result<()> {
+            anyhow::bail!("unused")
+        }
         async fn list_notification_endpoints(
             &self,
         ) -> Result<Vec<crate::api::types::NotificationEndpoint>> {

--- a/src/state/apply.rs
+++ b/src/state/apply.rs
@@ -46,7 +46,8 @@ use crate::api::types::{Pool, PoolDetails};
 use crate::state::diff::{Change, ChangeKind};
 use crate::state::model::{
     AclDecl, BackupJobDecl, FirewallAliasDecl, FirewallGroupDecl, FirewallIpsetCidrDecl,
-    FirewallIpsetDecl, FirewallOptionsDecl, NotificationMatcherDecl, PoolDecl, StorageDecl,
+    FirewallIpsetDecl, FirewallOptionsDecl, HaRuleDecl, NotificationMatcherDecl, PoolDecl,
+    StorageDecl,
 };
 
 /// Options controlling apply behaviour.
@@ -171,6 +172,11 @@ pub trait StateWriteView: Send + Sync {
         params: &[(&str, &str)],
     ) -> Result<()>;
     async fn delete_notification_matcher_view(&self, name: &str) -> Result<()>;
+
+    // ── HA rules (PVE 9, epic #74) ────────────────────────
+    async fn create_ha_rule_view(&self, params: &[(&str, &str)]) -> Result<()>;
+    async fn update_ha_rule_view(&self, rule: &str, params: &[(&str, &str)]) -> Result<()>;
+    async fn delete_ha_rule_view(&self, rule: &str) -> Result<()>;
 }
 
 #[async_trait]
@@ -286,6 +292,16 @@ where
     async fn delete_notification_matcher_view(&self, name: &str) -> Result<()> {
         crate::api::ProxmoxGateway::delete_notification_matcher(self, name).await
     }
+
+    async fn create_ha_rule_view(&self, params: &[(&str, &str)]) -> Result<()> {
+        crate::api::ProxmoxGateway::create_ha_rule(self, params).await
+    }
+    async fn update_ha_rule_view(&self, rule: &str, params: &[(&str, &str)]) -> Result<()> {
+        crate::api::ProxmoxGateway::update_ha_rule(self, rule, params).await
+    }
+    async fn delete_ha_rule_view(&self, rule: &str) -> Result<()> {
+        crate::api::ProxmoxGateway::delete_ha_rule(self, rule).await
+    }
 }
 
 /// Apply a list of changes, in order, against a live cluster.
@@ -373,6 +389,9 @@ async fn apply_one<C: StateWriteView + ?Sized>(client: &C, change: &Change) -> A
         ("notification_matcher", ChangeKind::Delete) => {
             apply_notif_matcher_delete(client, change).await
         }
+        ("ha_rule", ChangeKind::Create) => apply_ha_rule_create(client, change).await,
+        ("ha_rule", ChangeKind::Update) => apply_ha_rule_update(client, change).await,
+        ("ha_rule", ChangeKind::Delete) => apply_ha_rule_delete(client, change).await,
         (resource, kind) => Err(anyhow::anyhow!(
             "unhandled change shape: resource={resource} kind={kind:?}"
         )),
@@ -1098,6 +1117,124 @@ async fn apply_notif_matcher_delete<C: StateWriteView + ?Sized>(
     client.delete_notification_matcher_view(&decl.name).await
 }
 
+/// Build the form-encoded params for `POST /cluster/ha/rules` and
+/// `PUT /cluster/ha/rules/{rule}`. The wire shape is flat: `type`,
+/// `rule` (POST only — PUT identifies via URL), `resources` as a
+/// CSV, `nodes` already-encoded with priority suffixes, `affinity`
+/// for resource-affinity, plus the common `comment`/`disable`/`strict`.
+///
+/// PVE's params parser accepts `0`/`1` for booleans uniformly across
+/// the API; we serialize that way (matches the notification matcher
+/// pattern and avoids `true`/`false` edge cases on older PVE versions).
+fn ha_rule_params(decl: &HaRuleDecl, include_rule_and_type: bool) -> Vec<(String, String)> {
+    let mut params: Vec<(String, String)> = Vec::new();
+    if include_rule_and_type {
+        // `type` is immutable on PUT (PVE rejects); only sent on create.
+        params.push(("type".to_string(), decl.rule_type.clone()));
+        params.push(("rule".to_string(), decl.rule.clone()));
+    }
+    // resources: rejoin the sorted Vec<String> into the wire CSV.
+    if !decl.resources.is_empty() {
+        params.push(("resources".to_string(), decl.resources.join(",")));
+    }
+    push_optional(&mut params, "comment", &decl.comment);
+    params.push((
+        "disable".to_string(),
+        if decl.disable { "1" } else { "0" }.to_string(),
+    ));
+    // node-affinity-only fields. Sending these for a resource-affinity
+    // rule is harmless — PVE's plugin layer drops fields not in the
+    // active plugin's schema with a 400 only when an unknown KEY is
+    // sent; `nodes`/`strict`/`affinity` are all *known* across both
+    // plugins (just dropped by the irrelevant one). Test this with a
+    // live cluster before relying on it; safer to filter by `rule_type`.
+    if decl.rule_type == "node-affinity" {
+        push_optional(&mut params, "nodes", &decl.nodes);
+        params.push((
+            "strict".to_string(),
+            if decl.strict { "1" } else { "0" }.to_string(),
+        ));
+    }
+    // resource-affinity-only field.
+    if decl.rule_type == "resource-affinity" {
+        push_optional(&mut params, "affinity", &decl.affinity);
+    }
+    params
+}
+
+async fn apply_ha_rule_create<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: HaRuleDecl = decode(change.after.as_ref(), "HA rule")?;
+    if decl.rule_type.is_empty() {
+        anyhow::bail!(
+            "HA rule '{}' missing `type` — must be 'node-affinity' or 'resource-affinity'",
+            decl.rule
+        );
+    }
+    let params = ha_rule_params(&decl, true);
+    client.create_ha_rule_view(&borrow(&params)).await
+}
+
+async fn apply_ha_rule_update<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let after: HaRuleDecl = decode(change.after.as_ref(), "HA rule")?;
+    // PUT cannot change `type` — PVE rejects with `type is immutable`.
+    // Detect a type change against `before` and surface an actionable
+    // error rather than letting PVE produce the cryptic one.
+    if let Some(before_val) = change.before.as_ref() {
+        let before: HaRuleDecl = decode(Some(before_val), "HA rule (before)")?;
+        if !before.rule_type.is_empty()
+            && !after.rule_type.is_empty()
+            && before.rule_type != after.rule_type
+        {
+            anyhow::bail!(
+                "HA rule '{}' type change ({} -> {}) is not supported by PVE — \
+                 delete + re-create the rule with the new type",
+                after.rule,
+                before.rule_type,
+                after.rule_type
+            );
+        }
+    }
+    let mut params = ha_rule_params(&after, false);
+    // PVE keeps unspecified fields at their old values (same trap the
+    // notification matcher hit). Send `delete=<key>` for fields that are
+    // now empty so the cluster converges. Per the matcher live-caught
+    // lesson, `delete` must be REPEATED keys (one per cleared field),
+    // never a CSV.
+    let mut del: Vec<&str> = Vec::new();
+    if after.comment.is_empty() {
+        del.push("comment");
+    }
+    if after.resources.is_empty() {
+        del.push("resources");
+    }
+    if after.rule_type == "node-affinity" && after.nodes.is_empty() {
+        del.push("nodes");
+    }
+    if after.rule_type == "resource-affinity" && after.affinity.is_empty() {
+        del.push("affinity");
+    }
+    for key in del {
+        params.push(("delete".to_string(), key.to_string()));
+    }
+    client
+        .update_ha_rule_view(&after.rule, &borrow(&params))
+        .await
+}
+
+async fn apply_ha_rule_delete<C: StateWriteView + ?Sized>(
+    client: &C,
+    change: &Change,
+) -> Result<()> {
+    let decl: HaRuleDecl = decode(change.before.as_ref(), "HA rule")?;
+    client.delete_ha_rule_view(&decl.rule).await
+}
+
 fn push_optional(params: &mut Vec<(String, String)>, key: &str, value: &str) {
     if !value.is_empty() {
         params.push((key.to_string(), value.to_string()));
@@ -1279,6 +1416,16 @@ mod tests {
         }
         async fn delete_notification_matcher_view(&self, name: &str) -> Result<()> {
             self.record(format!("delete_matcher({name})")).await
+        }
+        async fn create_ha_rule_view(&self, params: &[(&str, &str)]) -> Result<()> {
+            self.record(format!("create_ha_rule {params:?}")).await
+        }
+        async fn update_ha_rule_view(&self, rule: &str, params: &[(&str, &str)]) -> Result<()> {
+            self.record(format!("update_ha_rule({rule}) {params:?}"))
+                .await
+        }
+        async fn delete_ha_rule_view(&self, rule: &str) -> Result<()> {
+            self.record(format!("delete_ha_rule({rule})")).await
         }
     }
 
@@ -1961,5 +2108,183 @@ mod tests {
         .await;
         assert!(matches!(out2[0].result, ApplyResult::Applied));
         assert_eq!(c2.lines().await, vec!["delete_matcher(oncall)".to_string()]);
+    }
+
+    // ── HA rules (epic #74) ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn ha_rule_create_node_affinity_dispatches_with_type_and_strict() {
+        let decl = HaRuleDecl {
+            rule: "pin-db".into(),
+            rule_type: "node-affinity".into(),
+            resources: vec!["vm:100".into(), "vm:101".into()],
+            nodes: "pve1:5,pve2".into(),
+            strict: true,
+            ..HaRuleDecl::default()
+        };
+        let c = RecordingClient::default();
+        let create = Change {
+            kind: ChangeKind::Create,
+            resource: "ha_rule",
+            identity: "pin-db".into(),
+            before: None,
+            after: Some(serde_json::to_value(&decl).unwrap()),
+        };
+        let out = apply(&c, vec![create], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let line = &c.lines().await[0];
+        assert!(line.starts_with("create_ha_rule"));
+        // Type, rule id, resources CSV, nodes, strict=1 all wired.
+        assert!(line.contains("\"type\""));
+        assert!(line.contains("\"node-affinity\""));
+        assert!(line.contains("\"pin-db\""));
+        assert!(line.contains("vm:100,vm:101"), "resources CSV: {line}");
+        assert!(line.contains("\"nodes\""));
+        assert!(line.contains("\"strict\""));
+        assert!(line.contains("\"1\""), "strict serialised as 1: {line}");
+        // `affinity` is resource-affinity-only — must not be sent for
+        // a node-affinity rule.
+        assert!(!line.contains("\"affinity\""), "leak: {line}");
+    }
+
+    #[tokio::test]
+    async fn ha_rule_create_resource_affinity_omits_node_fields() {
+        let decl = HaRuleDecl {
+            rule: "web-spread".into(),
+            rule_type: "resource-affinity".into(),
+            resources: vec!["vm:200".into(), "vm:201".into()],
+            affinity: "negative".into(),
+            ..HaRuleDecl::default()
+        };
+        let c = RecordingClient::default();
+        let change = Change {
+            kind: ChangeKind::Create,
+            resource: "ha_rule",
+            identity: "web-spread".into(),
+            before: None,
+            after: Some(serde_json::to_value(&decl).unwrap()),
+        };
+        let out = apply(&c, vec![change], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let line = &c.lines().await[0];
+        assert!(line.starts_with("create_ha_rule"));
+        assert!(line.contains("\"affinity\""));
+        assert!(line.contains("\"negative\""));
+        // node-affinity-only fields must NOT leak through for a
+        // resource-affinity rule.
+        assert!(!line.contains("\"nodes\""), "leak: {line}");
+        assert!(!line.contains("\"strict\""), "leak: {line}");
+    }
+
+    #[tokio::test]
+    async fn ha_rule_update_clears_emptied_fields_via_repeated_delete_keys() {
+        // PVE keeps old values unless explicitly told to unset them;
+        // declaring an empty `comment` must send `delete=comment` as a
+        // standalone key. Same matcher-lesson: repeated keys, never a
+        // CSV list.
+        let after = HaRuleDecl {
+            rule: "pin-db".into(),
+            rule_type: "node-affinity".into(),
+            resources: vec!["vm:100".into()],
+            // intentionally empty: comment cleared, nodes kept
+            comment: String::new(),
+            nodes: "pve1".into(),
+            ..HaRuleDecl::default()
+        };
+        let before = HaRuleDecl {
+            rule: "pin-db".into(),
+            rule_type: "node-affinity".into(),
+            resources: vec!["vm:100".into()],
+            comment: "old".into(),
+            nodes: "pve1".into(),
+            ..HaRuleDecl::default()
+        };
+        let c = RecordingClient::default();
+        let change = Change {
+            kind: ChangeKind::Update,
+            resource: "ha_rule",
+            identity: "pin-db".into(),
+            before: Some(serde_json::to_value(&before).unwrap()),
+            after: Some(serde_json::to_value(&after).unwrap()),
+        };
+        let out = apply(&c, vec![change], ApplyOptions::default()).await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        let line = &c.lines().await[0];
+        assert!(line.starts_with("update_ha_rule(pin-db)"));
+        // `type` must NOT be sent on Update (PVE rejects type mutation).
+        assert!(!line.contains("\"type\""), "type leaked on PUT: {line}");
+        // `delete=comment` repeated key must be present.
+        assert!(
+            line.contains("\"delete\""),
+            "delete keys absent for cleared comment: {line}"
+        );
+        assert!(line.contains("\"comment\""));
+    }
+
+    #[tokio::test]
+    async fn ha_rule_update_rejects_type_change_with_actionable_error() {
+        // Switching `rule_type` on the same identifier is rejected by
+        // PVE with a cryptic message; we catch it upstream with a
+        // human-readable bail.
+        let before = HaRuleDecl {
+            rule: "r1".into(),
+            rule_type: "node-affinity".into(),
+            ..HaRuleDecl::default()
+        };
+        let after = HaRuleDecl {
+            rule: "r1".into(),
+            rule_type: "resource-affinity".into(),
+            affinity: "positive".into(),
+            ..HaRuleDecl::default()
+        };
+        let c = RecordingClient::default();
+        let change = Change {
+            kind: ChangeKind::Update,
+            resource: "ha_rule",
+            identity: "r1".into(),
+            before: Some(serde_json::to_value(&before).unwrap()),
+            after: Some(serde_json::to_value(&after).unwrap()),
+        };
+        let out = apply(&c, vec![change], ApplyOptions::default()).await;
+        match &out[0].result {
+            ApplyResult::Failed { error, .. } => {
+                assert!(
+                    error.contains("type change") && error.contains("delete + re-create"),
+                    "expected actionable type-change error, got: {error}"
+                );
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        // Apply should not have called the gateway at all for the
+        // rejected change.
+        assert!(c.lines().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ha_rule_delete_dispatches() {
+        let decl = HaRuleDecl {
+            rule: "pin-db".into(),
+            rule_type: "node-affinity".into(),
+            ..HaRuleDecl::default()
+        };
+        let c = RecordingClient::default();
+        let change = Change {
+            kind: ChangeKind::Delete,
+            resource: "ha_rule",
+            identity: "pin-db".into(),
+            before: Some(serde_json::to_value(&decl).unwrap()),
+            after: None,
+        };
+        let out = apply(
+            &c,
+            vec![change],
+            ApplyOptions {
+                prune: true,
+                ..ApplyOptions::default()
+            },
+        )
+        .await;
+        assert!(matches!(out[0].result, ApplyResult::Applied));
+        assert_eq!(c.lines().await, vec!["delete_ha_rule(pin-db)".to_string()]);
     }
 }

--- a/src/state/diff.rs
+++ b/src/state/diff.rs
@@ -40,7 +40,7 @@ use serde::Serialize;
 
 use crate::state::model::{
     AclDecl, BackupJobDecl, ClusterState, FirewallAliasDecl, FirewallGroupDecl, FirewallIpsetDecl,
-    FirewallOptionsDecl, NotificationMatcherDecl, PoolDecl, StorageDecl,
+    FirewallOptionsDecl, HaRuleDecl, NotificationMatcherDecl, PoolDecl, StorageDecl,
 };
 
 /// Kind of mutation a change represents. `Create` + `Delete` are
@@ -110,6 +110,7 @@ pub fn diff(declared: &ClusterState, live: &ClusterState) -> Vec<Change> {
         &live.notification_matchers,
         &mut out,
     );
+    diff_ha_rules(&declared.ha_rules, &live.ha_rules, &mut out);
     out
 }
 
@@ -591,6 +592,65 @@ fn diff_notification_matchers(
         out.push(Change {
             kind: ChangeKind::Create,
             resource: "notification_matcher",
+            identity: (*k).to_string(),
+            before: None,
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+}
+
+/// Diff HA rules by `rule` (identifier). Identity-by-`rule`; any other
+/// field change (type / resources / nodes / strict / affinity / disable
+/// / comment) is an Update. A `rule_type` change between an existing
+/// and a declared rule with the same `rule` id surfaces as an Update;
+/// PVE will refuse the PUT (type is immutable) and the apply error
+/// surfaces actionable next-step text. Operators wanting to switch
+/// type must Delete + re-Create.
+fn diff_ha_rules(declared: &[HaRuleDecl], live: &[HaRuleDecl], out: &mut Vec<Change>) {
+    use std::collections::HashMap;
+    let live_by: HashMap<&str, &HaRuleDecl> = live.iter().map(|r| (r.rule.as_str(), r)).collect();
+    let decl_by: HashMap<&str, &HaRuleDecl> =
+        declared.iter().map(|r| (r.rule.as_str(), r)).collect();
+
+    let mut deletes: Vec<_> = live_by
+        .keys()
+        .filter(|k| !decl_by.contains_key(*k))
+        .collect();
+    deletes.sort_unstable();
+    for k in deletes {
+        out.push(Change {
+            kind: ChangeKind::Delete,
+            resource: "ha_rule",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: None,
+        });
+    }
+
+    let mut updates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| live_by.get(*k).is_some_and(|l| *l != decl_by[*k]))
+        .collect();
+    updates.sort_unstable();
+    for k in updates {
+        out.push(Change {
+            kind: ChangeKind::Update,
+            resource: "ha_rule",
+            identity: (*k).to_string(),
+            before: serde_json::to_value(live_by[k]).ok(),
+            after: serde_json::to_value(decl_by[k]).ok(),
+        });
+    }
+
+    let mut creates: Vec<_> = decl_by
+        .keys()
+        .filter(|k| !live_by.contains_key(*k))
+        .collect();
+    creates.sort_unstable();
+    for k in creates {
+        out.push(Change {
+            kind: ChangeKind::Create,
+            resource: "ha_rule",
             identity: (*k).to_string(),
             before: None,
             after: serde_json::to_value(decl_by[k]).ok(),
@@ -1205,6 +1265,119 @@ mod tests {
             ..ClusterState::default()
         };
         assert!(diff(&s, &s).is_empty());
+    }
+
+    // ── HA rules (epic #74) ───────────────────────────────────────
+
+    #[test]
+    fn diff_ha_rule_create_update_delete() {
+        let mk_node = |rule: &str, nodes: &str, strict: bool| HaRuleDecl {
+            rule: rule.into(),
+            rule_type: "node-affinity".into(),
+            resources: vec!["vm:100".into(), "vm:101".into()],
+            nodes: nodes.into(),
+            strict,
+            ..HaRuleDecl::default()
+        };
+        // CREATE: declared has the rule, live empty.
+        let declared = ClusterState {
+            ha_rules: vec![mk_node("pin-db", "pve1:5,pve2", false)],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &ClusterState::default());
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Create);
+        assert_eq!(d[0].resource, "ha_rule");
+        assert_eq!(d[0].identity, "pin-db");
+
+        // DELETE: declared empty, live has the rule.
+        let d = diff(&ClusterState::default(), &declared);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Delete);
+        assert_eq!(d[0].resource, "ha_rule");
+
+        // UPDATE: same id, different `nodes` priority encoding.
+        let live = ClusterState {
+            ha_rules: vec![mk_node("pin-db", "pve1,pve2", false)],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &live);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Update);
+        assert_eq!(d[0].identity, "pin-db");
+        // Both sides serialised — preflight needs the before/after pair
+        // to detect a `strict` flip (Severe-tier).
+        assert!(d[0].before.is_some() && d[0].after.is_some());
+    }
+
+    #[test]
+    fn diff_ha_rule_resource_affinity_create() {
+        // Different rule_type — exercise the resource-affinity branch.
+        let declared = ClusterState {
+            ha_rules: vec![HaRuleDecl {
+                rule: "web-spread".into(),
+                rule_type: "resource-affinity".into(),
+                resources: vec!["vm:200".into(), "vm:201".into(), "vm:202".into()],
+                affinity: "negative".into(),
+                ..HaRuleDecl::default()
+            }],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &ClusterState::default());
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Create);
+        assert_eq!(d[0].identity, "web-spread");
+    }
+
+    #[test]
+    fn diff_identical_ha_rules_produces_no_change() {
+        let r = HaRuleDecl {
+            rule: "pin-db".into(),
+            rule_type: "node-affinity".into(),
+            resources: vec!["vm:100".into()],
+            nodes: "pve1".into(),
+            strict: true,
+            ..HaRuleDecl::default()
+        };
+        let s = ClusterState {
+            ha_rules: vec![r],
+            ..ClusterState::default()
+        };
+        assert!(diff(&s, &s).is_empty());
+    }
+
+    #[test]
+    fn diff_ha_rule_strict_flip_is_an_update() {
+        // Regression guard for the Severe-tier preflight path: a
+        // `strict` flip must produce an Update with before+after so
+        // preflight can detect it.
+        let live_rule = HaRuleDecl {
+            rule: "pin-db".into(),
+            rule_type: "node-affinity".into(),
+            resources: vec!["vm:100".into()],
+            nodes: "pve1".into(),
+            strict: false,
+            ..HaRuleDecl::default()
+        };
+        let mut decl_rule = live_rule.clone();
+        decl_rule.strict = true;
+        let declared = ClusterState {
+            ha_rules: vec![decl_rule],
+            ..ClusterState::default()
+        };
+        let live = ClusterState {
+            ha_rules: vec![live_rule],
+            ..ClusterState::default()
+        };
+        let d = diff(&declared, &live);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].kind, ChangeKind::Update);
+        let before: HaRuleDecl = serde_json::from_value(d[0].before.clone().unwrap()).unwrap();
+        let after: HaRuleDecl = serde_json::from_value(d[0].after.clone().unwrap()).unwrap();
+        assert!(
+            !before.strict && after.strict,
+            "strict flip must be visible"
+        );
     }
 
     #[test]

--- a/src/state/export.rs
+++ b/src/state/export.rs
@@ -20,13 +20,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::api::types::{
     AclEntry, ApiVersion, BackupJob, FirewallAlias, FirewallIpset, FirewallIpsetCidr,
-    FirewallOptions, FirewallSecurityGroup, NotificationMatcher, Pool, PoolDetails, PoolMember,
-    StorageDefinition,
+    FirewallOptions, FirewallSecurityGroup, HaRule, NotificationMatcher, Pool, PoolDetails,
+    PoolMember, StorageDefinition,
 };
 use crate::state::model::{
     AclDecl, BackupJobDecl, ClusterState, FirewallAliasDecl, FirewallGroupDecl,
-    FirewallIpsetCidrDecl, FirewallIpsetDecl, FirewallOptionsDecl, NotificationMatcherDecl,
-    PoolDecl, StateMeta, StorageDecl,
+    FirewallIpsetCidrDecl, FirewallIpsetDecl, FirewallOptionsDecl, HaRuleDecl,
+    NotificationMatcherDecl, PoolDecl, StateMeta, StorageDecl,
 };
 
 /// Which resource families to export. Parsed from the CLI `--resource`
@@ -47,6 +47,13 @@ pub enum Resource {
     /// design — they carry secrets PVE won't disclose on `GET`, so they
     /// can't round-trip; see [`ClusterState::notification_matchers`].
     Notifications,
+    /// HA placement rules (`/cluster/ha/rules`, PVE 9+) — node-affinity
+    /// and resource-affinity. Closes epic
+    /// [#74](https://github.com/fabriziosalmi/proxxx/issues/74). Legacy
+    /// `/cluster/ha/groups` (PVE 8) is intentionally NOT modelled — PVE 9
+    /// migrated it to rules, and we don't ship two parallel families for
+    /// the same desired-state surface.
+    HaRules,
 }
 
 impl Resource {
@@ -62,9 +69,10 @@ impl Resource {
             "backup-jobs" => Ok(vec![Self::BackupJobs]),
             "firewall-cluster" => Ok(vec![Self::FirewallCluster]),
             "notifications" => Ok(vec![Self::Notifications]),
+            "ha-rules" => Ok(vec![Self::HaRules]),
             "all" => Ok(Self::all()),
             other => anyhow::bail!(
-                "unknown resource '{other}' (valid: pools | acl | storage | backup-jobs | firewall-cluster | notifications | all — see https://github.com/fabriziosalmi/proxxx/issues/74 for the roadmap)"
+                "unknown resource '{other}' (valid: pools | acl | storage | backup-jobs | firewall-cluster | notifications | ha-rules | all)"
             ),
         }
     }
@@ -85,6 +93,7 @@ impl Resource {
             Self::BackupJobs,
             Self::FirewallCluster,
             Self::Notifications,
+            Self::HaRules,
         ]
     }
 
@@ -98,6 +107,7 @@ impl Resource {
             Self::BackupJobs => "backup-jobs",
             Self::FirewallCluster => "firewall-cluster",
             Self::Notifications => "notifications",
+            Self::HaRules => "ha-rules",
         }
     }
 }
@@ -126,6 +136,7 @@ pub trait StateReadView: Send + Sync {
     ) -> Result<Vec<FirewallIpsetCidr>>;
     async fn list_cluster_firewall_groups_view(&self) -> Result<Vec<FirewallSecurityGroup>>;
     async fn list_notification_matchers_view(&self) -> Result<Vec<NotificationMatcher>>;
+    async fn list_ha_rules_view(&self) -> Result<Vec<HaRule>>;
     async fn get_api_version_view(&self) -> Result<ApiVersion>;
 }
 
@@ -170,6 +181,9 @@ where
     async fn list_notification_matchers_view(&self) -> Result<Vec<NotificationMatcher>> {
         crate::api::ProxmoxGateway::list_notification_matchers(self).await
     }
+    async fn list_ha_rules_view(&self) -> Result<Vec<HaRule>> {
+        crate::api::ProxmoxGateway::list_ha_rules(self).await
+    }
     async fn get_api_version_view(&self) -> Result<ApiVersion> {
         crate::api::ProxmoxGateway::get_api_version(self).await
     }
@@ -205,6 +219,7 @@ pub async fn export_state<C: StateReadView + ?Sized>(
         firewall_ipsets: Vec::new(),
         firewall_groups: Vec::new(),
         notification_matchers: Vec::new(),
+        ha_rules: Vec::new(),
     };
 
     for r in resources {
@@ -247,6 +262,11 @@ pub async fn export_state<C: StateReadView + ?Sized>(
                 state.notification_matchers = export_notification_matchers(client)
                     .await
                     .with_context(|| "exporting notification matchers")?;
+            }
+            Resource::HaRules => {
+                state.ha_rules = export_ha_rules(client)
+                    .await
+                    .with_context(|| "exporting HA rules")?;
             }
         }
     }
@@ -535,6 +555,47 @@ async fn export_notification_matchers<C: StateReadView + ?Sized>(
         .collect())
 }
 
+/// Read every HA rule and project to `Vec<HaRuleDecl>`, sorted by
+/// `rule`. The wire-side `resources` comma-string is split, sorted, and
+/// deduped into a `Vec<String>` for TOML-friendly editing and for
+/// diff-stable identity equality (set equality vs string equality). The
+/// wire `nodes` priority-encoded string is kept verbatim — splitting
+/// would lose PVE's parser validation (duplicate-node rejection),
+/// recomposing risks reordering, and operators write the canonical
+/// `nodes` form by hand. `digest` is dropped (server-derived churn).
+async fn export_ha_rules<C: StateReadView + ?Sized>(client: &C) -> Result<Vec<HaRuleDecl>> {
+    let mut rules = client
+        .list_ha_rules_view()
+        .await
+        .context("listing HA rules")?;
+    rules.sort_by(|a, b| a.rule.cmp(&b.rule));
+
+    Ok(rules
+        .into_iter()
+        .map(|r| {
+            let mut resources: Vec<String> = r
+                .resources
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect();
+            resources.sort();
+            resources.dedup();
+            HaRuleDecl {
+                rule: r.rule,
+                rule_type: r.rule_type,
+                resources,
+                comment: r.comment,
+                disable: r.disable,
+                nodes: r.nodes,
+                strict: r.strict,
+                affinity: r.affinity,
+            }
+        })
+        .collect())
+}
+
 /// Sort the comma-separated tokens of a CSV-style PVE field. Empty
 /// input maps to empty output. Whitespace around commas is preserved
 /// (PVE doesn't emit any; if it ever does, we'd reformat on round-
@@ -702,6 +763,7 @@ mod tests {
                 Resource::BackupJobs,
                 Resource::FirewallCluster,
                 Resource::Notifications,
+                Resource::HaRules,
             ]
         );
         // `parse("all")` and `Resource::all()` must stay in lockstep —
@@ -725,6 +787,7 @@ mod tests {
             Resource::BackupJobs,
             Resource::FirewallCluster,
             Resource::Notifications,
+            Resource::HaRules,
         ] {
             assert!(all.contains(&r), "Resource::all() is missing {r:?}");
         }
@@ -776,6 +839,7 @@ mod tests {
         fw_ipset_cidrs: std::collections::HashMap<String, Vec<FirewallIpsetCidr>>,
         fw_groups: Vec<FirewallSecurityGroup>,
         notif_matchers: Vec<NotificationMatcher>,
+        ha_rules: Vec<HaRule>,
     }
 
     #[async_trait]
@@ -818,6 +882,9 @@ mod tests {
         }
         async fn list_notification_matchers_view(&self) -> Result<Vec<NotificationMatcher>> {
             Ok(self.notif_matchers.clone())
+        }
+        async fn list_ha_rules_view(&self) -> Result<Vec<HaRule>> {
+            Ok(self.ha_rules.clone())
         }
         async fn get_api_version_view(&self) -> Result<ApiVersion> {
             Ok(ApiVersion {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -6,12 +6,13 @@
 //!
 //! Today this module covers **pools, ACL grants, storage definitions,
 //! scheduled backup jobs, the cluster firewall (options + aliases + IP
-//! sets + security groups), and notification matchers** across the full
-//! export → diff → apply loop. HA groups are the one remaining family
-//! from the epic, deferred while PVE 9's node-affinity `/cluster/ha/rules`
-//! lacks a write gateway. Pre-flight risk gates + HITL approval per
-//! destructive apply change (shipped v0.3.0) wrap the dispatch layer in
-//! [`preflight`] without changing it.
+//! sets + security groups), notification matchers, and HA rules
+//! (node-affinity + resource-affinity)** across the full export → diff
+//! → apply loop. Epic #74 is now at 6/6 writable families. (Legacy PVE-8
+//! `/cluster/ha/groups` is intentionally not modelled — PVE 9 migrated
+//! it to `/cluster/ha/rules`, and proxxx targets PVE 9.x.) Pre-flight
+//! risk gates + HITL approval per destructive apply change (shipped
+//! v0.3.0) wrap the dispatch layer in [`preflight`] without changing it.
 //!
 //! ## Layered design
 //!

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -112,6 +112,21 @@ pub struct ClusterState {
     /// fail at apply with PVE's own error.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub notification_matchers: Vec<NotificationMatcherDecl>,
+
+    /// HA rules — `GET /cluster/ha/rules` (PVE 9+). Identity is `rule`.
+    /// Closes epic [#74](https://github.com/fabriziosalmi/proxxx/issues/74).
+    ///
+    /// Two `rule_type` values today: `node-affinity` (pin resources to a
+    /// node set, optionally with `:priority` and `strict` mode) and
+    /// `resource-affinity` (collocate or anti-collocate a set). The
+    /// legacy PVE-8 `/cluster/ha/groups` endpoint is NOT modelled: PVE 9
+    /// migrated it to rules (the old POST 500s), and we don't ship
+    /// two parallel families for the same desired-state surface.
+    ///
+    /// `digest` is server-generated for optimistic concurrency and is
+    /// deliberately NOT exported (would churn the TOML on every read).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub ha_rules: Vec<HaRuleDecl>,
 }
 
 /// Metadata header emitted by the export layer. Captures *which*
@@ -390,6 +405,72 @@ pub struct NotificationMatcherDecl {
     /// `true` = matcher is kept but inactive (no routing).
     #[serde(skip_serializing_if = "is_false")]
     pub disable: bool,
+}
+
+/// One HA placement rule — `GET /cluster/ha/rules` (PVE 9+). Identity
+/// is `rule`. Two rule types today (more may land upstream):
+///
+/// * **`node-affinity`** — pin `resources` to `nodes` (optionally with
+///   `node:priority` notation), optionally `strict` (no fallback).
+///   Replaces what PVE-8 HA groups did. Plugin-specific fields:
+///   `nodes`, `strict`.
+/// * **`resource-affinity`** — `positive` collocates a set on the same
+///   node; `negative` keeps them on different nodes (anti-affinity).
+///   No `nodes` field — placement is computed against the set itself.
+///   Plugin-specific field: `affinity`.
+///
+/// Resources are kept as a sorted `Vec<String>` of HA SIDs (`vm:100`,
+/// `ct:200`) on disk; the wire form uses a comma-encoded string. The
+/// list-form is friendlier for TOML editing and identity equality in
+/// the diff (`{"vm:100","ct:200"} == {"ct:200","vm:100"}`).
+///
+/// `nodes` is kept as `String` (priority-encoded) to match PVE's wire
+/// form exactly — splitting and recomposing would lose validation that
+/// PVE's parser does (e.g. duplicate-node rejection). Diff equality is
+/// byte-by-byte, so operators should write the canonical form
+/// (sorted nodes, `:priority` only where != 0).
+///
+/// `digest` is deliberately NOT modelled — server-generated, would
+/// churn the TOML on every export.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HaRuleDecl {
+    /// Rule identifier — the URL last-segment. Operator-chosen on
+    /// create (`keep-db-on-pve1`, `web-spread`).
+    pub rule: String,
+    /// `node-affinity` or `resource-affinity`. Mutating this on an
+    /// existing rule is rejected by PVE; the diff/apply layer treats a
+    /// `rule_type` change as Delete + Create (handled by identity
+    /// remaining the same, equality differing → Update; PVE will reject
+    /// the Update PUT; operators should delete + re-declare).
+    #[serde(rename = "type")]
+    pub rule_type: String,
+    /// HA SIDs the rule constrains, e.g. `vm:100`, `ct:200`. Sorted on
+    /// export. Empty = no resources bound (PVE rejects this on create).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub resources: Vec<String>,
+    /// Free-text comment.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub comment: String,
+    /// `true` = rule kept but inactive (CRM ignores it).
+    #[serde(skip_serializing_if = "is_false")]
+    pub disable: bool,
+
+    // ── node-affinity specific ─────────────────────────────────────
+    /// Target nodes with optional `:priority` (`pve1:5,pve2`). Only
+    /// meaningful for `node-affinity`; empty for `resource-affinity`.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub nodes: String,
+    /// `true` = resources MUST run on `nodes` (no fallback). Only
+    /// meaningful for `node-affinity`.
+    #[serde(skip_serializing_if = "is_false")]
+    pub strict: bool,
+
+    // ── resource-affinity specific ─────────────────────────────────
+    /// `positive` (collocate) or `negative` (anti-collocate). Only
+    /// meaningful for `resource-affinity`.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub affinity: String,
 }
 
 /// One cluster-wide storage definition — `GET /storage`. The

--- a/src/state/preflight.rs
+++ b/src/state/preflight.rs
@@ -25,6 +25,8 @@
 //! | [`StateRisk::FirewallAliasDelete`] / [`StateRisk::FirewallIpsetDelete`] | Warning — rules referencing `+name` break. |
 //! | [`StateRisk::FirewallGroupDelete`] | Severe — drops the group's rules (not modelled, so unrecoverable) and breaks group-direction rules. |
 //! | [`StateRisk::NotificationMatcherDelete`] | Warning — events that matched it stop being routed; alerting silently goes quiet. |
+//! | [`StateRisk::HaRuleDelete`] | Warning — resources fall back to global HA defaults (no node preference / no affinity); does not stop them, just removes the constraint. |
+//! | [`StateRisk::HaRuleStrictChange`] | Severe — flipping `strict` on a node-affinity rule can force-migrate every constrained guest (or refuse them placement) within seconds. |
 //! | [`StateRisk::BulkChangeCount { n }`] | Notice → Warning if `n ≥ 10`, Severe if `n ≥ 50` (very large batches = high attention cost). |
 //!
 //! ## Decision contract
@@ -118,6 +120,21 @@ pub enum StateRisk {
     /// (no error, the notifications just stop arriving).
     NotificationMatcherDelete { name: String },
 
+    /// Delete of an HA rule. Resources the rule constrained revert to
+    /// the global HA defaults (no node preference for node-affinity,
+    /// no collocation for resource-affinity). The guests don't stop —
+    /// they just lose the placement constraint.
+    HaRuleDelete { rule: String },
+
+    /// `strict` flag on a node-affinity HA rule flipped on an existing
+    /// rule. PVE's CRM enforces strict mode by force-migrating any
+    /// guest the rule binds that's not currently on one of `nodes` —
+    /// this can be a fleet-wide move within ~30s of apply. The
+    /// reverse direction (strict → non-strict) is non-destructive (the
+    /// constraint just relaxes), but the diff/apply layer can't tell
+    /// the direction here cheaply so we surface both as Severe.
+    HaRuleStrictChange { rule: String },
+
     /// Very-large-batch warning. Increases attention cost
     /// proportionally; defer with `--allow-risk` if intentional.
     BulkChangeCount { n: usize },
@@ -132,7 +149,8 @@ impl StateRisk {
             | Self::AclDeleteRootRole { .. }
             | Self::StorageDeleteShared { .. }
             | Self::FirewallDisabled
-            | Self::FirewallGroupDelete { .. } => RiskLevel::Severe,
+            | Self::FirewallGroupDelete { .. }
+            | Self::HaRuleStrictChange { .. } => RiskLevel::Severe,
             Self::StoragePropertyChange { .. }
             | Self::AclPropagateFlip { .. }
             | Self::AclDeleteAuditor { .. }
@@ -140,7 +158,8 @@ impl StateRisk {
             | Self::FirewallPolicyLoosened { .. }
             | Self::FirewallAliasDelete { .. }
             | Self::FirewallIpsetDelete { .. }
-            | Self::NotificationMatcherDelete { .. } => RiskLevel::Warning,
+            | Self::NotificationMatcherDelete { .. }
+            | Self::HaRuleDelete { .. } => RiskLevel::Warning,
             Self::BulkChangeCount { n } => {
                 if *n >= 50 {
                     RiskLevel::Severe
@@ -214,6 +233,14 @@ impl StateRisk {
             Self::NotificationMatcherDelete { name } => format!(
                 "delete notification matcher `{name}` — events it matched \
                  will silently stop being routed"
+            ),
+            Self::HaRuleDelete { rule } => format!(
+                "delete HA rule `{rule}` — constrained resources revert to \
+                 global HA defaults (no node preference, no affinity)"
+            ),
+            Self::HaRuleStrictChange { rule } => format!(
+                "node-affinity rule `{rule}` `strict` flag changed — CRM may \
+                 force-migrate every constrained guest within seconds"
             ),
             Self::BulkChangeCount { n } => {
                 format!("{n} changes in one apply — attention cost proportional")
@@ -389,6 +416,30 @@ fn assess_one(change: &Change, live: &ClusterState) -> Vec<StateRisk> {
             out.push(StateRisk::NotificationMatcherDelete {
                 name: change.identity.clone(),
             });
+        }
+        (ChangeKind::Delete, "ha_rule") => {
+            out.push(StateRisk::HaRuleDelete {
+                rule: change.identity.clone(),
+            });
+        }
+        (ChangeKind::Update, "ha_rule") => {
+            // Surface `strict` flips on node-affinity rules as Severe.
+            // Other Updates (resources list, comment, etc.) are routine.
+            let before: Option<crate::state::model::HaRuleDecl> = change
+                .before
+                .as_ref()
+                .and_then(|v| serde_json::from_value(v.clone()).ok());
+            let after: Option<crate::state::model::HaRuleDecl> = change
+                .after
+                .as_ref()
+                .and_then(|v| serde_json::from_value(v.clone()).ok());
+            if let (Some(b), Some(a)) = (before, after) {
+                if a.rule_type == "node-affinity" && b.strict != a.strict {
+                    out.push(StateRisk::HaRuleStrictChange {
+                        rule: change.identity.clone(),
+                    });
+                }
+            }
         }
         _ => {}
     }
@@ -801,5 +852,71 @@ mod tests {
         assert_eq!(r.len(), 1);
         assert_eq!(r[0].level(), RiskLevel::Warning);
         assert!(matches!(&r[0], StateRisk::NotificationMatcherDelete { name } if name == "oncall"));
+    }
+
+    #[test]
+    fn ha_rule_delete_is_warning() {
+        let live = sample_live();
+        let r = assess(&[delete_change("ha_rule", "pin-db")], &live);
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].level(), RiskLevel::Warning);
+        assert!(matches!(&r[0], StateRisk::HaRuleDelete { rule } if rule == "pin-db"));
+    }
+
+    #[test]
+    fn ha_rule_strict_flip_is_severe() {
+        // node-affinity rule with strict flipping false → true.
+        // The diff layer emits Update with both sides serialised;
+        // preflight inspects before/after to detect the flip.
+        let before = crate::state::model::HaRuleDecl {
+            rule: "pin-db".into(),
+            rule_type: "node-affinity".into(),
+            nodes: "pve1".into(),
+            strict: false,
+            ..crate::state::model::HaRuleDecl::default()
+        };
+        let after = crate::state::model::HaRuleDecl {
+            strict: true,
+            ..before.clone()
+        };
+        let change = Change {
+            kind: ChangeKind::Update,
+            resource: "ha_rule",
+            identity: "pin-db".into(),
+            before: Some(serde_json::to_value(&before).unwrap()),
+            after: Some(serde_json::to_value(&after).unwrap()),
+        };
+        let live = sample_live();
+        let r = assess(&[change], &live);
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].level(), RiskLevel::Severe);
+        assert!(matches!(&r[0], StateRisk::HaRuleStrictChange { rule } if rule == "pin-db"));
+    }
+
+    #[test]
+    fn ha_rule_update_without_strict_flip_emits_no_risk() {
+        // Routine Updates (resources, comment) shouldn't trigger any
+        // risk — only `strict` flips on node-affinity rules do.
+        let before = crate::state::model::HaRuleDecl {
+            rule: "pin-db".into(),
+            rule_type: "node-affinity".into(),
+            nodes: "pve1".into(),
+            comment: "old".into(),
+            ..crate::state::model::HaRuleDecl::default()
+        };
+        let after = crate::state::model::HaRuleDecl {
+            comment: "new".into(),
+            ..before.clone()
+        };
+        let change = Change {
+            kind: ChangeKind::Update,
+            resource: "ha_rule",
+            identity: "pin-db".into(),
+            before: Some(serde_json::to_value(&before).unwrap()),
+            after: Some(serde_json::to_value(&after).unwrap()),
+        };
+        let live = sample_live();
+        let r = assess(&[change], &live);
+        assert!(r.is_empty(), "comment-only Update must be risk-free");
     }
 }

--- a/tests/hitl_e2e.rs
+++ b/tests/hitl_e2e.rs
@@ -925,6 +925,18 @@ impl ProxmoxGateway for HitlMockGateway {
     async fn delete_ha_group(&self, _: &str) -> Result<()> {
         anyhow::bail!("unused")
     }
+    async fn list_ha_rules(&self) -> Result<Vec<proxxx::api::types::HaRule>> {
+        Ok(vec![])
+    }
+    async fn create_ha_rule(&self, _: &[(&str, &str)]) -> Result<()> {
+        anyhow::bail!("unused")
+    }
+    async fn update_ha_rule(&self, _: &str, _: &[(&str, &str)]) -> Result<()> {
+        anyhow::bail!("unused")
+    }
+    async fn delete_ha_rule(&self, _: &str) -> Result<()> {
+        anyhow::bail!("unused")
+    }
     async fn list_notification_endpoints(
         &self,
     ) -> Result<Vec<proxxx::api::types::NotificationEndpoint>> {


### PR DESCRIPTION
Closes [#74](https://github.com/fabriziosalmi/proxxx/issues/74).

Adds the last writable family from epic #74 to `proxxx state {export,diff,apply}`: node-affinity + resource-affinity rules under `/cluster/ha/rules` (PVE 9+), full CRUD with preflight risk tiering.

## Why now

The original deferral (2026-05-22) said: *"PVE 9's node-affinity `/cluster/ha/rules` has no write gateway — adding it is a separate larger task."* No longer true: `pve-ha-manager.git src/PVE/API2/HA/Rules.pm` exposes the full CRUD surface (verified at HEAD against `https://git.proxmox.com/?p=pve-ha-manager.git`):

| Method | Path | Perm |
|---|---|---|
| GET | / | Sys.Audit |
| GET | {rule} | Sys.Audit |
| **POST** | / | Sys.Console |
| **PUT** | {rule} | Sys.Console |
| **DELETE** | {rule} | Sys.Console |

Plugin schemas from `src/PVE/HA/Rules/{NodeAffinity,ResourceAffinity}.pm`:
- **node-affinity**: `nodes` (with `:priority` notation), `strict` (bool)
- **resource-affinity**: `affinity` (positive | negative)
- common: `type`, `rule`, `resources`, `disable`, `comment`, `digest`

## Architecture

Follows the matchers / firewall-cluster family pattern; each layer below is one section of the diff.

| Layer | What lands |
|---|---|
| `src/api/types.rs` | `HaRule` wire struct, flat. Plugin fields all optional; serde `default` makes deserialize lossy across rule types. `parse_resource_list` / `parse_priority_list` helpers mirror `HaGroup`. |
| `src/api/{mod.rs,client.rs}` | 4 new `ProxmoxGateway` methods (`list_ha_rules` / `create_ha_rule` / `update_ha_rule` / `delete_ha_rule`). Mock impls updated in `src/app/patch.rs` and `tests/hitl_e2e.rs`. |
| `src/state/model.rs` | `HaRuleDecl` (desired-state shape). `resources` becomes sorted `Vec<String>` for diff-stable set-equality. `nodes` stays wire-format (priority encoding preserved). `digest` dropped (server-derived). New field on `ClusterState`. |
| `src/state/export.rs` | New `Resource::HaRules` enum variant (parse / all / as_str). `StateReadView::list_ha_rules_view` (blanket impl). `export_ha_rules` reads, sorts by `rule`, splits resources CSV → sorted+deduped Vec. **Wired into `Resource::all()`** (the v0.5.0 durable lesson). |
| `src/state/diff.rs` | `diff_ha_rules` identity-by-`rule`, Delete → Update → Create order. Update emits both `before` + `after` so preflight can inspect transitions. |
| `src/state/apply.rs` | `ha_rule_params` builder is rule-type-aware (`nodes`/`strict` only for node-affinity, `affinity` only for resource-affinity — no field leak). Update path uses the matcher lesson: empty fields → repeated `delete=<key>` params (never CSV). `type` omitted on PUT (PVE rejects mutation); type-change caught upstream with actionable `"delete + re-create"` error. |
| `src/state/preflight.rs` | Two new `StateRisk`: `HaRuleDelete` (Warning) + `HaRuleStrictChange` (Severe). |

## Tests (+12 lib tests, 631→643)

| Test | Guards |
|---|---|
| `resource_all_includes_every_variant` (updated) | Every variant in `Resource::all()` |
| `resource_parse_all_returns_every_supported_family` (updated) | Explicit-order contract |
| `diff_ha_rule_create_update_delete` | Basic CRUD |
| `diff_ha_rule_resource_affinity_create` | Second rule type covered |
| `diff_ha_rule_strict_flip_is_an_update` | Preflight regression — before+after must round-trip |
| `diff_identical_ha_rules_produces_no_change` | Idempotency |
| `ha_rule_create_node_affinity_dispatches_with_type_and_strict` | Param wiring + leak check (no `affinity` field) |
| `ha_rule_create_resource_affinity_omits_node_fields` | Symmetric leak check |
| `ha_rule_update_clears_emptied_fields_via_repeated_delete_keys` | PUT must emit `delete=<key>` AND MUST NOT emit `type` |
| `ha_rule_update_rejects_type_change_with_actionable_error` | Upstream-friendly bail; gateway not called |
| `ha_rule_delete_dispatches` | Basic delete |
| `ha_rule_delete_is_warning` / `ha_rule_strict_flip_is_severe` / `ha_rule_update_without_strict_flip_emits_no_risk` | Preflight tiers |

## Out of scope

* **HA resources** (`/cluster/ha/resources`) — which guests are HA-managed; read path already exists, write path follow-up.
* **Legacy `/cluster/ha/groups`** — PVE 9 migrated this; proxxx targets PVE 9.x, no compat shim.
* **Live e2e** — schema validated against pve-ha-manager.git HEAD; live round-trip against the 9.1.1 homelab cluster will follow in a separate session when creds are at hand. All other unit + integration tests are green offline.

## Local gate

| Check | Result |
|---|---|
| `cargo fmt --all --check` | ✓ |
| `cargo clippy --all-targets -- -D warnings` | ✓ (stricter than CI's no-D) |
| `cargo test --lib` | 631 / 631 |
| `cargo test --all-targets` | ~1078 / ~1078 (only live-cluster tests ignored) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)