### PR TITLE
fix(release-notes): prefer [version] section over [Unreleased] in extractor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,10 +274,22 @@ jobs:
           ( cd dist && shasum -a 256 "proxxx-${VERSION}.cdx.json" > "proxxx-${VERSION}.cdx.json.sha256" )
 
       - name: Compose release notes
-        # Pull the `[Unreleased]` section from CHANGELOG.md if present;
-        # otherwise emit a minimal blurb. We deliberately do NOT use
+        # Pull the `[X.Y.Z]` section from CHANGELOG.md (the curated,
+        # human-written notes for THIS tag), falling back to
+        # `[Unreleased]` for the case where a tag is cut before the
+        # bump commit has renamed the section, and finally to a link
+        # to the file if both are missing. We deliberately do NOT use
         # `gh release create --generate-notes` — the curated CHANGELOG
         # entries beat the auto-generated commit-list every time.
+        #
+        # Why version-first (and not [Unreleased]-first like the
+        # original implementation): the repo's bump convention adds a
+        # new `## [X.Y.Z] — YYYY-MM-DD` section while leaving
+        # `## [Unreleased]` alone with a `_no entries yet._` placeholder.
+        # Old behaviour: every release page got that placeholder
+        # instead of the actual notes (visible on the v0.6.1 / v0.6.2
+        # pages before this fix). Version-first matches the section
+        # the bump commit just wrote.
         id: notes
         run: |
           set -e
@@ -286,10 +298,17 @@ jobs:
           {
             echo "## proxxx ${GITHUB_REF_NAME}"
             echo
-            # Try to extract the [Unreleased] section, stop at the
-            # next `## [` marker.
-            if awk '/^## \[Unreleased\]/{flag=1;next} /^## \[/{flag=0} flag' CHANGELOG.md > /tmp/unreleased.md && [ -s /tmp/unreleased.md ]; then
-              cat /tmp/unreleased.md
+            # 1) Per-version section — `## [X.Y.Z]` through the next
+            #    `## [` marker. `awk -v v=...` injects the version as
+            #    a literal substring (SemVer's `.` matches itself in
+            #    regex; no quoting needed for that).
+            # 2) `[Unreleased]` section — safety net for the
+            #    pre-bump-commit window or any future convention drift.
+            # 3) Link to CHANGELOG.md on the repo at this tag.
+            if awk -v v="$VERSION" '$0 ~ "^## \\["v"\\]"{flag=1;next} /^## \[/{flag=0} flag' CHANGELOG.md > /tmp/notes.md && [ -s /tmp/notes.md ]; then
+              cat /tmp/notes.md
+            elif awk '/^## \[Unreleased\]/{flag=1;next} /^## \[/{flag=0} flag' CHANGELOG.md > /tmp/notes.md && [ -s /tmp/notes.md ]; then
+              cat /tmp/notes.md
             else
               echo "See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF_NAME}/CHANGELOG.md) for details."
             fi


### PR DESCRIPTION
## The bug

The 'Compose release notes' step in [release.yml](.github/workflows/release.yml) was always extracting the `[Unreleased]` section from CHANGELOG.md. The repo's bump convention (see [94a5fbb](https://github.com/fabriziosalmi/proxxx/commit/94a5fbb) for v0.6.1 and [321d761](https://github.com/fabriziosalmi/proxxx/commit/321d761) for v0.6.2) **adds** a new `## [X.Y.Z] — YYYY-MM-DD` section while leaving `## [Unreleased]` untouched with a `_no entries yet._` placeholder — so every release page got that placeholder text instead of the actual notes humans wrote.

Visible on the live release pages, both literally rendering `_no entries yet._` as their body:
- [v0.6.1](https://github.com/fabriziosalmi/proxxx/releases/tag/v0.6.1)
- [v0.6.2](https://github.com/fabriziosalmi/proxxx/releases/tag/v0.6.2)

## The fix

Switch the awk to prefer the per-version section first, with two fallbacks:

1. **`awk -v v="$VERSION"` extracts `## [X.Y.Z]` → next `## [`.** The version interpolates as a literal substring; SemVer's `.` chars are regex meta but match themselves, so no escaping needed.
2. **`[Unreleased]` extraction stays as a safety net** — for the pre-bump-commit window, or any future convention drift where someone *does* put content under Unreleased.
3. **Fall through to the CHANGELOG.md link** as before.

## Verification (dry-runs against current CHANGELOG.md)

| `GITHUB_REF_NAME` | Result |
|---|---|
| `v0.6.2` | extracts **56 lines** from `## [0.6.2]` (Module shape headline + Changed/Fixed subsections); stops at the v0.6.1 boundary; no `_no entries yet._` leak |
| `v0.6.1` | extracts **20 lines** from `## [0.6.1]` (Correctness headline) |
| `v9.9.9` (non-existent) | 0 lines → falls through to `[Unreleased]` extraction (which is empty-ish for the current CHANGELOG) → then to the link |
| Edge: `v0.6.10-rc.1`-style version | matches literally; the `.` and `-` aren't regex problems |

End-to-end render simulation (running the full `run:` block with `GITHUB_REF_NAME=v0.6.2`):
```
=== Rendered notes (58 lines) ===
## proxxx v0.6.2

Headline: **Module shape — lift HTTP transport and the watch dispatch out
of the two largest monolithic files, behind a green audit gate.** Pure
housekeeping patch release: zero behaviour change, zero public-surface
...
```

## Not in scope

A separate `gh release edit` pass can backfill v0.6.1 and v0.6.2 with the now-correct generated notes — this commit alone only fixes **future** tags, not the historical pages. Happy to do that as a follow-up once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)