### PR TITLE
ci: docs su self-hosted, scorecard torna a ubuntu-latest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   build:
     name: Build VitePress
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -84,7 +84,7 @@ jobs:
     # Push to main only — PRs build but don't deploy.
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: [self-hosted, homelab]
+    runs-on: ubuntu-latest
     permissions:
       # Required for codeql-action/upload-sarif.
       security-events: write


### PR DESCRIPTION
**Cambio target runner per due workflow:**

| File | da | a | motivo |
|---|---|---|---|
| `scorecard.yml` | `[self-hosted, homelab]` | `ubuntu-latest` (revert) | Scorecard API ([restriction](https://github.com/ossf/scorecard-action#workflow-restrictions)) rifiuta il publish se il job non gira su Ubuntu GitHub-hosted. L'analisi gira ma 400 sul publish. Caso speciale. |
| `docs.yml` (build + deploy) | `ubuntu-latest` | `[self-hosted, Linux, X64]` | VitePress build + GitHub Pages deploy. Nessuna restrizione → buon candidato per il primo workflow self-hosted "vero". Label generica = sia Contabo (`vmi3020113`) sia homelab (`runner-02-homelab`) possono prendere il job. |

## Validazione precedente
Il PR #128 ha confermato end-to-end che il runner self-hosted homelab funziona: set up job, docker pull dell'action containerizzata, checkout, esecuzione. L'unico fail era la specifica restrizione lato Scorecard pubblico.

## Cosa monitorare dopo il merge
1. PR push → trigger pull_request (build only, no deploy). Vedi su quale runner atterra.
2. Merge → push su main → build + deploy.
3. `gh run list --repo fabriziosalmi/proxxx --workflow docs.yml --limit 3` per controllare runner usato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)