### PR TITLE
fix(release-notes): unwrap hard-wrapped paragraphs before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,43 @@ jobs:
           set -e
           VERSION="${GITHUB_REF_NAME#v}"
           NOTES_FILE="$(mktemp)"
+
+          # The unwrap-prototype lesson (v0.7.3 → v0.7.4): GitHub's
+          # release-page renderer treats single newlines INSIDE
+          # paragraphs as hard line breaks, NOT as the soft-wrap-becomes-
+          # space behaviour of standard GFM. CHANGELOG.md hard-wraps at
+          # ~75 chars for git-diff readability, so without post-processing
+          # every release page renders with visible mid-sentence breaks
+          # (visible on v0.6.1–v0.7.3 — backfilled in-place after this
+          # commit lands). The script below joins paragraph-internal
+          # lines into single lines while preserving list items
+          # (`- ...` / `* ...` / `1. ...`), headings (`# ...`),
+          # blockquotes (`> ...`), tables (`| ...`), indented continuations,
+          # and fenced code blocks.
+          cat > /tmp/unwrap.py <<'PY'
+          import sys, re
+          in_code = False
+          buf = []
+          def flush():
+              if buf:
+                  sys.stdout.write(" ".join(buf) + "\n")
+                  buf.clear()
+          for raw in sys.stdin.read().splitlines():
+              if raw.startswith("```"):
+                  flush(); print(raw); in_code = not in_code; continue
+              if in_code:
+                  flush(); print(raw); continue
+              if not raw.strip():
+                  flush(); print(); continue
+              stripped = raw.lstrip()
+              if raw != stripped:
+                  flush(); print(raw); continue
+              if re.match(r"^([-*+>#|]|\d+[.)]\s)", stripped):
+                  flush(); print(raw); continue
+              buf.append(raw)
+          flush()
+          PY
+
           {
             echo "## proxxx ${GITHUB_REF_NAME}"
             echo
@@ -306,9 +343,9 @@ jobs:
             #    pre-bump-commit window or any future convention drift.
             # 3) Link to CHANGELOG.md on the repo at this tag.
             if awk -v v="$VERSION" '$0 ~ "^## \\["v"\\]"{flag=1;next} /^## \[/{flag=0} flag' CHANGELOG.md > /tmp/notes.md && [ -s /tmp/notes.md ]; then
-              cat /tmp/notes.md
+              python3 /tmp/unwrap.py < /tmp/notes.md
             elif awk '/^## \[Unreleased\]/{flag=1;next} /^## \[/{flag=0} flag' CHANGELOG.md > /tmp/notes.md && [ -s /tmp/notes.md ]; then
-              cat /tmp/notes.md
+              python3 /tmp/unwrap.py < /tmp/notes.md
             else
               echo "See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF_NAME}/CHANGELOG.md) for details."
             fi


### PR DESCRIPTION
## The bug

GitHub's release-page renderer treats single newlines inside paragraphs as **hard line breaks** (visible as `<br>`-style splits in the UI), NOT as the soft-wrap-becomes-space behaviour of standard GFM. `CHANGELOG.md` hard-wraps paragraphs at ~75 chars for git-diff readability, so every release page from v0.6.1 through v0.7.3 has been rendering with visible mid-sentence breaks as a result — worst on the long headline paragraphs.

## The fix

After the awk extracts the per-version section, pipe through a small Python paragraph-unwrap pass that:

- Flushes-then-emits-blank on a blank line (paragraph separator)
- Flushes + emits verbatim for list items (`- / * / + / N. / N)`), headings (`#`), blockquotes (`>`), tables (`|`)
- Flushes + emits verbatim for indented lines (list-item continuations or indented-pre-formatted)
- Emits verbatim inside ```fenced code blocks```
- Accumulates everything else into the current paragraph buffer
- End-of-input flush keeps a trailing paragraph clean

Idempotent on flat-paragraph input.

## Backfill (separate from this PR's CI)

Same logic applied in-place to the 6 historical release pages via `gh release edit --notes-file` — done before opening this PR:

| Release | Paragraph-internal newlines joined |
|---|---|
| v0.6.1 | 22 |
| v0.6.2 | 24 |
| v0.7.0 | 19 |
| v0.7.1 | 31 |
| v0.7.2 | 31 |
| v0.7.3 | 15 |
| **Total** | **142** |

Byte counts identical pre/post (newline → space, same width). Rendered output now flat across all six pages.

## Verification (local)

Dry-run against current `CHANGELOG.md` [0.7.3] section produces single-line headline + intact list items + intact subsection headings. The Python script handles the common GFM block elements I care about.

## Lesson recorded

Saved in l0-memory (`repo:proxxx / release-notes-line-wrap-rendering`) for next time someone hits the same trap on a fresh project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)