### PR TITLE
feat(api): expose auth headers for WebSocket handshakes

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -137,6 +137,27 @@ impl AuthMethod {
         }
     }
 
+    /// Get the raw headers representing this auth method (e.g. for WebSocket handshakes)
+    pub fn headers(&self) -> Vec<(String, String)> {
+        match self {
+            Self::Token {
+                user,
+                token_id,
+                token_secret,
+            } => {
+                let secret_ref: &str = token_secret;
+                vec![(
+                    "Authorization".to_string(),
+                    format!("PVEAPIToken={user}!{token_id}={secret_ref}"),
+                )]
+            }
+            Self::Password { ticket, .. } => {
+                let ticket_ref: &str = ticket;
+                vec![("Cookie".to_string(), format!("PVEAuthCookie={ticket_ref}"))]
+            }
+        }
+    }
+
     /// Check if auth needs refresh (only relevant for password auth)
     pub fn needs_refresh(&self) -> bool {
         match self {
@@ -145,5 +166,82 @@ impl AuthMethod {
                 *expires_at < std::time::Instant::now() + std::time::Duration::from_mins(2)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_headers_emit_pveapi_authorization() {
+        // PVE's API-token auth flavor expects a single `Authorization`
+        // header of shape `PVEAPIToken=<user>!<tokenid>=<secret>`. This
+        // pins the format the WebSocket termproxy / vncproxy handshakes
+        // need — same shape as our HTTP requests (route through reqwest's
+        // header builder there, vs tungstenite's here).
+        let auth =
+            AuthMethod::from_token("root@pam", "proxxx-rw", "9b1c-be01-deca-fbad-deadbeefcafe");
+        let headers = auth.headers();
+        assert_eq!(headers.len(), 1, "token auth must emit exactly 1 header");
+        assert_eq!(headers[0].0, "Authorization");
+        assert_eq!(
+            headers[0].1,
+            "PVEAPIToken=root@pam!proxxx-rw=9b1c-be01-deca-fbad-deadbeefcafe"
+        );
+    }
+
+    #[test]
+    fn password_headers_emit_pveauthcookie_only() {
+        // For PAM/ticket auth the WS handshake needs the
+        // `PVEAuthCookie=<ticket>` cookie. The CSRF prevention token is
+        // deliberately NOT in this header set — PVE requires it only on
+        // state-changing HTTP requests, never on the WS upgrade. A
+        // future contributor reading the source should not "fix" the
+        // omission by adding it here.
+        use zeroize::Zeroizing;
+        let auth = AuthMethod::Password {
+            ticket: Zeroizing::new("PVE:root@pam:6A185B44::ZDPSgsM...".to_string()),
+            csrf_token: Zeroizing::new("6A185B44:4BTds5sVl8Z...".to_string()),
+            expires_at: std::time::Instant::now() + std::time::Duration::from_hours(2),
+        };
+        let headers = auth.headers();
+        assert_eq!(headers.len(), 1, "password auth must emit exactly 1 header");
+        assert_eq!(headers[0].0, "Cookie");
+        assert!(
+            headers[0].1.starts_with("PVEAuthCookie="),
+            "cookie value must be prefixed `PVEAuthCookie=`: {}",
+            headers[0].1
+        );
+        assert!(
+            headers[0].1.contains("PVE:root@pam:6A185B44::ZDPSgsM..."),
+            "cookie value must carry the full ticket verbatim: {}",
+            headers[0].1
+        );
+        // The CSRF prevention token must NOT leak into the WS headers.
+        // Pin it so a future "let's also send csrf" change breaks this test.
+        let combined = format!("{}: {}", headers[0].0, headers[0].1);
+        assert!(
+            !combined.contains("CSRFPreventionToken"),
+            "CSRF prevention token leaked into WS headers: {combined}"
+        );
+        assert!(
+            !combined.contains("6A185B44:4BTds5sVl8Z"),
+            "CSRF token value leaked into WS headers: {combined}"
+        );
+    }
+
+    #[test]
+    fn token_headers_handle_special_chars_in_user_and_token_id() {
+        // PVE userids can contain `@` (`<user>@<realm>`) and tokenids
+        // can contain `-` / digits. Both flow into the Authorization
+        // header verbatim — the format string takes care of the
+        // delimiters.
+        let auth = AuthMethod::from_token("alice@pve", "ops-2026-q2", "uuid-secret");
+        let headers = auth.headers();
+        assert_eq!(
+            headers[0].1,
+            "PVEAPIToken=alice@pve!ops-2026-q2=uuid-secret"
+        );
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -273,6 +273,29 @@ impl PxClient {
         &self.profile_config
     }
 
+    /// Retrieve the authentication headers for this client, suitable for
+    /// outbound non-HTTP connections that PVE authenticates the same way
+    /// (today: WebSocket termproxy + vncproxy handshakes).
+    ///
+    /// Calls [`PxClient::ensure_auth`] first so a long-idle PAM session
+    /// with an expiring ticket gets refreshed before we expose the
+    /// `PVEAuthCookie` header — otherwise the WS handshake would carry
+    /// a stale ticket and PVE would `401` the upgrade. Token auth is a
+    /// no-op refresh (token secrets don't expire).
+    ///
+    /// The returned vector is `(header-name, header-value)` pairs ready
+    /// for the tungstenite request builder:
+    /// * Token auth → one `Authorization: PVEAPIToken=<user>!<id>=<secret>`
+    /// * Password auth → one `Cookie: PVEAuthCookie=<ticket>`
+    ///
+    /// The CSRF prevention token is deliberately omitted — PVE only
+    /// requires it on state-changing HTTP requests, never on the
+    /// WebSocket upgrade.
+    pub async fn auth_headers(&self) -> Result<Vec<(String, String)>> {
+        self.ensure_auth().await?;
+        Ok(self.auth.read().await.headers())
+    }
+
     /// Send a request with retry on transient failures (SPOF 2.2 fix).
     ///
     /// `make_req` rebuilds the `RequestBuilder` on each attempt — required

--- a/src/cli/console.rs
+++ b/src/cli/console.rs
@@ -159,7 +159,11 @@ pub async fn execute_serial(
         &ticket.user,
     );
 
-    let mut ws = crate::wsterm::connect(&target, config.verify_tls).await?;
+    // Refresh auth (if needed) BEFORE the WS upgrade — a PAM ticket
+    // that's about to expire would 401 the handshake otherwise. Token
+    // auth is a no-op refresh.
+    let headers = client.auth_headers().await?;
+    let mut ws = crate::wsterm::connect(&target, config.verify_tls, &headers).await?;
 
     // Put the local terminal in raw mode + alternate screen so the
     // remote shell controls every keystroke. The global panic hook

--- a/src/wsterm/mod.rs
+++ b/src/wsterm/mod.rs
@@ -37,6 +37,7 @@ pub use url::{build_ws_target, WsTarget};
 pub async fn connect(
     target: &WsTarget,
     verify_tls: bool,
+    headers: &[(String, String)],
 ) -> Result<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 > {
@@ -49,11 +50,18 @@ pub async fn connect(
         Some(Connector::Rustls(Arc::new(cfg)))
     };
 
-    let request: tokio_tungstenite::tungstenite::handshake::client::Request = target
+    let mut request: tokio_tungstenite::tungstenite::handshake::client::Request = target
         .url
         .as_str()
         .into_client_request()
         .context("bad WS URL")?;
+
+    for (name, val) in headers {
+        let hn =
+            tokio_tungstenite::tungstenite::http::header::HeaderName::from_bytes(name.as_bytes())?;
+        let hv = tokio_tungstenite::tungstenite::http::HeaderValue::from_str(val)?;
+        request.headers_mut().insert(hn, hv);
+    }
 
     // (Gemini audit) — explicit frame/message size limits.
     //


### PR DESCRIPTION
Sprint 3.B landing. The starting point was a WIP that had been sitting on the working tree across multiple sessions; this PR carves out the **WS auth headers** thread cleanly and ships it focused, leaving the two unrelated changes that were mixed into the same WIP for separate follow-ups.

## What this PR ships

Plumbs PVE authentication headers through to the WebSocket termproxy (serial console) handshake. Defensive fix that makes `proxxx serial <vmid>` authenticate via **both** the URL-embedded ticket AND the proper auth headers — PVE accepts either, sending both is belt-and-suspenders that survives PVE-side termproxy auth tightening + opens the door for other WS endpoints (vncproxy, spiceproxy) that don't embed the ticket in the URL.

| File | Change |
|---|---|
| `src/api/auth.rs` | New `AuthMethod::headers()` returning the raw header pairs the WS handshake needs. Token auth → `Authorization: PVEAPIToken=…`. Password auth → `Cookie: PVEAuthCookie=…`. **CSRF deliberately omitted** (PVE only needs it on state-changing HTTP requests); regression test pins the omission. |
| `src/api/client.rs` | New `PxClient::auth_headers() -> Result<Vec>` wraps the above + **calls the existing `ensure_auth()` first** — an idle PAM session about to expire gets refreshed before we expose the cookie. Token auth is a no-op refresh. |
| `src/wsterm/mod.rs` | `connect()` now takes `headers: &[(String, String)]` and injects them via the tungstenite request builder before handshake. |
| `src/cli/console.rs` | `execute_serial` plumbs `client.auth_headers().await?` into `wsterm::connect`. |

## Tests (+3 lib, 643 → 646)

- `token_headers_emit_pveapi_authorization` — pins exact `PVEAPIToken=<user>!<id>=<secret>` shape
- `password_headers_emit_pveauthcookie_only` — pins the cookie shape **AND** that CSRF doesn't leak into the WS surface
- `token_headers_handle_special_chars_in_user_and_token_id` — delimiter robustness for `@` / `-` / digits

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | ✓ |
| `cargo clippy --all-targets -- -D warnings` | ✓ |
| `cargo test --lib` | 646 / 646 |
| `cargo test --all-targets` | ~1093 / 1093 (22 ignored = live-cluster only) |

## Carve-outs (NOT in this PR — for the user's follow-up)

The starting WIP also contained two unrelated changes I split out for scope discipline:

1. **`get_node_zfs_detail()` method on PxClient** — added but no caller in-tree yet. Probably feeds a future `proxxx ls zfs-detail` or similar. Belongs in a focused ZFS-detail PR.
2. **`fn config_path() → pub fn config_path()`** visibility flip in `src/config/mod.rs` — unused by anything else in the WIP. Likely staged for a future feature that needs cross-crate access to the config path. Belongs with whatever needs it.

Neither carve-out was destructive — both are trivially re-applied in their own PR when scope is clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)