### PR TITLE
docs: align README + reference docs with v0.7.4 codebase reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Pick the row that matches you and jump straight to the right page.
 
 - **One binary** — `proxxx`. CLI, TUI, MCP server, unified daemon (alerts + HITL + schedule) all in the same executable.
 - **Cluster-wide read in a second** — `proxxx ls nodes`, `proxxx ls guests`, fuzzy search across the whole cluster from `/`. `--all-profiles` fans the read across every configured cluster in parallel.
-- **GitOps for Proxmox** — `proxxx state {export,diff,apply}` produces a byte-stable TOML of pools/ACL/storage, diffs against live, converges via dispatched API calls. Pre-flight risk gates refuse Severe changes (non-empty pool delete, root-role ACL delete, shared-storage delete) unless `--allow-risk`; `--interactive` adds per-Severe `[y/N]` stdin prompts.
+- **GitOps for Proxmox** — `proxxx state {export,diff,apply}` produces a byte-stable TOML across **eight state families** (pools, ACL grants, storage definitions, backup jobs, cluster firewall, notification matchers, HA rules, HA resources), diffs against live, converges via dispatched API calls. Pre-flight risk gates refuse Severe changes (non-empty pool delete, root-role ACL delete, shared-storage delete, HA-rule strict-flip) unless `--allow-risk`; `--interactive` adds per-Severe `[y/N]` stdin prompts.
 - **Pipeline writes** — start, stop, migrate, snapshot, clone, backup, patch, disk-move, with `--format json` for jq. `migrate --stream` shows live per-disk progress.
-- **Pre-flight risk gate** — both per-guest (Locked/Running/LongUptime/TaggedProd/ActiveNetTraffic/HaManaged) and state-change (PoolDeleteNonEmpty/AclDeleteRootRole/StorageDeleteShared/BulkChangeCount) — refuses destructive ops without explicit override.
+- **Pre-flight risk gate** — both per-guest (Locked/Running/LongUptime/TaggedProd/ActiveNetTraffic/HaManaged + 5 more) and state-change (PoolDeleteNonEmpty/AclDeleteRootRole/StorageDeleteShared/BackupJobDelete/NotificationMatcherDelete/HaRuleDelete/HaRuleStrictChange/HaResourceDelete/HaResourceStateChange/BulkChangeCount) — refuses destructive ops without explicit override.
 - **HITL** — Telegram-mediated human approval gate, deny-on-timeout (120 s), policy-driven by tag / vmid / wildcard.
 - **Incident lockdown** — `proxxx incident freeze --reason X --ttl 4h` halts every mutation cluster-wide (`POST`/`PUT`/`DELETE` refuse with exit 8); `thaw` lifts it. Reads keep working for investigators.
 - **Console handoff + recording** — SSH/serial/SPICE/noVNC, all from `proxxx <verb> <vmid>`. `proxxx serial --record` writes asciinema cast v2; `proxxx play-cast` replays.
@@ -57,7 +57,7 @@ Pick the row that matches you and jump straight to the right page.
 - **PBS browse + restore** — REST browse plus `proxmox-backup-client` restore with `kill_on_drop` supervision. `proxxx backup-verify` does metadata-level integrity probing.
 - **Observability** — `proxxx logs tail` (cross-node journalctl fanout via SSH), `proxxx heatmap` (per-node API RTT), `proxxx anomaly` (z-score outliers), `proxxx accounting --timeframe month` (CPU-hours/GiB·h/net-GiB from per-guest RRD).
 - **Upgrade pre-flight** — `proxxx upgrade-check --target 9.x` scans cluster + config against bundled rules; exit code 1 on any block-severity finding (CI-gateable).
-- **Bundled error knowledge base** — `proxxx explain <error-id>` for every typed error proxxx can emit (13 entries; ships with the binary, no network needed).
+- **Bundled error knowledge base** — `proxxx explain <error-id>` for every typed error proxxx can emit (15 entries; ships with the binary, no network needed).
 - **Cluster digest for LLMs** — `proxxx describe --output llm-context` emits a token-compact prose+key:value paste-pronto for AI chats.
 - **MCP server** — stdio JSON-RPC + HTTP/SSE for LLM agents, compile-time-fixed tool registry, surface SHA-256 pinned. Server-sent `notifications/cluster-event` on both transports (task lifecycle + freeze/thaw events).
 - **Verifiable releases** — every tarball ships with three layers: SHA-256 sidecar, sigstore keyless cosign signature pinned to this exact workflow path (offline-verifiable; transparency-log inclusion proof embedded), and a CycloneDX SBOM generated from `Cargo.lock`. Audit with `cosign verify-blob` + `grype` / `trivy`.
@@ -276,9 +276,9 @@ Eight stages, run as both a pre-commit hook and the CI contract in [`.github/wor
 | 2 | `cargo clippy --release --all-targets` | 10–60 s |
 | 3 | `cargo audit --deny warnings` | 3–5 s |
 | 4 | `cargo deny check` (license / banned crates / sources / wildcards) | 2–4 s |
-| 5 | `cargo test --release --all-targets` (unit + integration + ~25 proptest properties × 256 cases each) | 10–90 s |
-| 6 | `tests/live/test_run.sh` (87 read-only probes against the live cluster) | ~30 s |
-| 7 | `tests/live/test_mutation.sh` (LXC + cluster-level CRUD + QEMU; opt-in QGA via `PROXXX_E2E_QGA_VMID=<vmid>`) | ~60 s |
+| 5 | `cargo test --release --all-targets` (646 lib tests + 447 integration tests including ~25 proptest properties × 256 cases each) | 10–90 s |
+| 6 | `tests/live/test_run.sh` (67 read-only probes against the live cluster) | ~30 s |
+| 7 | `tests/live/test_mutation.sh` (34 mutation probes: LXC + cluster-level CRUD across all 8 state families + QEMU; opt-in QGA via `PROXXX_E2E_QGA_VMID=<vmid>`) | ~60 s |
 
 End-to-end wall time against a reachable cluster: **~340–480 s**.
 
@@ -317,8 +317,9 @@ Pure Elm-pattern TUI over a typed REST client. The reducer is sync, total, and t
 | Module | Responsibility |
 | :--- | :--- |
 | [`src/app.rs`](src/app.rs) | Pure reducer. No I/O, no async. ~70 `Action` variants, ~20 `SideEffect`. |
-| [`src/api/`](src/api) | `ProxmoxGateway` trait, typed `ApiError` enum (8 categorical variants), reqwest client with 32 MiB body cap and rate limiter. |
-| [`src/api/error.rs`](src/api/error.rs) | `Unauthorized`, `Forbidden`, `NotFound`, `RateLimited`, `PayloadTooLarge`, `StorageHang`, `Transport`, `Schema`. Callers `.downcast_ref()` for differentiated handling. |
+| [`src/api/`](src/api) | `ProxmoxGateway` trait, typed `ApiError` enum (9 categorical variants), reqwest client with 32 MiB body cap and rate limiter. The `types/` directory holds ~3100 LOC of serde-typed PVE responses split across 16 submodules. |
+| [`src/api/error.rs`](src/api/error.rs) | `Unauthorized`, `Forbidden`, `NotFound`, `RateLimited`, `PayloadTooLarge`, `StorageHang`, `Transport`, `Parse`, `Other`. Callers `.downcast_ref()` for differentiated handling. |
+| [`src/state/`](src/state) | GitOps loop — model + export + diff + apply + preflight, eight state families (pools, ACL, storage, backup-jobs, firewall-cluster, notifications, HA rules, HA resources), byte-stable TOML. |
 | [`src/pbs/`](src/pbs) | PBS REST browse + `kill_on_drop(true)` supervision over `proxmox-backup-client restore`. |
 | [`src/ssh/`](src/ssh) | `russh`, publickey only, dedicated TOFU `known_hosts` (separate from `~/.ssh/`), per-node connection pool. |
 | [`src/app/cache.rs`](src/app/cache.rs) | SQLite-backed time-travel cache, drives `proxxx replay <timestamp>`. |
@@ -349,8 +350,8 @@ Pure Elm-pattern TUI over a typed REST client. The reducer is sync, total, and t
 
 | File | Tracked | Purpose |
 | :--- | :---: | :--- |
-| [`test_run.sh`](tests/live/test_run.sh) | ✓ | 87 read-only probes covering the full CLI surface; logs to `test_run.log` |
-| [`test_mutation.sh`](tests/live/test_mutation.sh) | ✓ | Full mutation lifecycle with `trap EXIT` cleanup: LXC 9999 (create → start → snapshot → stop → delete), cluster-level CRUD (pool / firewall-cluster alias+group+ipset / backup-job / notifications endpoint+matcher / storage-defs), QEMU 9998 from alpine ISO, opt-in QGA round-trips via `PROXXX_E2E_QGA_VMID=<vmid>` |
+| [`test_run.sh`](tests/live/test_run.sh) | ✓ | 67 read-only probes covering the full CLI surface; logs to `test_run.log` |
+| [`test_mutation.sh`](tests/live/test_mutation.sh) | ✓ | 34 mutation probes with `trap EXIT` cleanup: LXC 9999 (create → start → snapshot → stop → delete), cluster-level CRUD across all 8 state families (pool / ACL / storage-defs / backup-job / firewall-cluster alias+group+ipset / notifications matcher / HA rules / HA resources), QEMU 9998 from alpine ISO, opt-in QGA round-trips via `PROXXX_E2E_QGA_VMID=<vmid>` |
 | `test_*.log` | — | Generated by the harness |
 
 ## Honest non-goals

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -47,9 +47,10 @@ The architecture is shaped by four hard rules:
 
 1. **Single binary, no installer.** Cross-platform (macOS, Linux,
    musl static), zero system deps beyond TLS (rustls, no openssl).
-2. **No skip flags in the gate.** Six-stage pre-commit gate (fmt,
-   clippy, audit, all-tests, live read, live mutation) — anything
-   that bypasses it is owned by the bypasser.
+2. **No skip flags in the gate.** Eight-stage pre-commit gate
+   (secret-shape scan, fmt, clippy, audit, cargo-deny, all-tests,
+   live read, live mutation) — anything that bypasses it is owned
+   by the bypasser.
 3. **Three callers, one core.** CLI, TUI, MCP — same risk gate, same
    HITL gate, same API client. Whatever protections apply to one,
    apply to all.
@@ -68,7 +69,11 @@ src/
 │   ├── error.rs         ;   ApiError closed enum 
 │   ├── auth.rs          ;   Token / ticket / Zeroizing<String> 
 │   ├── mod.rs           ;   ProxmoxGateway trait
-│   └── types.rs         ;   ~2000 LOC of serde-typed PVE responses
+│   └── types/           ;   ~3100 LOC of serde-typed PVE responses,
+│                        ;   split across 16 submodules (cluster, ha,
+│                        ;   guest, guest_agent, storage, firewall,
+│                        ;   pool, node, node_hw, task, replication,
+│                        ;   access, acme, backup, console, notifications)
 ├── pbs/                 ; PBS REST client + restore subprocess
 ├── ssh/                 ; russh client + TOFU known_hosts + per-node pool
 ├── wsterm/              ; WebSocket termproxy client (serial console)
@@ -78,9 +83,16 @@ src/
 ├── mcp/                 ; Stdio JSON-RPC server + tool registry
 ├── access/              ; pveum shell-out for full grant-tree expansion
                           ; (`access permissions` API path is in api/client.rs)
+├── state/               ; GitOps loop — export, diff, apply across 8
+                          ; state families (pools, ACL, storage,
+                          ; backup-jobs, firewall-cluster,
+                          ; notifications, HA rules, HA resources)
+├── audit/               ; Append-only SQLite mutation log + HMAC chain
+├── incident/            ; Cluster-wide write kill-switch (freeze/thaw)
+├── metrics/             ; Cluster heatmap + accounting + anomaly
 ├── config/              ; TOML loader + secret resolution
 ├── util/                ; panic_hook, shutdown, format
-├── app.rs               ; Elm reducer (1700 LOC)
+├── app.rs               ; Elm reducer (~2000 LOC)
 ├── app/                 ; Sub-state for views
 │   ├── cache.rs         ;   SQLite time-travel cache
 │   ├── queue.rs         ;   Operation queue + replay-as-script
@@ -95,7 +107,7 @@ src/
 │   ├── mod.rs           ;   Run loop, dispatch, terminal guard
 │   ├── event.rs         ;   Crossterm key → Action mapping
 │   ├── terminal_guard.rs;   RAII enter/leave raw mode 
-│   ├── views/           ;   19 view modules (one per screen)
+│   ├── views/           ;   18 view modules (one per screen)
 │   └── widgets/         ;   modal, input_bar, pty
 └── cli/                 ; argv parser + execute()
 ```

--- a/docs/guide/pre-commit-gate.md
+++ b/docs/guide/pre-commit-gate.md
@@ -1,6 +1,6 @@
 # Pre-commit gate
 
-proxxx ships with a six-stage gate that runs against the local source
+proxxx ships with an eight-stage gate that runs against the local source
 tree AND a real Proxmox cluster. It is the single source of truth for
 "ready to commit". There are **no skip flags**.
 
@@ -10,34 +10,39 @@ tree AND a real Proxmox cluster. It is the single source of truth for
 git config core.hooksPath .githooks
 chmod +x scripts/gate.sh .githooks/pre-commit .githooks/pre-push
 cargo install cargo-audit --locked
+cargo install cargo-deny --locked
 ```
 
 Both hooks call `scripts/gate.sh`. Defense in depth — even if you
 `git commit --no-verify`, the push hook re-runs the gate before
 anything reaches the remote.
 
-## The six stages
+## The eight stages
 
 ```
-─── stage 1/6: cargo fmt --check ───
-─── stage 2/6: cargo clippy --release --all-targets ───
-─── stage 3/6: cargo audit --deny warnings ───
-─── stage 4/6: cargo test --release --all-targets ───
-─── stage 5/6: tests/live/test_run.sh ───
-─── stage 6/6: tests/live/test_mutation.sh ───
-✓ GATE PASSED in 84s
+─── stage 0/8: secret regression scan ───
+─── stage 1/8: cargo fmt --check ───
+─── stage 2/8: cargo clippy --release --all-targets ───
+─── stage 3/8: cargo audit --deny warnings ───
+─── stage 4/8: cargo deny check ───
+─── stage 5/8: cargo test --release --all-targets ───
+─── stage 6/8: tests/live/test_run.sh ───
+─── stage 7/8: tests/live/test_mutation.sh ───
+✓ GATE PASSED in ~340–480s
 ```
 
 | # | Stage | Time | Catches |
 |---|---|---|---|
+| 0 | secret regression scan | <1 s | inline secrets / tokens / private keys in staged files |
 | 1 | `cargo fmt --all -- --check` | ~3 s | formatting drift |
-| 2 | `cargo clippy --all-targets` | 10–60 s | lint policy: `unwrap_used`, `expect_used`, `panic`, `todo`, `await_holding_lock` are `deny` |
+| 2 | `cargo clippy --release --all-targets` | 10–60 s | lint policy: `unwrap_used`, `expect_used`, `panic`, `todo`, `await_holding_lock` are `deny` |
 | 3 | `cargo audit --deny warnings` | 3–5 s | new CVEs in `Cargo.lock`, against a documented advisory ignore policy in `.cargo/audit.toml` |
-| 4 | `cargo test --release --all-targets` | 10–90 s | full unit + integration + wiremock + TUI snapshot suites |
-| 5 | `tests/live/test_run.sh` | ~30 s | 88 read-only probes against a live cluster |
-| 6 | `tests/live/test_mutation.sh` | ~60 s | full mutation lifecycle: LXC 9999 (create → start → snapshot → stop → delete), cluster-level CRUD (pool / firewall-cluster / backup-jobs / notifications / storage-defs), QEMU 9998 from alpine ISO, opt-in QGA round-trips via `PROXXX_E2E_QGA_VMID=<vmid>` |
+| 4 | `cargo deny check` | 2–4 s | license whitelist, banned crates (`openssl`, `native-tls`, etc.), crates.io-only sources, wildcard ban — policy in `deny.toml` |
+| 5 | `cargo test --release --all-targets` | 10–90 s | full unit + integration + wiremock + TUI snapshot suites (646 lib tests + 447 integration tests + ~25 proptest properties × 256 cases each) |
+| 6 | `tests/live/test_run.sh` | ~30 s | 67 read-only probes against a live cluster |
+| 7 | `tests/live/test_mutation.sh` | ~60 s | 34 mutation probes covering full lifecycle: LXC 9999 (create → start → snapshot → stop → delete), cluster-level CRUD across all 8 state families (pools / ACL / storage-defs / backup-jobs / firewall-cluster / notifications / HA rules / HA resources), QEMU 9998 from alpine ISO, opt-in QGA round-trips via `PROXXX_E2E_QGA_VMID=<vmid>` |
 
-Stages 1–4 mirror CI exactly. Stages 5–6 require `pve1`,
+Stages 0–5 mirror CI exactly. Stages 6–7 require `pve1`,
 `pve2`, `pve3` to be reachable — they are skipped on
 machines without that environment, but they are **not** skipped on
 the developer's primary workstation where the cluster lives.
@@ -45,12 +50,12 @@ the developer's primary workstation where the cluster lives.
 ## Why integration tests in the gate
 
 A previous gate ran `cargo test --release --lib` only. That covered
-171 lib tests but missed 200+ tests in `tests/*.rs` that CI catches.
+the lib tests but missed the 447 tests in `tests/*.rs` that CI catches.
 A developer could land a stale-mock regression locally, push, and CI
 would fail in remote — wasting a round trip.
 
 The gate now runs `--all-targets` so the local checkpoint is *exactly*
-what CI sees. Stage 4 is intentionally identical to the
+what CI sees. Stage 5 is intentionally identical to the
 `.github/workflows/ci.yml#test` step.
 
 ## The audit policy
@@ -69,7 +74,7 @@ upstream-bumps tracked.
 
 ## What "live" means
 
-Stage 5 (read-only) runs every read CLI against the cluster:
+Stage 6 (read-only) runs every read CLI against the cluster:
 
 ```
 [probe] ls nodes      [OK] exit=0
@@ -77,33 +82,36 @@ Stage 5 (read-only) runs every read CLI against the cluster:
 [probe] ls storage    [OK] exit=0
 [probe] ha preview    [OK] exit=0
 [probe] hw conflicts  [OK] exit=0
-... 88 probes total, 0 fail ...
+... 67 probes total, 0 fail ...
 ```
 
-Stage 6 (mutation) runs the full lifecycle on the live cluster:
+Stage 7 (mutation) runs the full lifecycle on the live cluster:
 LXC 9999 (create → start → snapshot → stop → delete), cluster-level
-CRUD (pool / firewall-cluster alias+group+ipset / backup-job /
-notifications endpoint+matcher / storage-defs), QEMU 9998 booted
-from an alpine ISO, and — when `PROXXX_E2E_QGA_VMID=<vmid>` is set —
-QGA agent-required round-trips (file read / write / network probe /
-QMP sendkey). Every artifact uses a `proxxx-mut-` prefix and a
-`trap EXIT` cleanup sweeps even after a panic mid-test.
+CRUD across all 8 state families (pool / ACL grant / storage-defs /
+backup-job / firewall-cluster alias+group+ipset / notifications
+matcher / HA rules node-affinity+resource-affinity / HA resources),
+QEMU 9998 booted from an alpine ISO, and — when
+`PROXXX_E2E_QGA_VMID=<vmid>` is set — QGA agent-required round-trips
+(file read / write / network probe / QMP sendkey). Every artifact
+uses a `proxxx-mut-` prefix and a `trap EXIT` cleanup sweeps even
+after a panic mid-test.
 
 ## Bypassing
 
 The only way out is `git commit --no-verify` (or
 `git push --no-verify`). The committer **owns the consequence** —
 that is the explicit policy in `scripts/gate.sh`. CI will re-run
-all six stages and reject the push if anything is broken.
+all eight stages and reject the push if anything is broken.
 
 See [Bypass policy](/guide/bypass-policy) for when bypass is
 acceptable.
 
 ## Trade-offs
 
-- **Latency.** A commit-grade run is ~60–120 s end-to-end. This is
-  the price of "no surprises in CI".
-- **Cluster requirement.** Stages 5–6 assume the test cluster is up.
+- **Latency.** A commit-grade run is ~340–480 s end-to-end on the
+  primary workstation (with the cluster reachable). Stages 0–5 alone
+  are ~30–160 s. This is the price of "no surprises in CI".
+- **Cluster requirement.** Stages 6–7 assume the test cluster is up.
   If it is not, the hook fails — by design. proxxx does not pretend
   the cluster is fine when it cannot reach it.
 - **Strict mode.** There is no `--lite` mode. If you need to commit

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,11 +29,11 @@ features:
   - title: No agent on the cluster
     details: Direct REST against PVE (token or password) and PBS (token only), with typed error categories so callers match on the failure shape instead of grepping prose. SSH only for the paths PVE never exposed over REST — patch apply, full effective-permissions, per-guest interactive sessions, per-node journalctl tailing, GPU/IOMMU readiness probing.
   - title: Eight-stage commit gate, no skip flags
-    details: secret-shape scan, cargo fmt, cargo clippy --all-targets at deny tier, cargo audit against a pinned advisory policy, cargo deny check (license whitelist + banned crates + crates.io-only sources + wildcard ban), the full test suite (536 lib tests + 49 new integration tests (error-handling + resilience-chaos sweeps) including ~25 proptest properties at 256 random cases each, ~6 400 invariant checks total), 87 read-only probes against a live cluster, and a full mutation lifecycle covering LXC, cluster-level CRUD, QEMU, and opt-in QGA agent-required round-trips. Every commit on main passes locally and in CI.
+    details: secret-shape scan, cargo fmt, cargo clippy --all-targets at deny tier, cargo audit against a pinned advisory policy, cargo deny check (license whitelist + banned crates + crates.io-only sources + wildcard ban), the full test suite (646 lib tests + 447 integration tests including ~25 proptest properties at 256 random cases each, ~6 400 invariant checks total), 67 read-only probes against a live cluster, and a full mutation lifecycle covering LXC, cluster-level CRUD across all 8 state families, QEMU, and opt-in QGA agent-required round-trips. Every commit on main passes locally and in CI.
   - title: Pre-flight risk gate plus HITL
     details: 11 risk variants — running, long-uptime, locked, HA-managed, tagged prod, active net traffic, listening on service, many snapshots, backup age warning, no backup found, deep-check skipped — refuse destructive operations on guests that look like production unless overridden explicitly. Above that, a real Telegram round-trip with deny-on-timeout for any op marked destructive by policy. The same gate fires on `state apply` for non-empty pool deletes, root-role ACL deletes, shared-storage removal, and batches ≥ 50.
   - title: GitOps loop for Proxmox
-    details: '`proxxx state export` → `proxxx state diff` → `proxxx state apply` over pools, ACL grants, and cluster storage definitions. Byte-stable TOML snapshots, structural diff with exit code 2 on drift (CI-gateable), and a converge step with `--dry-run`, `--prune`, `--continue-on-error`, `--allow-risk`, and `--interactive` per-Severe stdin prompts.'
+    details: '`proxxx state export` → `proxxx state diff` → `proxxx state apply` over eight state families — pools, ACL grants, cluster storage definitions, backup jobs, cluster firewall (options + aliases + IP sets + security groups), notification matchers, HA rules, and HA resources. Byte-stable TOML snapshots, structural diff with exit code 2 on drift (CI-gateable), and a converge step with `--dry-run`, `--prune`, `--continue-on-error`, `--allow-risk`, and `--interactive` per-Severe stdin prompts.'
   - title: Incident lockdown
     details: '`proxxx incident freeze` raises a cluster-wide write kill-switch with TTL + audit log. Every `POST`/`PUT`/`DELETE` is refused with typed `FreezeRefusal` → exit code 8 until `proxxx incident thaw` or the TTL fires. Reads keep working. Designed for the "stop the bleeding" minute.'
 ---
@@ -98,7 +98,7 @@ onMounted(() => {
 
 <div class="status-row">
   <span><span class="ok">●</span> <strong>main</strong> · gate green</span>
-  <span><strong>v0.5.0</strong></span>
+  <span><strong>v0.7.4</strong></span>
   <span><strong>full mutation lifecycle</strong> · LXC + cluster + QEMU + QGA</span>
   <span><strong>0</strong> system deps · rustls only</span>
   <span><strong>MIT</strong></span>
@@ -108,11 +108,11 @@ onMounted(() => {
 
 | Surface               | Today                                                    |
 | :-------------------- | :------------------------------------------------------- |
-| Source                | ~60 KLOC Rust · ~14 KLOC tests · 536 lib tests + 49 new integration tests (error-handling + resilience-chaos sweeps)           |
+| Source                | ~66 KLOC Rust · ~16 KLOC tests · 646 lib tests + 447 integration tests (error-handling + resilience-chaos sweeps)           |
 | Quality gate          | 8 stages · ~340–480 s wall time (live cluster path)      |
-| Live cluster coverage | 87 read probes + 47 mutation probes per gate run         |
+| Live cluster coverage | 67 read probes + 34 mutation probes per gate run         |
 | Property testing      | ~25 proptest properties × 256 random cases = ~6 400 invariant checks per `cargo test` |
-| Mutation lifecycle    | LXC create→start→snapshot→stop→delete · cluster-level CRUD (pool / firewall-cluster / backup-jobs / notifications / storage-defs) · QEMU 9998 from alpine ISO · opt-in QGA round-trips |
+| Mutation lifecycle    | LXC create→start→snapshot→stop→delete · cluster-level CRUD across all 8 state families (pools / ACL / storage-defs / backup-jobs / firewall-cluster / notifications / HA rules / HA resources) · QEMU 9998 from alpine ISO · opt-in QGA round-trips |
 | Binary                | 6–9 MB stripped depending on target · single static · no installer |
 | Supply chain          | `cargo audit --deny warnings` + `cargo deny check` per push + nightly cron + CodeQL Rust SAST |
 | System dependencies   | 0 — rustls only, no native-tls, no openssl (banned in `deny.toml`) |
@@ -144,7 +144,8 @@ proxxx serial 100 --node pve1           # raw termproxy WebSocket
 proxxx spice  100 --node pve1           # writes .vv (0600), launches remote-viewer
 proxxx novnc  100 --node pve1           # opens browser to web UI's noVNC
 
-# GitOps loop over pools / ACLs / cluster storage
+# GitOps loop over 8 state families
+# (pools / ACL / storage / backup-jobs / firewall-cluster / notifications / ha-rules / ha-resources)
 proxxx state export > cluster.toml      # byte-stable TOML snapshot
 proxxx state diff cluster.toml          # exit 2 if drift (CI-gateable)
 proxxx state apply cluster.toml --dry-run

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -191,7 +191,7 @@ within a major version.
 
 | Command | What it does |
 | :--- | :--- |
-| `proxxx state export [--resource pools\|acl\|storage\|backup-jobs\|firewall-cluster\|notifications\|all] [--output toml\|json]` | Byte-stable snapshot of cluster state. Default emits TOML; `--output json` for piping. `firewall-cluster` covers options + aliases + IP sets + security groups; `notifications` covers matchers (routing rules; endpoints are out-of-band — they carry secrets PVE won't disclose). Diff-stable across runs against an unchanged cluster. |
+| `proxxx state export [--resource pools\|acl\|storage\|backup-jobs\|firewall-cluster\|notifications\|ha-rules\|ha-resources\|all] [--output toml\|json]` | Byte-stable snapshot of cluster state. Default emits TOML; `--output json` for piping. `firewall-cluster` covers options + aliases + IP sets + security groups; `notifications` covers matchers (routing rules; endpoints are out-of-band — they carry secrets PVE won't disclose); `ha-rules` covers node-affinity + resource-affinity rules (PVE 9+); `ha-resources` covers per-guest HA-managed declarations (state / group / max-relocate / max-restart / failback / comment). Diff-stable across runs against an unchanged cluster. |
 | `proxxx state diff <declared.toml> [--output text\|json]` | Structural diff of declared vs live. Exit 2 on drift. |
 | `proxxx state apply <declared.toml> [--dry-run] [--prune] [--continue-on-error] [--allow-risk] [--interactive] [--output text\|json]` | Converge live toward declared. Pre-flight risk gate refuses Severe changes (non-empty pool delete, root-role ACL delete, shared-storage delete, batch ≥ 50) without `--allow-risk`. `--interactive` adds per-Severe `[y/N]` stdin prompts. Exit code 6 on refusal. |
 


### PR DESCRIPTION
## Summary

Sweep aligning the public-facing docs with what actually shipped between v0.5.0 and v0.7.4. Triggered by an explicit drift audit — 7 high/medium findings plus a handful of correlated ones caught en route.

**Zero functional change. Docs only.** Build still green locally (`cargo build --release`).

## Drift fixed

**README.md**
- GitOps families: `pools/ACL/storage` → all 8 families
- Pre-flight state-change risk variants: 4 listed → full 10
- Error knowledge base: 13 → 15 entries
- Gate row: real test counts (646 lib + 447 integration), real probe counts (67 read, 34 mutation), mutation lifecycle covers all 8 state families
- ApiError variants: 8 → 9 (with correct names — Parse + Other, not Schema)
- New `src/state/` module row in the architecture table + types/ split note

**docs/index.md**
- Status row: `v0.5.0` → `v0.7.4`
- "By the numbers" table: 60K→66K LOC, 14K→16K test LOC, 536/49→646/447 tests, 87→67 read probes, 47→34 mutation probes
- Eight-stage feature card test counts brought current
- GitOps loop feature card lists all 8 families
- Taste-snippet GitOps comment lists all 8 families

**docs/reference/cli.md**
- `state export --resource` choice list adds `ha-rules` and `ha-resources` with per-family descriptions

**docs/architecture/overview.md**
- Six-stage gate description → eight-stage (with secret-scan + cargo-deny stages)
- `api/types.rs ~2000 LOC` monolith → `api/types/ ~3100 LOC, 16 submodules` (cluster, ha, guest, …)
- Module map adds `state/` (GitOps), `audit/` (HMAC chain), `incident/` (freeze/thaw), `metrics/`
- `app.rs` LOC: 1700 → ~2000; views count: 19 → 18

**docs/guide/pre-commit-gate.md**
- Full eight-stage rewrite — secret-scan (stage 0) and cargo-deny (stage 4) stages added, real test counts, real probe counts (67 + 34), mutation lifecycle lists all 8 state families, wall-time 60-120s → 340-480s

## Numbers were verified against HEAD

| Claim | Source-of-truth check |
| :--- | :--- |
| 646 lib tests | `cargo test --lib` → `test result: ok. 646 passed` |
| 447 integration tests | per-test `cargo test --test <name>` sum |
| 67 read-only probes | `grep -cE 'probe\s+"' tests/live/test_run.sh` |
| 34 mutation probes | `grep -cE 'probe\s+"' tests/live/test_mutation.sh` |
| 15 explain entries | `grep -c 'Entry {' src/cli/explain.rs` |
| 66 KLOC src | `find src -name '*.rs' \| xargs wc -l` |
| 16 KLOC tests | `find tests -name '*.rs' \| xargs wc -l` |
| 8 state families | `Resource::all()` in src/state/export.rs |
| 9 ApiError variants | enum variants in src/api/error.rs |
| 10 state-change risk variants | `pub enum StateRisk` in src/state/preflight.rs |
| 16 api/types/ submodules | `ls src/api/types/ \| wc -l` (17 incl. mod.rs) |
| 18 tui/views/ | `ls src/tui/views/ \| grep -v mod.rs \| wc -l` |
| 25 MCP tools | unchanged — already in docs |

## Test plan

- [x] `cargo build --release` — green
- [ ] CI gate (`.github/workflows/ci.yml`) — docs-only changes should be no-op for the test step, expect green
- [ ] Visual sanity-check on the GitHub Pages preview once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)