### PR TITLE
feat(tui): read-only multi-cluster fleet view (`proxxx fleet`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ SemVer contract:
 
 ## [Unreleased]
 
-_no entries yet._
+### Added — `proxxx fleet`: read-only multi-cluster fleet view
+
+- **New CLI subcommand `proxxx fleet`** launches a full-screen, **strictly read-only** TUI that aggregates nodes, guests, and storage across **every** configured `[profiles.NAME]` — clusters and standalone hosts, mixed — into one screen. Closes the long-standing "one cluster at a time in the TUI" gap: a homelab with N Proxmox endpoints is now viewable from a single pane without profile-switching.
+- **Read-only by construction, not by convention.** The fleet view runs in its own dedicated runner (`src/tui/fleet/`) that is a stripped-down mirror of `tui::run`: it wires **no** `SideEffect` channel, **no** HITL coordinator, **no** SSH handler, **no** op-queue, and **no** cache writes, and its keymap is navigation-only (`q`/`Esc`, `↑↓`/`jk`, `Tab`) — there is no code path from a keystroke to a mutation. It reuses the proven multi-profile read fan-out from `proxxx ls --all-profiles` (one fresh `PxClient` per profile; per-cluster failures degrade gracefully to a `DOWN` row and never abort the others).
+- **Attribution by containment, zero contract change.** Each cluster's `Node`/`Guest`/`StoragePool` live in a per-profile bucket that owns the profile name — the domain structs are **unmodified**, so the `--format json` CLI shape and the SQLite cache schema are byte-identical. No change to `AppState`, the single-profile TUI loop, or any existing command. `proxxx fleet` ignores `--profile` (it aggregates all of them); `--secure` is irrelevant (no writes exist).
+- The screen shows a per-cluster summary (reachable/down + error, node count, running/stopped guests, aggregate CPU cores, memory used/total, and storage used/total de-duplicated across nodes) plus an aggregated guest table; `Tab` toggles the guest pane between the selected cluster and the whole fleet. An unreachable cluster retains its last-known data (flagged stale) instead of flickering empty.
+- Tests: 11 reducer/aggregation unit tests, a wiremock multi-server integration test (real `PxClient` fan-out + graceful one-cluster-down degradation + shared-VMID attribution), a render snapshot, and a read-only live verification script (`tests/live/test_fleet_readonly.sh`).
 
 ## [0.7.4] — 2026-05-28
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -879,6 +879,13 @@ pub enum Command {
         /// Shell to generate completions for
         shell: clap_complete::Shell,
     },
+    /// Read-only fleet view — a full-screen TUI that aggregates nodes,
+    /// guests, and storage across EVERY configured `[profiles.NAME]`
+    /// (clusters and standalone hosts, mixed) into one screen. Strictly
+    /// read-only: no mutation path is reachable. Ignores `--profile`
+    /// (it aggregates all of them). Launched as its own dedicated TUI
+    /// runner; intercepted in `main.rs` before the CLI/stdout pipeline.
+    Fleet,
     /// Self-diagnostic: validate config, cluster connectivity, auth,
     /// Telegram HITL, PBS, SSH key, and audit log in one pass. Prints
     /// a status table and exits 0 if all critical checks pass, 1 if
@@ -1748,6 +1755,11 @@ pub async fn execute(
             unreachable!("Init handled in early-exit block")
         }
         Command::Completions { .. } => Ok((serde_json::json!({}), 0)),
+        // `Fleet` launches a TUI runner — intercepted in `main.rs`
+        // before `execute` (like `Completions`), so it never reaches
+        // the CLI/stdout pipeline. This arm exists only for match
+        // exhaustiveness.
+        Command::Fleet => Ok((serde_json::json!({}), 0)),
         Command::Doctor => Ok((serde_json::json!({}), 0)),
         Command::Audit { .. } => Ok((serde_json::json!({}), 0)),
         Command::State { action } => state::execute_state(&client, profile, action).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,15 @@ fn main() -> Result<()> {
                 return Ok(());
             }
 
+            // Fleet is a read-only full-screen TUI, not a stdout
+            // command — intercept it before `cli::execute` (mirrors the
+            // Completions early-exit). It aggregates ALL profiles, so it
+            // ignores `--profile`; `--secure` is irrelevant (no writes).
+            if matches!(cmd, cli::Command::Fleet) {
+                rt.block_on(tui::fleet::run_fleet(cli.token_secret.as_deref()))?;
+                return Ok(());
+            }
+
             match rt.block_on(cli::execute(
                 cmd,
                 cli.profile.as_deref(),

--- a/src/tui/fleet/mod.rs
+++ b/src/tui/fleet/mod.rs
@@ -1,0 +1,561 @@
+//! Read-only fleet view — aggregate nodes / guests / storage across
+//! EVERY configured profile into one screen.
+//!
+//! ## Why a separate runner
+//!
+//! The single-profile TUI (`tui::run`) is built around one
+//! `Arc<PxClient>`, one `DataMsg` channel, an `AppState`, an SSH
+//! handler, a HITL coordinator, and a keymap full of mutation actions.
+//! The fleet view aggregates N clusters and is *strictly read-only*, so
+//! it gets its OWN tiny runner instead of being bolted onto that loop.
+//! Nothing here touches `AppState`, the `SQLite` cache, or any write
+//! method on the gateway — the mutation machinery simply does not exist
+//! in this module, which is the structural guarantee that fleet mode
+//! cannot mutate a cluster.
+//!
+//! ## Attribution by containment
+//!
+//! Each cluster's `Node`/`Guest`/`StoragePool` live inside a
+//! [`FleetCluster`] bucket that owns the `profile` name. The domain
+//! structs are stored UNMODIFIED — we never add a `profile` field to
+//! them (that would change the CLI JSON contract and the cache schema).
+//! The `cluster` column in the guest table is synthesised from the
+//! bucket, never read off the guest.
+
+// `pub` so the snapshot test harness can call `fleet::view::draw`.
+pub mod view;
+mod worker;
+
+pub use worker::{fetch_with_gateway, fleet_fetch_all, FleetDataMsg};
+
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tokio::sync::mpsc;
+
+use super::event::{self, AppEvent};
+use super::terminal_guard::TerminalGuard;
+use crate::api::types::{GuestStatus, Node, StoragePool};
+
+/// Fleet poll cadence. Slower than the single-profile loop's 5s: a
+/// fleet sweep fans out over N clusters, so 10s halves the aggregate
+/// API load and is plenty for an at-a-glance overview.
+const FLEET_POLL_SECS: u64 = 10;
+
+/// One cluster/host's slice of the fleet. Attribution lives here: every
+/// `Node`/`Guest`/`StoragePool` inside is owned by `profile`.
+#[derive(Debug, Clone, Default)]
+pub struct FleetCluster {
+    pub profile: String,
+    /// `false` => unreachable / errored this cycle. The last-known
+    /// `nodes`/`guests`/`storage` are RETAINED (not blanked) so a
+    /// transient blip doesn't flicker the row empty; `error` says why.
+    pub reachable: bool,
+    pub error: Option<String>,
+    pub nodes: Vec<Node>,
+    pub guests: Vec<crate::api::types::Guest>,
+    pub storage: Vec<StoragePool>,
+}
+
+impl FleetCluster {
+    fn empty(profile: &str) -> Self {
+        Self {
+            profile: profile.to_string(),
+            ..Self::default()
+        }
+    }
+
+    #[must_use]
+    pub fn running_guests(&self) -> usize {
+        self.guests
+            .iter()
+            .filter(|g| g.status == GuestStatus::Running)
+            .count()
+    }
+
+    #[must_use]
+    pub fn stopped_guests(&self) -> usize {
+        self.guests
+            .iter()
+            .filter(|g| g.status == GuestStatus::Stopped)
+            .count()
+    }
+
+    #[must_use]
+    pub fn total_cpu_cores(&self) -> u32 {
+        self.nodes.iter().map(|n| n.maxcpu).sum()
+    }
+
+    #[must_use]
+    pub fn mem_used(&self) -> u64 {
+        self.nodes.iter().map(|n| n.mem).sum()
+    }
+
+    #[must_use]
+    pub fn mem_total(&self) -> u64 {
+        self.nodes.iter().map(|n| n.maxmem).sum()
+    }
+
+    /// Storage usage, de-duplicated by pool name. Shared storage (NFS,
+    /// PBS, `CephFS`) is reported once per-node by PVE; summing raw would
+    /// multiply a single 4 TB NAS by the node count. We fold by the
+    /// `storage` id and count each pool once.
+    #[must_use]
+    pub fn storage_used(&self) -> u64 {
+        self.dedup_storage(|p| p.used)
+    }
+
+    #[must_use]
+    pub fn storage_total(&self) -> u64 {
+        self.dedup_storage(|p| p.total)
+    }
+
+    fn dedup_storage(&self, field: impl Fn(&StoragePool) -> u64) -> u64 {
+        let mut seen = std::collections::HashSet::new();
+        let mut sum = 0u64;
+        for p in &self.storage {
+            if seen.insert(p.storage.as_str()) {
+                sum = sum.saturating_add(field(p));
+            }
+        }
+        sum
+    }
+}
+
+/// Which content the bottom pane shows. `↑↓` always moves the cluster
+/// selection in the summary table; `Tab` flips this.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FleetFocus {
+    /// Guests of the currently-selected cluster only.
+    #[default]
+    SelectedCluster,
+    /// Every guest across the whole fleet, with the `cluster` column.
+    AllGuests,
+}
+
+/// Single source of truth for fleet mode. Lives ONLY inside the fleet
+/// runner — never inside `AppState` — so the single-profile contract
+/// stays pristine. Fields are `pub` so the snapshot/integration tests
+/// can build a deterministic state without a constructor.
+#[derive(Debug, Clone, Default)]
+pub struct FleetState {
+    /// Stable, sorted by profile name (matches `fanout.rs` ordering).
+    pub clusters: Vec<FleetCluster>,
+    pub selected_index: usize,
+    pub focus: FleetFocus,
+    pub last_sync: Option<Instant>,
+    /// Hard error: couldn't even enumerate profiles. Shown as a banner.
+    pub fatal: Option<String>,
+}
+
+impl FleetState {
+    const fn select_next(&mut self) {
+        if !self.clusters.is_empty() {
+            self.selected_index = (self.selected_index + 1) % self.clusters.len();
+        }
+    }
+
+    fn select_prev(&mut self) {
+        if !self.clusters.is_empty() {
+            self.selected_index = self
+                .selected_index
+                .checked_sub(1)
+                .unwrap_or(self.clusters.len() - 1);
+        }
+    }
+
+    const fn toggle_focus(&mut self) {
+        self.focus = match self.focus {
+            FleetFocus::SelectedCluster => FleetFocus::AllGuests,
+            FleetFocus::AllGuests => FleetFocus::SelectedCluster,
+        };
+    }
+
+    /// `(profile, &Guest)` pairs for the bottom pane, attribution by
+    /// containment. Stable order `(profile, vmid)` for deterministic
+    /// rendering + snapshot diffs.
+    #[must_use]
+    pub fn visible_guests(&self) -> Vec<(&str, &crate::api::types::Guest)> {
+        let mut out: Vec<(&str, &crate::api::types::Guest)> = match self.focus {
+            FleetFocus::SelectedCluster => self
+                .clusters
+                .get(self.selected_index)
+                .map(|c| c.guests.iter().map(|g| (c.profile.as_str(), g)).collect())
+                .unwrap_or_default(),
+            FleetFocus::AllGuests => self
+                .clusters
+                .iter()
+                .flat_map(|c| c.guests.iter().map(move |g| (c.profile.as_str(), g)))
+                .collect(),
+        };
+        out.sort_by(|(pa, ga), (pb, gb)| pa.cmp(pb).then(ga.vmid.cmp(&gb.vmid)));
+        out
+    }
+}
+
+/// Find the bucket for `profile`, inserting an empty (unreachable) one
+/// when first seen. Returns its index in the sorted `clusters` vec.
+fn idx_for(clusters: &mut Vec<FleetCluster>, profile: &str) -> usize {
+    if let Some(i) = clusters.iter().position(|c| c.profile == profile) {
+        return i;
+    }
+    clusters.push(FleetCluster::empty(profile));
+    clusters.sort_by(|a, b| a.profile.cmp(&b.profile));
+    clusters
+        .iter()
+        .position(|c| c.profile == profile)
+        .unwrap_or(0)
+}
+
+/// Pure reducer: fold one [`FleetDataMsg`] into the [`FleetState`]. No
+/// I/O, no clock reads — fully deterministic for unit tests.
+pub fn apply(state: &mut FleetState, msg: FleetDataMsg) {
+    match msg {
+        FleetDataMsg::ClusterSnapshot {
+            profile,
+            nodes,
+            guests,
+            storage,
+        } => {
+            // A successful snapshot anywhere clears a prior fatal
+            // (profiles became enumerable again).
+            state.fatal = None;
+            let i = idx_for(&mut state.clusters, &profile);
+            if let Some(c) = state.clusters.get_mut(i) {
+                c.nodes = nodes;
+                c.guests = guests;
+                c.storage = storage;
+                c.reachable = true;
+                c.error = None;
+            }
+        }
+        FleetDataMsg::ClusterError { profile, error } => {
+            let i = idx_for(&mut state.clusters, &profile);
+            if let Some(c) = state.clusters.get_mut(i) {
+                // Retain last-known data; just flag it stale.
+                c.reachable = false;
+                c.error = Some(error);
+            }
+        }
+        FleetDataMsg::FatalError(e) => {
+            state.fatal = Some(e);
+        }
+    }
+    // Keep the selection in range as clusters appear.
+    if state.selected_index >= state.clusters.len() {
+        state.selected_index = state.clusters.len().saturating_sub(1);
+    }
+}
+
+/// Top-level fleet runner. A stripped-down read-only mirror of
+/// `tui::run`: terminal guard + a poll worker + a tiny event loop with
+/// a navigation-only keymap. No `SideEffect`, no HITL, no SSH, no cache
+/// writes — there is no code path from a keystroke to a mutation.
+pub async fn run_fleet(cli_secret: Option<&str>) -> Result<()> {
+    let mut guard = TerminalGuard::install()?;
+    guard.terminal_mut().clear()?;
+
+    let mut state = FleetState::default();
+
+    let (tx, mut rx) = mpsc::channel::<FleetDataMsg>(64);
+    let secret = cli_secret.map(str::to_owned);
+    // The worker is the only sender; it owns `tx` for its lifetime.
+    let worker = tokio::spawn(async move {
+        loop {
+            fleet_fetch_all(secret.as_deref(), &tx).await;
+            tokio::time::sleep(Duration::from_secs(FLEET_POLL_SECS)).await;
+        }
+    });
+
+    // 250ms tick guarantees we drain data + redraw ~4×/s even with no
+    // keyboard input.
+    let mut events = event::spawn_event_loop(Duration::from_millis(250));
+
+    loop {
+        let mut dirty = false;
+        while let Ok(msg) = rx.try_recv() {
+            apply(&mut state, msg);
+            dirty = true;
+        }
+        if dirty {
+            state.last_sync = Some(Instant::now());
+        }
+
+        guard
+            .terminal_mut()
+            .draw(|f| view::draw(f, f.area(), &state))?;
+
+        match events.recv().await {
+            Some(AppEvent::Key(key)) => {
+                if handle_key(&mut state, key) {
+                    break;
+                }
+            }
+            Some(AppEvent::Resize(..) | AppEvent::Tick) => {}
+            None => break,
+        }
+    }
+
+    worker.abort();
+    guard.restore()?;
+    Ok(())
+}
+
+/// Navigation-only keymap. Returns `true` when the user wants to quit.
+/// Deliberately NOT `event::map_key` — that maps `s`/`S`/`d` to
+/// destructive actions. Every key here is read-only.
+fn handle_key(state: &mut FleetState, key: KeyEvent) -> bool {
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        return true;
+    }
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => return true,
+        KeyCode::Char('j') | KeyCode::Down => state.select_next(),
+        KeyCode::Char('k') | KeyCode::Up => state.select_prev(),
+        KeyCode::Tab | KeyCode::BackTab => state.toggle_focus(),
+        _ => {}
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::{Guest, GuestStatus, GuestType, Node, NodeStatus, StoragePool};
+
+    fn node(name: &str, cores: u32, mem: u64, maxmem: u64) -> Node {
+        Node {
+            node: name.into(),
+            status: NodeStatus::Online,
+            maxcpu: cores,
+            mem,
+            maxmem,
+            ..Node::default()
+        }
+    }
+
+    fn guest(vmid: u32, name: &str, running: bool) -> Guest {
+        Guest {
+            vmid,
+            name: name.into(),
+            status: if running {
+                GuestStatus::Running
+            } else {
+                GuestStatus::Stopped
+            },
+            guest_type: GuestType::Qemu,
+            ..Guest::default()
+        }
+    }
+
+    fn pool(name: &str, used: u64, total: u64) -> StoragePool {
+        StoragePool {
+            storage: name.into(),
+            used,
+            total,
+            ..StoragePool::default()
+        }
+    }
+
+    fn snapshot(profile: &str, nodes: Vec<Node>, guests: Vec<Guest>) -> FleetDataMsg {
+        FleetDataMsg::ClusterSnapshot {
+            profile: profile.into(),
+            nodes,
+            guests,
+            storage: vec![],
+        }
+    }
+
+    #[test]
+    fn snapshot_merges_into_named_cluster() {
+        let mut s = FleetState::default();
+        apply(
+            &mut s,
+            snapshot(
+                "dev",
+                vec![node("pve1", 8, 0, 0)],
+                vec![guest(100, "a", true)],
+            ),
+        );
+        assert_eq!(s.clusters.len(), 1);
+        let c = &s.clusters[0];
+        assert_eq!(c.profile, "dev");
+        assert!(c.reachable);
+        assert!(c.error.is_none());
+        assert_eq!(c.nodes.len(), 1);
+        assert_eq!(c.guests.len(), 1);
+    }
+
+    #[test]
+    fn error_marks_cluster_down_without_blanking_others_or_itself() {
+        let mut s = FleetState::default();
+        apply(
+            &mut s,
+            snapshot("dev", vec![node("d1", 4, 0, 0)], vec![guest(1, "x", true)]),
+        );
+        apply(
+            &mut s,
+            snapshot("prod", vec![node("p1", 4, 0, 0)], vec![guest(2, "y", true)]),
+        );
+        // prod goes down this cycle.
+        apply(
+            &mut s,
+            FleetDataMsg::ClusterError {
+                profile: "prod".into(),
+                error: "connection refused".into(),
+            },
+        );
+        let dev = s.clusters.iter().find(|c| c.profile == "dev").unwrap();
+        let prod = s.clusters.iter().find(|c| c.profile == "prod").unwrap();
+        // dev untouched.
+        assert!(dev.reachable);
+        assert_eq!(dev.guests.len(), 1);
+        // prod flagged down but retains last-known data (no flicker).
+        assert!(!prod.reachable);
+        assert_eq!(prod.error.as_deref(), Some("connection refused"));
+        assert_eq!(prod.guests.len(), 1, "down cluster keeps prior data");
+    }
+
+    #[test]
+    fn first_cycle_error_inserts_empty_unreachable_bucket() {
+        let mut s = FleetState::default();
+        apply(
+            &mut s,
+            FleetDataMsg::ClusterError {
+                profile: "lab".into(),
+                error: "timeout".into(),
+            },
+        );
+        assert_eq!(s.clusters.len(), 1);
+        assert!(!s.clusters[0].reachable);
+        assert!(s.clusters[0].guests.is_empty());
+    }
+
+    #[test]
+    fn clusters_stay_sorted_by_profile_regardless_of_arrival_order() {
+        let mut s = FleetState::default();
+        apply(&mut s, snapshot("zeta", vec![], vec![]));
+        apply(&mut s, snapshot("alpha", vec![], vec![]));
+        apply(&mut s, snapshot("mike", vec![], vec![]));
+        let names: Vec<&str> = s.clusters.iter().map(|c| c.profile.as_str()).collect();
+        assert_eq!(names, ["alpha", "mike", "zeta"]);
+    }
+
+    #[test]
+    fn repeated_snapshot_updates_in_place_not_duplicates() {
+        let mut s = FleetState::default();
+        apply(
+            &mut s,
+            snapshot("dev", vec![node("d1", 4, 0, 0)], vec![guest(1, "x", true)]),
+        );
+        apply(
+            &mut s,
+            snapshot("dev", vec![node("d1", 4, 0, 0)], vec![guest(1, "x", false)]),
+        );
+        assert_eq!(s.clusters.len(), 1);
+        assert_eq!(s.clusters[0].stopped_guests(), 1);
+    }
+
+    #[test]
+    fn fatal_sets_banner_without_panicking_or_dropping_clusters() {
+        let mut s = FleetState::default();
+        apply(&mut s, snapshot("dev", vec![], vec![]));
+        apply(&mut s, FleetDataMsg::FatalError("config unreadable".into()));
+        assert_eq!(s.fatal.as_deref(), Some("config unreadable"));
+        assert_eq!(s.clusters.len(), 1);
+        // A later good snapshot clears the banner.
+        apply(&mut s, snapshot("dev", vec![], vec![]));
+        assert!(s.fatal.is_none());
+    }
+
+    #[test]
+    fn all_guests_pairs_each_guest_with_its_own_profile_even_on_shared_vmid() {
+        let mut s = FleetState::default();
+        // Same VMID 100 exists on both clusters — attribution must
+        // come from the bucket, not the guest struct.
+        apply(
+            &mut s,
+            snapshot("dev", vec![], vec![guest(100, "dev-vm", true)]),
+        );
+        apply(
+            &mut s,
+            snapshot("prod", vec![], vec![guest(100, "prod-vm", true)]),
+        );
+        s.focus = FleetFocus::AllGuests;
+        let pairs = s.visible_guests();
+        assert_eq!(pairs.len(), 2);
+        // Sorted by (profile, vmid): dev first, prod second.
+        assert_eq!(pairs[0].0, "dev");
+        assert_eq!(pairs[0].1.name, "dev-vm");
+        assert_eq!(pairs[1].0, "prod");
+        assert_eq!(pairs[1].1.name, "prod-vm");
+    }
+
+    #[test]
+    fn selected_cluster_focus_shows_only_that_cluster_guests() {
+        let mut s = FleetState::default();
+        apply(
+            &mut s,
+            snapshot(
+                "alpha",
+                vec![],
+                vec![guest(1, "a1", true), guest(2, "a2", true)],
+            ),
+        );
+        apply(&mut s, snapshot("beta", vec![], vec![guest(9, "b1", true)]));
+        s.selected_index = 0; // alpha
+        s.focus = FleetFocus::SelectedCluster;
+        let pairs = s.visible_guests();
+        assert_eq!(pairs.len(), 2);
+        assert!(pairs.iter().all(|(p, _)| *p == "alpha"));
+    }
+
+    #[test]
+    fn storage_usage_dedupes_shared_pools_across_nodes() {
+        let c = FleetCluster {
+            profile: "x".into(),
+            reachable: true,
+            error: None,
+            nodes: vec![],
+            guests: vec![],
+            // "nfs" reported by 3 nodes; "local" distinct per node name.
+            storage: vec![
+                pool("nfs", 1000, 4000),
+                pool("nfs", 1000, 4000),
+                pool("nfs", 1000, 4000),
+                pool("local", 50, 100),
+            ],
+        };
+        // nfs counted once (1000/4000) + local (50/100).
+        assert_eq!(c.storage_used(), 1050);
+        assert_eq!(c.storage_total(), 4100);
+    }
+
+    #[test]
+    fn aggregate_cpu_and_mem_sum_across_nodes() {
+        let c = FleetCluster {
+            profile: "x".into(),
+            reachable: true,
+            error: None,
+            nodes: vec![node("n1", 8, 16, 64), node("n2", 16, 32, 128)],
+            guests: vec![],
+            storage: vec![],
+        };
+        assert_eq!(c.total_cpu_cores(), 24);
+        assert_eq!(c.mem_used(), 48);
+        assert_eq!(c.mem_total(), 192);
+    }
+
+    #[test]
+    fn selection_wraps_and_stays_in_range() {
+        let mut s = FleetState::default();
+        apply(&mut s, snapshot("a", vec![], vec![]));
+        apply(&mut s, snapshot("b", vec![], vec![]));
+        assert_eq!(s.selected_index, 0);
+        s.select_prev(); // wrap to last
+        assert_eq!(s.selected_index, 1);
+        s.select_next(); // wrap to first
+        assert_eq!(s.selected_index, 0);
+    }
+}

--- a/src/tui/fleet/view.rs
+++ b/src/tui/fleet/view.rs
@@ -1,0 +1,250 @@
+//! Pure render for the fleet view. `(Frame, Rect, &FleetState)` — no
+//! business logic, no I/O, mirrors the `tui::views::*` contract.
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Row, Table},
+    Frame,
+};
+
+use super::{FleetCluster, FleetFocus, FleetState};
+use crate::api::types::{GuestStatus, GuestType};
+use crate::tui::theme::Theme;
+use crate::util::sanitize::{sanitize_display, truncate_ellipsis};
+
+pub fn draw(f: &mut Frame, area: Rect, state: &FleetState) {
+    let fatal_h: u16 = if state.fatal.is_some() { 2 } else { 0 };
+    // Summary: borders (2) + header (1) + one row per cluster, capped.
+    let summary_h = u16::try_from(state.clusters.len().clamp(1, 12)).unwrap_or(12) + 3;
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),         // 0 header
+            Constraint::Length(fatal_h),   // 1 fatal banner (0 when none)
+            Constraint::Length(summary_h), // 2 per-cluster summary
+            Constraint::Min(3),            // 3 aggregated guests
+            Constraint::Length(1),         // 4 footer
+        ])
+        .split(area);
+
+    draw_header(f, chunks[0], state);
+    if state.fatal.is_some() {
+        draw_fatal(f, chunks[1], state);
+    }
+    draw_summary(f, chunks[2], state);
+    draw_guests(f, chunks[3], state);
+    draw_footer(f, chunks[4], state);
+}
+
+fn draw_header(f: &mut Frame, area: Rect, state: &FleetState) {
+    let total = state.clusters.len();
+    let reachable = state.clusters.iter().filter(|c| c.reachable).count();
+    let line = Line::from(vec![
+        Span::styled(" Fleet ", Theme::title()),
+        Span::styled(format!(" {total} clusters "), Theme::dim()),
+        Span::styled(
+            format!(" {reachable} reachable "),
+            Style::default().fg(Theme::SUCCESS),
+        ),
+        Span::styled(
+            format!(" {} down ", total.saturating_sub(reachable)),
+            Style::default().fg(if reachable == total {
+                Theme::TEXT_DIM
+            } else {
+                Theme::DANGER
+            }),
+        ),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn draw_fatal(f: &mut Frame, area: Rect, state: &FleetState) {
+    let msg = state.fatal.as_deref().unwrap_or("");
+    let line = Line::from(Span::styled(
+        format!(" ⚠ {} ", sanitize_display(msg)),
+        Style::default()
+            .fg(Theme::DANGER)
+            .add_modifier(Modifier::BOLD),
+    ));
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn draw_summary(f: &mut Frame, area: Rect, state: &FleetState) {
+    let header = Row::new(vec![
+        "", "cluster", "status", "nodes", "guests", "cpu", "mem", "storage",
+    ])
+    .style(Theme::header())
+    .height(1);
+
+    let rows: Vec<Row> = state
+        .clusters
+        .iter()
+        .enumerate()
+        .map(|(i, c)| summary_row(i, c, i == state.selected_index))
+        .collect();
+
+    let widths = [
+        Constraint::Length(2),  // marker
+        Constraint::Min(10),    // cluster
+        Constraint::Min(14),    // status
+        Constraint::Length(5),  // nodes
+        Constraint::Length(9),  // guests R/S
+        Constraint::Length(6),  // cpu cores
+        Constraint::Length(13), // mem used/total
+        Constraint::Length(15), // storage used/total
+    ];
+
+    let table = Table::new(rows, widths).header(header).block(
+        Block::default()
+            .title(" Clusters ")
+            .borders(Borders::ALL)
+            .border_style(Theme::border_focus()),
+    );
+    f.render_widget(table, area);
+}
+
+fn summary_row(_idx: usize, c: &FleetCluster, selected: bool) -> Row<'static> {
+    let marker = if selected { ">" } else { " " };
+
+    let (status_text, status_style) = if c.reachable {
+        ("● OK".to_string(), Style::default().fg(Theme::SUCCESS))
+    } else {
+        let detail = c.error.as_deref().unwrap_or("unreachable");
+        (
+            format!("● {}", truncate_ellipsis(detail, 30)),
+            Style::default().fg(Theme::DANGER),
+        )
+    };
+
+    let guests = format!("{}/{}", c.running_guests(), c.stopped_guests());
+    let cpu = format!("{}c", c.total_cpu_cores());
+    let mem = format!(
+        "{}/{}",
+        format_bytes(c.mem_used()),
+        format_bytes(c.mem_total())
+    );
+    let storage = format!(
+        "{}/{}",
+        format_bytes(c.storage_used()),
+        format_bytes(c.storage_total())
+    );
+
+    let row = Row::new(vec![
+        Span::raw(marker.to_string()),
+        Span::raw(truncate_ellipsis(&sanitize_display(&c.profile), 18)),
+        Span::styled(status_text, status_style),
+        Span::raw(c.nodes.len().to_string()),
+        Span::raw(guests),
+        Span::raw(cpu),
+        Span::raw(mem),
+        Span::raw(storage),
+    ]);
+
+    if selected {
+        row.style(Theme::selected())
+    } else {
+        row
+    }
+}
+
+fn draw_guests(f: &mut Frame, area: Rect, state: &FleetState) {
+    let pairs = state.visible_guests();
+    let total = pairs.len();
+
+    // Borders (2) + header (1) consume 3 rows.
+    let visible_height = (area.height.saturating_sub(3)) as usize;
+    let shown = pairs.iter().take(visible_height.max(1));
+
+    let scope = match state.focus {
+        FleetFocus::SelectedCluster => state.clusters.get(state.selected_index).map_or_else(
+            || "—".to_string(),
+            |c| sanitize_display(&c.profile).into_owned(),
+        ),
+        FleetFocus::AllGuests => "all fleet".to_string(),
+    };
+    let mut title = format!(" Guests · {scope} [{total}] ");
+    if total > visible_height {
+        title = format!(" Guests · {scope} [showing {visible_height}/{total}] ");
+    }
+
+    let header = Row::new(vec![
+        "cluster", "vmid", "name", "type", "status", "node", "cpu", "mem",
+    ])
+    .style(Theme::header())
+    .height(1);
+
+    let rows: Vec<Row> = shown
+        .map(|(profile, g)| {
+            let type_str = match g.guest_type {
+                GuestType::Qemu => "VM",
+                GuestType::Lxc => "LXC",
+            };
+            let status = format!("{:?}", g.status).to_lowercase();
+            let style = match g.status {
+                GuestStatus::Running => Style::default().fg(Theme::SUCCESS),
+                GuestStatus::Stopped => Style::default().fg(Theme::DANGER),
+                GuestStatus::Paused | GuestStatus::Suspended => Style::default().fg(Theme::INFO),
+                GuestStatus::Unknown => Style::default().fg(Theme::WARNING),
+            };
+            Row::new(vec![
+                truncate_ellipsis(&sanitize_display(profile), 12),
+                g.vmid.to_string(),
+                truncate_ellipsis(&sanitize_display(&g.name), 22),
+                type_str.to_string(),
+                status,
+                truncate_ellipsis(&sanitize_display(&g.node), 12),
+                format!("{:.0}%", g.cpu * 100.0),
+                format_bytes(g.mem),
+            ])
+            .style(style)
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(12), // cluster
+        Constraint::Length(6),  // vmid
+        Constraint::Min(14),    // name
+        Constraint::Length(4),  // type
+        Constraint::Length(8),  // status
+        Constraint::Length(12), // node
+        Constraint::Length(5),  // cpu
+        Constraint::Length(8),  // mem
+    ];
+
+    let table = Table::new(rows, widths).header(header).block(
+        Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(Theme::border()),
+    );
+    f.render_widget(table, area);
+}
+
+fn draw_footer(f: &mut Frame, area: Rect, state: &FleetState) {
+    let focus = match state.focus {
+        FleetFocus::SelectedCluster => "selected-cluster guests",
+        FleetFocus::AllGuests => "all-fleet guests",
+    };
+    let line = Line::from(Span::styled(
+        format!(" q quit · ↑↓ select cluster · Tab: {focus} · read-only "),
+        Theme::dim(),
+    ));
+    f.render_widget(Paragraph::new(line), area);
+}
+
+/// IEC byte formatting, matching the per-view helper used across
+/// `tui::views::*` (G/T thresholds, M for the remainder).
+fn format_bytes(bytes: u64) -> String {
+    const GB: u64 = 1_073_741_824;
+    const TB: u64 = 1_099_511_627_776;
+    if bytes >= TB {
+        format!("{:.1}T", bytes as f64 / TB as f64)
+    } else if bytes >= GB {
+        format!("{:.1}G", bytes as f64 / GB as f64)
+    } else {
+        format!("{:.0}M", bytes as f64 / 1_048_576.0)
+    }
+}

--- a/src/tui/fleet/worker.rs
+++ b/src/tui/fleet/worker.rs
@@ -1,0 +1,118 @@
+//! Multi-client read-only fan-out for the fleet view.
+//!
+//! Mirrors the proven `src/cli/fanout.rs` pattern: enumerate every
+//! named profile, build one `PxClient` per profile, fan out
+//! concurrently with one task per cluster. A failed cluster yields a
+//! [`FleetDataMsg::ClusterError`] and NEVER aborts the others — the
+//! same "make progress against the reachable clusters" rule the CLI
+//! fanout uses.
+//!
+//! Read-only by construction: [`fetch_with_gateway`] calls ONLY the
+//! `get_nodes` / `get_all_guests` / `get_all_storage_pools` read
+//! methods. No write method on `ProxmoxGateway` is referenced anywhere
+//! in this file.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::sync::mpsc::Sender;
+
+use crate::api::types::{Guest, Node, StoragePool};
+use crate::api::{ProxmoxGateway, PxClient};
+
+/// Worker → controller. One message per profile per poll cycle. The
+/// reducer (`super::apply`) merges by `profile` into `FleetState`.
+#[derive(Debug)]
+pub enum FleetDataMsg {
+    /// A profile's full read snapshot for this cycle.
+    ClusterSnapshot {
+        profile: String,
+        nodes: Vec<Node>,
+        guests: Vec<Guest>,
+        storage: Vec<StoragePool>,
+    },
+    /// A profile failed this cycle (connect / auth / network / panic).
+    ClusterError { profile: String, error: String },
+    /// Could not even enumerate profiles (config unreadable / empty).
+    FatalError(String),
+}
+
+/// Fan a read-only sweep across every configured profile, sending one
+/// message per profile to `tx`. Returns once all per-cluster tasks have
+/// reported. Enumeration failure (no/unreadable config) sends a single
+/// [`FleetDataMsg::FatalError`] and returns.
+pub async fn fleet_fetch_all(cli_secret: Option<&str>, tx: &Sender<FleetDataMsg>) {
+    let profiles = match crate::config::list_profiles() {
+        Ok(p) if !p.is_empty() => p,
+        Ok(_) => {
+            let _ = tx
+                .send(FleetDataMsg::FatalError(
+                    "no named profiles in config.toml — fleet view requires at least one \
+                     [profiles.NAME] block (run `proxxx init` for a fresh setup)"
+                        .into(),
+                ))
+                .await;
+            return;
+        }
+        Err(e) => {
+            let _ = tx.send(FleetDataMsg::FatalError(format!("{e:#}"))).await;
+            return;
+        }
+    };
+
+    let secret = cli_secret.map(str::to_owned);
+    let mut set = tokio::task::JoinSet::new();
+    for profile in profiles {
+        let tx = tx.clone();
+        let secret = secret.clone();
+        set.spawn(async move {
+            let msg = match fetch_one_cluster(&profile, secret.as_deref()).await {
+                Ok((nodes, guests, storage)) => FleetDataMsg::ClusterSnapshot {
+                    profile,
+                    nodes,
+                    guests,
+                    storage,
+                },
+                Err(e) => FleetDataMsg::ClusterError {
+                    profile,
+                    error: format!("{e:#}"),
+                },
+            };
+            let _ = tx.send(msg).await;
+        });
+    }
+    // Drain the JoinSet; each task already sent its own message. A
+    // panicked task is swallowed here (its cluster simply shows no
+    // update this cycle and stays at its prior state) — it cannot take
+    // down the others.
+    while set.join_next().await.is_some() {}
+}
+
+/// Build a fresh `PxClient` for one profile and run the read sweep.
+/// Same client-construction path as `fanout.rs::query_one_profile`.
+async fn fetch_one_cluster(
+    profile: &str,
+    cli_secret: Option<&str>,
+) -> Result<(Vec<Node>, Vec<Guest>, Vec<StoragePool>)> {
+    let cfg = crate::config::load_config(Some(profile))?;
+    let client = Arc::new(PxClient::new(cfg, cli_secret).await?);
+    fetch_with_gateway(client.as_ref()).await
+}
+
+/// The read sweep itself, against any `ProxmoxGateway`. Factored out as
+/// the testable seam so integration tests can drive it with a
+/// wiremock-backed `PxClient` (or any fake) without a config file.
+///
+/// Uses the trait-default `get_all_guests` / `get_all_storage_pools`
+/// (online nodes only; a per-node fetch failure propagates rather than
+/// silently truncating). The isolation granularity is the PROFILE: a
+/// failure here marks the whole cluster unreachable, which is the right
+/// grain for an at-a-glance fleet overview.
+pub async fn fetch_with_gateway(
+    g: &dyn ProxmoxGateway,
+) -> Result<(Vec<Node>, Vec<Guest>, Vec<StoragePool>)> {
+    let nodes = g.get_nodes().await?;
+    let guests = g.get_all_guests().await?;
+    let storage = g.get_all_storage_pools().await?;
+    Ok((nodes, guests, storage))
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5,6 +5,10 @@
 // `event` is `pub` so integration tests in `tests/console_test.rs`
 // can import `map_key` and pin the keymap → action contract.
 pub mod event;
+// `fleet` is `pub` so the snapshot test harness in `tests/tui_snapshot.rs`
+// can drive `fleet::view::draw` against a hand-built `FleetState`, and so
+// `main.rs` can launch `fleet::run_fleet`. Read-only multi-cluster view.
+pub mod fleet;
 mod ssh_handler;
 mod terminal_guard;
 mod theme;

--- a/tests/fleet_test.rs
+++ b/tests/fleet_test.rs
@@ -1,0 +1,255 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+//! Fleet view integration tests.
+//!
+//! Exercises the REAL read path: a `PxClient` per fake cluster
+//! (wiremock-backed, built exactly like the production client), driven
+//! through `tui::fleet::fetch_with_gateway`, then folded into
+//! `FleetState` via the real `apply` reducer. Proves:
+//!   * aggregation across clusters with correct counts,
+//!   * one-cluster-down graceful degradation (a 500 on `/nodes`
+//!     becomes a `ClusterError`, never aborts the others),
+//!   * attribution-by-containment (each guest carries its OWNING
+//!     cluster's profile, even when a VMID is shared).
+//!
+//! This is the highest-fidelity test: it spans `PxClient` HTTP, the
+//! trait-default `get_all_guests`/`get_all_storage_pools`, and the
+//! reducer — the exact production pipeline minus the config-file
+//! enumeration (which the live script covers against real hosts).
+
+#[cfg(test)]
+mod tests {
+    use proxxx::api::PxClient;
+    use proxxx::config::ProfileConfig;
+    use proxxx::tui::fleet::{apply, fetch_with_gateway, FleetDataMsg, FleetFocus, FleetState};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn cfg_for(server: &MockServer) -> ProfileConfig {
+        ProfileConfig {
+            url: server.uri(),
+            user: "root@pam".into(),
+            auth: "token".into(),
+            token_id: Some("test".into()),
+            token_secret: None,
+            token_secret_file: None,
+            password: None,
+            verify_tls: false,
+            tls_pin_mode: None,
+            rate_limit: Some(100),
+            policies: None,
+            telegram: None,
+            ssh: None,
+            pbs: None,
+            alerts: None,
+            mcp_token: None,
+            profile_name: None,
+        }
+    }
+
+    async fn client_for(server: &MockServer) -> PxClient {
+        PxClient::new(cfg_for(server), Some("fake-secret"))
+            .await
+            .expect("client builds")
+    }
+
+    #[allow(clippy::needless_pass_by_value)] // moved into the json! macro
+    fn data(body: serde_json::Value) -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({ "data": body }))
+    }
+
+    /// Mount `/nodes` listing the given online node names.
+    async fn mount_nodes(server: &MockServer, nodes: &[&str]) {
+        let arr: Vec<_> = nodes
+            .iter()
+            .map(|n| {
+                serde_json::json!({
+                    "node": n, "status": "online",
+                    "maxcpu": 8, "cpu": 0.1,
+                    "mem": 16_u64 << 30, "maxmem": 64_u64 << 30,
+                    "disk": 0, "maxdisk": 0, "uptime": 1000
+                })
+            })
+            .collect();
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes"))
+            .respond_with(data(serde_json::json!(arr)))
+            .mount(server)
+            .await;
+    }
+
+    /// Mount a node's qemu + lxc guest lists and its storage pools.
+    async fn mount_node_detail(
+        server: &MockServer,
+        node: &str,
+        qemu: serde_json::Value,
+        lxc: serde_json::Value,
+        storage: serde_json::Value,
+    ) {
+        Mock::given(method("GET"))
+            .and(path(format!("/api2/json/nodes/{node}/qemu")))
+            .respond_with(data(qemu))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/api2/json/nodes/{node}/lxc")))
+            .respond_with(data(lxc))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/api2/json/nodes/{node}/storage")))
+            .respond_with(data(storage))
+            .mount(server)
+            .await;
+    }
+
+    fn vm(vmid: u32, name: &str, status: &str) -> serde_json::Value {
+        serde_json::json!({"vmid": vmid, "name": name, "status": status, "type": "qemu"})
+    }
+    fn ct(vmid: u32, name: &str, status: &str) -> serde_json::Value {
+        serde_json::json!({"vmid": vmid, "name": name, "status": status, "type": "lxc"})
+    }
+    fn pool(name: &str, used: u64, total: u64) -> serde_json::Value {
+        serde_json::json!({"storage": name, "type": "dir", "used": used, "total": total,
+                           "avail": total - used, "active": 1, "content": "images"})
+    }
+
+    #[tokio::test]
+    async fn fleet_aggregates_across_clusters_and_degrades_gracefully() {
+        // ── alpha: 2 online nodes, 3 guests, shared nfs pool ──
+        let alpha = MockServer::start().await;
+        mount_nodes(&alpha, &["a1", "a2"]).await;
+        mount_node_detail(
+            &alpha,
+            "a1",
+            serde_json::json!([vm(100, "alpha-web", "running")]),
+            serde_json::json!([]),
+            serde_json::json!([pool("local", 50, 100), pool("nfs", 1000, 4000)]),
+        )
+        .await;
+        mount_node_detail(
+            &alpha,
+            "a2",
+            serde_json::json!([vm(101, "alpha-db", "stopped")]),
+            serde_json::json!([ct(200, "alpha-ct", "running")]),
+            // nfs reported again by a2 — must be de-duplicated.
+            serde_json::json!([pool("local", 50, 100), pool("nfs", 1000, 4000)]),
+        )
+        .await;
+
+        // ── beta: 1 online node, 1 guest (VMID 100 — shared with alpha!) ──
+        let beta = MockServer::start().await;
+        mount_nodes(&beta, &["b1"]).await;
+        mount_node_detail(
+            &beta,
+            "b1",
+            serde_json::json!([vm(100, "beta-web", "running")]),
+            serde_json::json!([]),
+            serde_json::json!([pool("local", 10, 100)]),
+        )
+        .await;
+
+        // ── gamma: /nodes returns 500 → whole cluster unreachable ──
+        let gamma = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&gamma)
+            .await;
+
+        // Drive the real fetch seam per cluster, fold via the real reducer.
+        let mut state = FleetState::default();
+
+        let ca = client_for(&alpha).await;
+        match fetch_with_gateway(&ca).await {
+            Ok((nodes, guests, storage)) => apply(
+                &mut state,
+                FleetDataMsg::ClusterSnapshot {
+                    profile: "alpha".into(),
+                    nodes,
+                    guests,
+                    storage,
+                },
+            ),
+            Err(e) => panic!("alpha should be reachable: {e:#}"),
+        }
+
+        let cb = client_for(&beta).await;
+        let (nodes, guests, storage) = fetch_with_gateway(&cb).await.expect("beta reachable");
+        apply(
+            &mut state,
+            FleetDataMsg::ClusterSnapshot {
+                profile: "beta".into(),
+                nodes,
+                guests,
+                storage,
+            },
+        );
+
+        let cg = client_for(&gamma).await;
+        let err = fetch_with_gateway(&cg)
+            .await
+            .expect_err("gamma 500 must error");
+        apply(
+            &mut state,
+            FleetDataMsg::ClusterError {
+                profile: "gamma".into(),
+                error: format!("{err:#}"),
+            },
+        );
+
+        // ── assertions ──
+        assert_eq!(state.clusters.len(), 3, "alpha + beta + gamma");
+        let names: Vec<&str> = state.clusters.iter().map(|c| c.profile.as_str()).collect();
+        assert_eq!(names, ["alpha", "beta", "gamma"], "stable-sorted");
+
+        let alpha_c = state
+            .clusters
+            .iter()
+            .find(|c| c.profile == "alpha")
+            .unwrap();
+        assert!(alpha_c.reachable);
+        assert_eq!(alpha_c.nodes.len(), 2);
+        assert_eq!(alpha_c.guests.len(), 3, "100 + 101 + 200");
+        assert_eq!(alpha_c.running_guests(), 2);
+        assert_eq!(alpha_c.stopped_guests(), 1);
+        // Both pools ("local", "nfs") are reported by BOTH nodes; dedup
+        // by name counts each once: local 50/100 + nfs 1000/4000.
+        assert_eq!(alpha_c.storage_used(), 1050, "local + nfs, deduped");
+        assert_eq!(alpha_c.storage_total(), 4100, "local + nfs, deduped");
+
+        let beta_c = state.clusters.iter().find(|c| c.profile == "beta").unwrap();
+        assert!(beta_c.reachable);
+        assert_eq!(beta_c.guests.len(), 1);
+
+        // gamma down but present, with an error, surviving siblings intact.
+        let gamma_c = state
+            .clusters
+            .iter()
+            .find(|c| c.profile == "gamma")
+            .unwrap();
+        assert!(!gamma_c.reachable);
+        assert!(gamma_c.error.is_some());
+        assert!(gamma_c.guests.is_empty());
+
+        // Fleet-wide guest view: 3 (alpha) + 1 (beta) = 4, each attributed
+        // to its OWNING cluster even though VMID 100 exists in both.
+        state.focus = FleetFocus::AllGuests;
+        let pairs = state.visible_guests();
+        assert_eq!(pairs.len(), 4);
+        let alpha_100 = pairs
+            .iter()
+            .find(|(p, g)| *p == "alpha" && g.vmid == 100)
+            .unwrap();
+        let beta_100 = pairs
+            .iter()
+            .find(|(p, g)| *p == "beta" && g.vmid == 100)
+            .unwrap();
+        assert_eq!(alpha_100.1.name, "alpha-web");
+        assert_eq!(beta_100.1.name, "beta-web");
+    }
+}

--- a/tests/live/test_fleet_readonly.sh
+++ b/tests/live/test_fleet_readonly.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Live read-only verification for the fleet view (`proxxx fleet`).
+#
+# The fleet TUI aggregates nodes/guests/storage across EVERY configured
+# profile using the SAME read methods (get_nodes / get_all_guests /
+# get_all_storage_pools) that `ls <kind> --all-profiles` fans out. This
+# script asserts that cross-profile read path against the real homelab
+# (5 Proxmox), plus a PTY smoke-test of the TUI itself.
+#
+# STRICTLY READ-ONLY: no mutation is issued and none is possible — the
+# fleet runner wires no SideEffect / HITL / SSH / cache-write path. We
+# additionally PROVE non-mutation by snapshotting the fleet-wide guest
+# state before and after a fetch cycle and asserting it is unchanged.
+#
+# No RAII cleanup block: nothing is created, so nothing to tear down.
+#
+# Run (config.toml must already point at the homelab, ≥2 [profiles.*]):
+#   ./tests/live/test_fleet_readonly.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+BIN="${BIN:-$ROOT/target/release/proxxx}"
+LOG_DIR="${LOG_DIR:-$SCRIPT_DIR}"
+LOG="$LOG_DIR/test_fleet_readonly.log"
+
+: > "$LOG"
+PASS=0
+FAIL=0
+
+ok()   { echo "[OK   ] $1" | tee -a "$LOG"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL ] $1" | tee -a "$LOG"; FAIL=$((FAIL + 1)); }
+
+echo "═══════════════════════════════════════════════════════════" | tee -a "$LOG"
+echo "proxxx fleet read-only verification — $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee -a "$LOG"
+echo "═══════════════════════════════════════════════════════════" | tee -a "$LOG"
+
+if [ ! -x "$BIN" ]; then
+    echo "binary not found at $BIN — run: cargo build --release" | tee -a "$LOG"
+    exit 2
+fi
+
+# ── 1. config has ≥2 named profiles (fleet's whole premise) ──
+PROFILE_COUNT=$(timeout 10 "$BIN" --format json profiles 2>/dev/null \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else 0)" 2>/dev/null)
+PROFILE_COUNT="${PROFILE_COUNT:-0}"
+echo "configured profiles: $PROFILE_COUNT" | tee -a "$LOG"
+if [ "$PROFILE_COUNT" -ge 2 ]; then
+    ok "config has ≥2 profiles ($PROFILE_COUNT) — fleet aggregation is meaningful"
+else
+    fail "fleet view needs ≥2 [profiles.*]; found $PROFILE_COUNT"
+    echo "Summary: PASS=$PASS FAIL=$FAIL" | tee -a "$LOG"
+    exit "$FAIL"
+fi
+
+# ── 2. cross-profile aggregation: each row carries `profile`, ≥2 distinct ──
+# This is the exact read path the fleet worker uses, just rendered as
+# rows instead of a TUI. Proves attribution + multi-cluster fan-out.
+for kind in nodes guests storage; do
+    OUT=$(timeout 30 "$BIN" --format json ls "$kind" --all-profiles 2>>"$LOG")
+    DISTINCT=$(echo "$OUT" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+rows=[r for r in d if isinstance(r,dict)]
+# every row must carry a 'profile' key (data rows AND error rows).
+assert rows, 'no rows'
+assert all('profile' in r for r in rows), 'a row is missing the profile attribution'
+print(len({r['profile'] for r in rows}))
+" 2>>"$LOG")
+    if [ "${DISTINCT:-0}" -ge 2 ]; then
+        ok "ls $kind --all-profiles: attributed rows across $DISTINCT profiles"
+    else
+        fail "ls $kind --all-profiles: expected ≥2 distinct profiles, got ${DISTINCT:-0}"
+    fi
+done
+
+# ── 3. read-only proof: fleet-wide guest state is identical before and ──
+#       after a fleet fetch cycle (the TUI's first poll). A mutating bug
+#       would change a guest's status/count between the two reads.
+fingerprint() {
+    timeout 30 "$BIN" --format json ls guests --all-profiles 2>>"$LOG" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+rows=[(r.get('profile'), (r.get('data') or {}).get('vmid'), (r.get('data') or {}).get('status'))
+      for r in d if isinstance(r,dict) and 'data' in r]
+rows.sort(key=lambda t: (str(t[0]), t[1] or 0))
+print(json.dumps(rows))
+" 2>>"$LOG"
+}
+
+BEFORE=$(fingerprint)
+# Drive ONE real fleet fetch cycle via the TUI under a PTY, then quit.
+# Best-effort: requires `expect`. The fleet runner needs a TTY (it
+# installs raw mode), so a plain pipe can't smoke it.
+if command -v expect >/dev/null 2>&1; then
+    FLEET_OUT=$(expect -c "
+        set timeout 20
+        spawn $BIN fleet
+        # let the first 10s poll cycle complete, then quit
+        sleep 12
+        send q
+        expect eof
+        catch wait result
+        exit [lindex \$result 3]
+    " 2>>"$LOG")
+    FLEET_RC=$?
+    if [ "$FLEET_RC" -eq 0 ]; then
+        ok "proxxx fleet: launched under PTY, polled, and quit cleanly (exit 0)"
+    else
+        fail "proxxx fleet: PTY smoke-test exited $FLEET_RC"
+    fi
+else
+    echo "[skip ] expect(1) not installed — skipping fleet PTY smoke-test" | tee -a "$LOG"
+fi
+AFTER=$(fingerprint)
+
+if [ "$BEFORE" = "$AFTER" ]; then
+    ok "read-only: fleet-wide guest state unchanged across a fetch cycle"
+else
+    fail "guest state DIFFERS before/after a fleet cycle — fleet must not mutate!"
+    { echo "--- BEFORE ---"; echo "$BEFORE"; echo "--- AFTER ---"; echo "$AFTER"; } >> "$LOG"
+fi
+
+echo "═══════════════════════════════════════════════════════════" | tee -a "$LOG"
+echo "Summary: PASS=$PASS  FAIL=$FAIL   (log: $LOG)" | tee -a "$LOG"
+echo "═══════════════════════════════════════════════════════════" | tee -a "$LOG"
+exit "$FAIL"

--- a/tests/snapshots/tui_snapshot__fleet_view_renders_reachable_and_down_clusters.snap
+++ b/tests/snapshots/tui_snapshot__fleet_view_renders_reachable_and_down_clusters.snap
@@ -1,0 +1,29 @@
+---
+source: tests/tui_snapshot.rs
+assertion_line: 650
+expression: dump
+---
+ Fleet  3 clusters  2 reachable  1 down
+┌ Clusters ────────────────────────────────────────────────────────────────────────────────────────┐
+│   cluster               status               nodes guests    cpu    mem           storage        │
+│>  homelab-a             ● OK                 1     1/1       4c     8.0G/64.0G    50.0G/200.0G   │
+│   standalone-b          ● OK                 1     1/0       4c     4.0G/32.0G    50.0G/200.0G   │
+│   prod-c                ● connection refused 1     1/0       4c     0M/0M         0M/0M          │
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ Guests · all fleet [4] ──────────────────────────────────────────────────────────────────────────┐
+│cluster      vmid   name                                 type status   node         cpu   mem     │
+│homelab-a    100    web                                  VM   running  a1           5%    512M    │
+│homelab-a    200    cache                                LXC  stopped  a1           0%    0M      │
+│prod-c       400    db                                   VM   running  c1           5%    512M    │
+│standalone-b 300    media                                VM   running  b1           5%    512M    │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+│                                                                                                  │
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘
+ q quit · ↑↓ select cluster · Tab: all-fleet guests · read-only

--- a/tests/tui_snapshot.rs
+++ b/tests/tui_snapshot.rs
@@ -46,6 +46,7 @@
 
 use proxxx::api::types::{Guest, GuestStatus, GuestType, Node, NodeStatus, StoragePool};
 use proxxx::app::{AppState, View};
+use proxxx::tui::fleet::{self, FleetCluster, FleetFocus, FleetState};
 use proxxx::tui::{views, widgets};
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
@@ -583,4 +584,87 @@ fn nodes_view_with_quorum_and_stale_stats_badges() {
         "nodes header must reflect 2 nodes, got:\n{dump}"
     );
     insta::assert_snapshot!(dump);
+}
+
+// ── Fleet view (read-only multi-cluster) ───────────────────────
+
+fn fleet_cluster(profile: &str, nodes: Vec<Node>, guests: Vec<Guest>) -> FleetCluster {
+    FleetCluster {
+        profile: profile.to_string(),
+        reachable: true,
+        error: None,
+        nodes,
+        guests,
+        storage: vec![storage_pool("local", 50 << 30, 200 << 30)],
+    }
+}
+
+#[test]
+fn fleet_view_renders_reachable_and_down_clusters() {
+    // Deterministic fleet: one healthy cluster + one standalone host +
+    // one unreachable cluster (retaining last-known data + an error).
+    let mut state = FleetState {
+        clusters: vec![
+            fleet_cluster(
+                "homelab-a",
+                vec![online_node("a1", 0.1, 8 << 30, 64 << 30)],
+                vec![
+                    running_qemu(100, "web", "a1"),
+                    stopped_lxc(200, "cache", "a1"),
+                ],
+            ),
+            fleet_cluster(
+                "standalone-b",
+                vec![online_node("b1", 0.2, 4 << 30, 32 << 30)],
+                vec![running_qemu(300, "media", "b1")],
+            ),
+            FleetCluster {
+                profile: "prod-c".to_string(),
+                reachable: false,
+                error: Some("connection refused".to_string()),
+                nodes: vec![online_node("c1", 0.0, 0, 0)],
+                guests: vec![running_qemu(400, "db", "c1")],
+                storage: vec![],
+            },
+        ],
+        selected_index: 0,
+        focus: FleetFocus::AllGuests,
+        last_sync: None,
+        fatal: None,
+    };
+
+    let dump = render_to_string(100, 24, |f| {
+        fleet::view::draw(f, f.area(), &state);
+    });
+
+    // Header counts: 3 clusters, 2 reachable, 1 down.
+    assert!(
+        dump.contains("3 clusters"),
+        "header lists cluster count:\n{dump}"
+    );
+    assert!(dump.contains("2 reachable"), "header lists reachable count");
+    // Every cluster row is present, including the down one with its error.
+    assert!(dump.contains("homelab-a"), "reachable cluster listed");
+    assert!(dump.contains("standalone-b"), "standalone host listed");
+    assert!(dump.contains("prod-c"), "down cluster still listed");
+    assert!(
+        dump.contains("connection refused"),
+        "down cluster shows its error"
+    );
+    // AllGuests focus surfaces guests from every cluster with attribution.
+    assert!(
+        dump.contains("web") && dump.contains("media"),
+        "fleet-wide guests shown"
+    );
+    insta::assert_snapshot!(dump);
+
+    // SelectedCluster focus narrows the bottom pane to one cluster.
+    state.focus = FleetFocus::SelectedCluster;
+    let dump_sel = render_to_string(100, 24, |f| {
+        fleet::view::draw(f, f.area(), &state);
+    });
+    assert!(
+        dump_sel.contains("homelab-a"),
+        "selected cluster summary present"
+    );
 }


### PR DESCRIPTION
## What

A new `proxxx fleet` subcommand: a full-screen, **strictly read-only** TUI that aggregates nodes, guests, and storage across **every** configured `[profiles.NAME]` — clusters and standalone hosts, mixed — into one screen. Closes the long-standing "one cluster at a time in the TUI" gap raised in discussion: a homelab with N Proxmox endpoints is now viewable from a single pane without profile-switching.

```
 Fleet  3 clusters  2 reachable  1 down
┌ Clusters ──────────────────────────────────────────────────────────┐
│   cluster      status               nodes guests  cpu   mem          │
│>  homelab-a    ● OK                 1     1/1     4c    8.0G/64.0G    │
│   standalone-b ● OK                 1     1/0     4c    4.0G/32.0G    │
│   prod-c       ● connection refused 1     1/0     4c    0M/0M         │
└──────────────────────────────────────────────────────────────────────┘
┌ Guests · all fleet [4] ─────────────────────────────────────────────┐
│cluster      vmid  name   type status  node  cpu  mem                 │
│homelab-a    100   web    VM   running a1    5%   512M                 │
│ ...                                                                   │
└──────────────────────────────────────────────────────────────────────┘
 q quit · ↑↓ select cluster · Tab: all-fleet guests · read-only
```

## Design — read-only by construction, not convention

The fleet view runs in **its own dedicated runner** (`src/tui/fleet/`), a stripped-down mirror of `tui::run`:
- **No** `SideEffect` channel, **no** HITL coordinator, **no** SSH handler, **no** op-queue, **no** cache writes.
- Navigation-only keymap (`q`/`Esc`, `↑↓`/`jk`, `Tab`) — deliberately **not** `event::map_key` (which maps `s`/`S`/`d` to destructive actions). There is no code path from a keystroke to a mutation.
- The read sweep (`fetch_with_gateway`) calls **only** `get_nodes` / `get_all_guests` / `get_all_storage_pools`.

It reuses the proven multi-profile read fan-out pattern from `proxxx ls --all-profiles` ([`src/cli/fanout.rs`](../blob/main/src/cli/fanout.rs)): one fresh `PxClient` per profile, concurrent, per-cluster failures degrade gracefully to a `DOWN` row + error and never abort the others. An unreachable cluster **retains its last-known data** (flagged stale) instead of flickering empty.

## Backward compatibility — zero contract change

- **Attribution by containment**: each cluster's `Node`/`Guest`/`StoragePool` live in a per-profile bucket (`FleetCluster`) that owns the profile name. The domain structs are **unmodified** → the `--format json` CLI shape and the SQLite cache schema are **byte-identical**.
- **No change** to `AppState`, the single-profile TUI loop, `DataMsg`, or any existing command. The only additions are a new module, one new `Command::Fleet` enum variant, and one early-exit branch in `main.rs` (intercepted before `cli::execute`, exactly like `Completions`).
- `fleet` ignores `--profile` (it aggregates all of them); `--secure` is irrelevant (no writes exist).

## Tests

- **11 unit tests** (pure reducer + aggregation): merge, graceful one-cluster-down without blanking siblings, stable sort, fatal banner, shared-VMID attribution, storage dedup.
- **Wiremock multi-server integration test** (`tests/fleet_test.rs`): real `PxClient` fan-out across 3 fake clusters (one 2-node, one standalone, one returning 500 on `/nodes`) → asserts aggregation + graceful degradation + attribution through the **real** production read path.
- **Render snapshot** (`tests/tui_snapshot.rs`).
- **Read-only live verification script** (`tests/live/test_fleet_readonly.sh`): asserts ≥2 profiles, cross-profile attributed reads against the real homelab, a PTY smoke-test, and a before/after guest-state fingerprint proving non-mutation.

`cargo test` (all targets), `cargo clippy --all-targets`, and `cargo fmt --check` all green.

## Follow-ups (out of scope, intentionally)

- In-TUI `F` key to enter fleet from a running single-profile session (would touch `AppMode`/`Action`/`SideEffect`/`event.rs` — deferred to keep this PR purely additive).
- Any cross-cluster **write** path stays explicitly out of scope: the "one mutation = one client" boundary is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)