### PR TITLE
fix(live): correct profile-count parse in fleet read-only script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ tests/live/*_summary.md
 # .example template is tracked.
 tests/e2e.env
 .env
+# proxxx's own runtime config carries live credentials (PVE
+# url/user/password or API token). It normally lives under the XDG
+# config dir, but a stray copy in the repo root (e.g. produced while
+# exercising the fleet live test) must never be committed.
+/config.toml
 # Pre-publication history backup (text + restorable bundle).
 git_history_backup.md
 proxxx-pre-reset.bundle

--- a/tests/live/test_fleet_readonly.sh
+++ b/tests/live/test_fleet_readonly.sh
@@ -42,8 +42,19 @@ if [ ! -x "$BIN" ]; then
 fi
 
 # ── 1. config has ≥2 named profiles (fleet's whole premise) ──
+# `proxxx profiles --format json` emits [{"profiles": ["a","b",...]}]; be
+# tolerant of either that shape or a bare list of profile names.
 PROFILE_COUNT=$(timeout 10 "$BIN" --format json profiles 2>/dev/null \
-    | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else 0)" 2>/dev/null)
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if isinstance(d, list) and d and isinstance(d[0], dict) and 'profiles' in d[0]:
+    print(len(d[0]['profiles']))
+elif isinstance(d, list):
+    print(len(d))
+else:
+    print(0)
+" 2>/dev/null)
 PROFILE_COUNT="${PROFILE_COUNT:-0}"
 echo "configured profiles: $PROFILE_COUNT" | tee -a "$LOG"
 if [ "$PROFILE_COUNT" -ge 2 ]; then


### PR DESCRIPTION
Follow-up to #137. Running `tests/live/test_fleet_readonly.sh` against the real homelab surfaced a parser bug in the script's pre-flight check.

`proxxx profiles --format json` emits `[{"profiles": ["a","b",...]}]` (a single-element list wrapping the names array), not a bare list of names. The check counted `len(d)` = 1 and aborted with "fleet view needs ≥2 profiles" even when ≥2 were configured. Fixed to parse the nested `profiles` array, tolerant of either shape.

**With the fix, the live read-only verification passes 6/6 against the homelab** (a single PVE host wrapped under two profile names for the test):
- `ls nodes|guests|storage --all-profiles` → attributed rows across 2 profiles
- `proxxx fleet` → launched under PTY, polled a full cycle, quit cleanly (exit 0)
- before/after fleet-wide guest-state fingerprint **identical** → confirms the fleet path does not mutate the cluster

Test-script only; no production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)