### PR TITLE
chore(release): v0.8.2 — init --profile + smarter profile-only load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ SemVer contract:
 
 ## [Unreleased]
 
+_no entries yet._
+
+## [0.8.2] — 2026-05-30
+
+Headline: **Multi-cluster setup UX.** Now that multi-profile is first-class (`proxxx fleet`, `--all-profiles`, per-profile `read_only`), `proxxx init` catches up: add a cluster without hand-editing TOML or clobbering your other profiles, and get a helpful error — not a serde dump — when a profile-only config has no default.
+
 ### Added — `proxxx init --profile <name>` (append) + smarter profile-only config loading (#142)
 
 - **`proxxx init --profile <name>`** now **appends** a `[profiles.<name>]` block to the existing `config.toml`, preserving every other profile, comment, and formatting (format-preserving via `toml_edit`). Creates the file if absent; refuses to overwrite a same-named profile without `--force` (other profiles are always preserved). This is the multi-cluster setup path: `proxxx init --profile prod` then `proxxx init --profile lab`, … — bare `proxxx init` still writes the flat starter template. (The interactive wizard still writes the flat config; `--interactive --profile` points you at the non-interactive append.)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"


### PR DESCRIPTION
Release **v0.8.2**. Bundles #142 (already merged to main).

## Included
- **`proxxx init --profile <name>`** (#142 / #146) — appends a `[profiles.<name>]` block format-preservingly (toml_edit), never clobbering other profiles; bare `init` refuses to clobber an existing config; `load_config(None)` honors `default = "<name>"`, auto-uses the sole profile, else an actionable error (lists profiles, suggests `--profile`/`proxxx fleet`); new `PROXXX_CONFIG` env override.

## This PR
- `Cargo.toml` / `Cargo.lock`: `0.8.1 → 0.8.2` (minor — additive feature).
- `CHANGELOG.md`: `[Unreleased]` → `[0.8.2] — 2026-05-30`.

On merge: tag `v0.8.2` (on the main commit) → `release.yml` builds the 3-target signed binaries + SBOM and publishes.

Follow-up: **#140** (PBS datastore + backup/restore e2e) — deferred to the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)