### PR TITLE
feat(dist): Homebrew tap auto-bump + `brew install` docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,3 +450,59 @@ jobs:
           # which hid the latest stable from the releases page.
           prerelease: ${{ contains(github.ref_name, '-') }}
           fail_on_unmatched_files: true
+
+  # ──────────────────────────────────────────────────────────
+  # Bump the Homebrew tap formula to the new version + sha256.
+  # Runs after the release is published. Requires a HOMEBREW_TAP_TOKEN
+  # repo secret — a PAT (classic: `repo`, or fine-grained: `contents:
+  # write` on fabriziosalmi/homebrew-proxxx). Without it this job fails,
+  # but the release itself is unaffected (separate, dependent job).
+  # ──────────────────────────────────────────────────────────
+  bump-homebrew:
+    name: Bump Homebrew formula
+    needs: release
+    runs-on: ubuntu-latest
+    # Stable tags only — the tap tracks releases, not rc/beta/alpha.
+    if: ${{ !contains(github.ref_name, '-') }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout the tap repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: fabriziosalmi/homebrew-proxxx
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Bump formula (version + per-target sha256)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          dl() { gh release download "$GITHUB_REF_NAME" --repo fabriziosalmi/proxxx --pattern "$1" -O - | awk '{print $1}'; }
+          SHA_DARWIN=$(dl "proxxx-${VERSION}-aarch64-apple-darwin.tar.gz.sha256")
+          SHA_LINUX_X64=$(dl "proxxx-${VERSION}-x86_64-unknown-linux-musl.tar.gz.sha256")
+          SHA_LINUX_ARM=$(dl "proxxx-${VERSION}-aarch64-unknown-linux-musl.tar.gz.sha256")
+          test -n "$SHA_DARWIN" && test -n "$SHA_LINUX_X64" && test -n "$SHA_LINUX_ARM"
+
+          F=Formula/proxxx.rb
+          sed -i -E "s/^  version \".*\"/  version \"${VERSION}\"/" "$F"
+          perl -0pi -e "s/(aarch64-apple-darwin\.tar\.gz\"\s*\n\s*sha256 \")[a-f0-9]{64}/\${1}${SHA_DARWIN}/" "$F"
+          perl -0pi -e "s/(x86_64-unknown-linux-musl\.tar\.gz\"\s*\n\s*sha256 \")[a-f0-9]{64}/\${1}${SHA_LINUX_X64}/" "$F"
+          perl -0pi -e "s/(aarch64-unknown-linux-musl\.tar\.gz\"\s*\n\s*sha256 \")[a-f0-9]{64}/\${1}${SHA_LINUX_ARM}/" "$F"
+
+          echo "── updated formula ──"
+          grep -E '^  version|sha256' "$F"
+
+      - name: Commit + push to the tap
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "Formula already current — nothing to bump."
+            exit 0
+          fi
+          git add Formula/proxxx.rb
+          git commit -m "proxxx ${GITHUB_REF_NAME}: bump formula (automated)"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ SemVer contract:
 ### Packaging
 
 - **Debian `.deb` packages — signed, attached to every release.** `cargo deb` now builds a `.deb` for **amd64** and **arm64** as part of the release workflow, alongside the tarballs. Because the binary is static-musl, the package declares **no runtime dependencies** — `sudo apt install ./proxxx_X.Y.Z-1_amd64.deb` drops it straight onto a Proxmox VE node (Debian) with no glibc/lib resolution. Each `.deb` ships its own SHA-256 and the same keyless **sigstore cosign bundle** as the tarball, so it carries the identical supply-chain guarantee. (A hosted apt repository is a separate follow-up; for now the `.deb` is a release asset, verifiable offline.)
+- **Homebrew tap — `brew install fabriziosalmi/proxxx/proxxx`.** A new [`fabriziosalmi/homebrew-proxxx`](https://github.com/fabriziosalmi/homebrew-proxxx) tap installs the pre-built static binary on macOS (Apple Silicon) and Linux (x86_64 / aarch64). The formula's version + per-target SHA-256 are bumped automatically on each release by a new `bump-homebrew` job in the release workflow (requires a `HOMEBREW_TAP_TOKEN` repo secret with write access to the tap). Verified end-to-end against the v0.8.5 release: `brew install` → `proxxx --version` → `proxxx 0.8.5`.
 
 ## [0.8.5] — 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ proxxx is designed for operators who need auditability, data sovereignty, and su
 
 Pre-built binaries for **macOS Apple Silicon**, **Linux x86_64-musl**, and **Linux aarch64-musl** (Pi 4/5, Ampere, Graviton, Oracle Free Tier) are attached to each [tagged release](https://github.com/fabriziosalmi/proxxx/releases). All Linux artefacts are statically linked — no glibc, drops onto Alpine through RHEL.
 
-Download + verify the full supply-chain trio:
+### Homebrew (macOS & Linux)
+
+```bash
+brew install fabriziosalmi/proxxx/proxxx
+```
+
+The fastest path on a workstation. For a Proxmox VE node (Debian) use the [`.deb`](#debian--ubuntu--proxmox-ve--deb) below; for air-gapped installs or full supply-chain verification, download + verify the trio manually:
 
 ```bash
 TARGET=x86_64-unknown-linux-musl     # or aarch64-apple-darwin


### PR DESCRIPTION
## What

The second distribution channel: a **Homebrew tap**. The tap repo [`fabriziosalmi/homebrew-proxxx`](https://github.com/fabriziosalmi/homebrew-proxxx) is already live with a working v0.8.5 formula — this PR wires the **upkeep** + the docs.

```bash
brew install fabriziosalmi/proxxx/proxxx
```

**Verified end-to-end** on this machine against the v0.8.5 release: `brew install` → `proxxx --version` → `proxxx 0.8.5`. 🍺

## How

- **`release.yml`** — a new `bump-homebrew` job (`needs: release`, stable tags only). It checks out the tap with a `HOMEBREW_TAP_TOKEN` secret, downloads the 3 per-target SHA-256 from the just-published release, rewrites `version` + each `sha256` in `Formula/proxxx.rb` (each replacement position-anchored on its target triple so the three identical-looking `sha256` lines never cross), and commits + pushes. **The bump logic was tested locally** against the real formula (version + all 3 shas mapped correctly to their targets).
- **`README.md`** — `brew install` as the fast workstation path, cross-linked to the `.deb` for Proxmox nodes.

## ⚠️ One-time maintainer action required

The bump job needs a **`HOMEBREW_TAP_TOKEN`** repo secret — a PAT (classic `repo`, or fine-grained `contents: write` on `fabriziosalmi/homebrew-proxxx`). Without it the bump job fails, **but the release itself is unaffected** (it's a separate, dependent job). The tap stays usable at its current version until the first successful bump.

## Distribution scorecard
- ✅ **`.deb`** (#166) · ✅ **Homebrew tap** (this) · ⏳ Proxmox VE Community-Scripts · ⏳ hosted apt repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)