### PR TITLE
docs(readme): make install-example version dynamic (was stale VERSION=0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Download + verify the full supply-chain trio:
 
 ```bash
 TARGET=x86_64-unknown-linux-musl     # or aarch64-apple-darwin
-VERSION=0.2.0                        # latest at time of writing
+VERSION=$(gh release view --repo fabriziosalmi/proxxx --json tagName -q .tagName | sed 's/^v//')
 
 gh release download v${VERSION} --repo fabriziosalmi/proxxx \
   --pattern "*-${TARGET}.tar.gz" \
@@ -135,7 +135,7 @@ The Linux musl artifact is statically linked — runs on every distro from RHEL 
 Each release also ships a `.deb` for **amd64** and **arm64**, signed with the same sigstore bundle. The binary is static-musl, so the package declares **no runtime dependencies** — drop it straight onto a Proxmox VE node (which is Debian):
 
 ```bash
-VERSION=0.8.5
+VERSION=$(gh release view --repo fabriziosalmi/proxxx --json tagName -q .tagName | sed 's/^v//')
 gh release download v${VERSION} --repo fabriziosalmi/proxxx \
   --pattern "proxxx_${VERSION}-1_amd64.deb"      # or _arm64.deb
 sudo apt install ./proxxx_${VERSION}-1_amd64.deb # or: sudo dpkg -i proxxx_*.deb


### PR DESCRIPTION
## What

The README "Install" tarball snippet hardcoded `VERSION=0.2.0  # latest at time of writing` — the project is at **v0.8.5**, so anyone copy-pasting it hit a 404 on the download.

Both install examples (tarball + `.deb`) now resolve the latest tag at runtime, so they never go stale again:

```bash
VERSION=$(gh release view --repo fabriziosalmi/proxxx --json tagName -q .tagName | sed 's/^v//')
```

Docs-only. No other hardcoded versions remain in README install examples (grep-verified).