### PR TITLE
chore(release): v0.9.0 — GitOps controller (Layers 1–3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ SemVer contract:
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-06-25
+
+Headline: **The GitOps controller, complete — `reconcile {run,converge}` + an unmanned drift-watch that self-heals.** Continuous reconciliation closes end to end: drift *detection* (Layers 1–2 — `reconcile run`, the `watch` daemon pillar, drift → Prometheus + MCP) and drift *convergence* (Layer 3 — `reconcile converge` + the opt-in unmanned `auto_converge` daemon) ship together, making "GitOps for Proxmox" a first-class workflow: `git push` → production converges, behind the same Severe-risk pre-flight gate that guards `state apply` — which the unmanned loop **never** overrides. Also the first release built + distributed through the new signed Debian `.deb` packages and the Homebrew tap.
+
 ### Added
 
 - **`reconcile converge` + unmanned `auto_converge` — the GitOps controller's WRITE half (continuous reconciliation, Layer 3).** Closes the loop: detection (Layers 1–2) now has a converge counterpart that mutates live state toward the declared source. Two surfaces over one shared core (`state::converge`):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -20,7 +20,7 @@ ships **three layers of artifact verification** for every tarball:
 
 ```sh
 TARGET=x86_64-unknown-linux-musl     # or aarch64-apple-darwin
-VERSION=0.1.7
+VERSION=$(gh release view --repo fabriziosalmi/proxxx --json tagName -q .tagName | sed 's/^v//')
 
 gh release download v${VERSION} --repo fabriziosalmi/proxxx \
   --pattern "*-${TARGET}.tar.gz" \

--- a/docs/guide/production-checklist.md
+++ b/docs/guide/production-checklist.md
@@ -18,7 +18,7 @@ material; we link to it but don't restate it.
 
 ```bash
 TARGET=x86_64-unknown-linux-musl   # or aarch64-apple-darwin
-VERSION=0.1.6                      # check the latest at /releases
+VERSION=$(gh release view --repo fabriziosalmi/proxxx --json tagName -q .tagName | sed 's/^v//')  # latest tag
 gh release download v${VERSION} \
   --repo fabriziosalmi/proxxx \
   --pattern "*-${TARGET}.tar.gz" \


### PR DESCRIPTION
Cuts **v0.9.0** — the capstone release: continuous reconciliation closes end to end.

- **Detection** (Layers 1–2, #162–#165): `reconcile run`, the `watch` daemon pillar, drift → Prometheus + MCP.
- **Convergence** (Layer 3, #169): `reconcile converge` (operator / CI push-mode) + the opt-in unmanned `auto_converge` daemon — `git push` → production converges, behind the same Severe-risk pre-flight gate as `state apply` (never overridden unmanned). Live-validated on pvetest.
- First release distributed via the signed Debian `.deb` packages (#166) + the Homebrew tap (#167) — **the first live run of the `.deb` + Homebrew auto-bump CI.**

### Changes
- `Cargo.toml` + `Cargo.lock`: `0.8.5` → `0.9.0`
- `CHANGELOG`: `[Unreleased]` → `[0.9.0] — 2026-06-25`
- docs: `installation.md` + `production-checklist.md` download examples → dynamic latest-tag pattern (were pinned to stale `0.1.7` / `0.1.6`)

Merge to `main`, then tag `v0.9.0` on the squash commit → `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
