### PR TITLE
chore(release): v0.9.1 — hardening patch (state apply audits + audit-key validation + QGA/misc fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ SemVer contract:
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-06-25
+
+Headline: **Hardening patch — `state apply` now leaves an audit trail, and the audit chain's key handling is tightened.** A code-health / security pass after the v0.9.0 GitOps-controller release. No CLI-contract changes (commands, exit codes, and `--format json` shapes are unchanged); the tamper-evident trail and a handful of robustness edges get firmer.
+
+### Security
+
+- **`state apply` now writes an HMAC audit entry**, closing the asymmetry where only the unmanned `reconcile converge` left a tamper-evident trail while the operator-driven `state apply` — issuing the *identical* mutations through the same `apply()` code — recorded nothing. Both now log one entry per dispatched run (`state_apply` / `reconcile_converge`) through the shared `apply_and_audit` core.
+- **The audit key is length-validated.** A truncated or empty `audit.key` (e.g. an interrupted first write) is now rejected with an actionable error instead of silently degrading to a forgeable all-zeros HMAC key; the zeroed-key fallback in `compute_hmac` is removed. `last_chain_hmac` now distinguishes an empty log (correct) from a real read error (which warns).
+- **`mcp_token` is held as `Zeroizing<String>`**, matching every other config secret.
+
+### Fixed
+
+- **QGA `network-get-interfaces` no longer swallows a malformed payload** into an empty interface list (indistinguishable from a guest that genuinely has none) — a deserialize failure now surfaces as a typed `Parse` error. Both call sites (`vm qga net`, console IP discovery) already handle it.
+- **QGA `guest-exec` builds its command argv as proper JSON** (`serde_json::json!`) instead of hand-rolled `"`-only escaping, so a command containing backslashes / newlines / tabs is no longer malformed.
+- **The Telegram HTTP client sets a 30 s request timeout** so `send` / `edit` / `approve` can't hang forever on a wedged connection (the long-poll keeps its own longer per-request timeout).
+
+### Deferred (tracked)
+
+- Folding `user` + `params_json` into the audit chain ([#173](https://github.com/fabriziosalmi/proxxx/issues/173) — needs a chain-format version so existing DBs still verify) and a test net for the destructive `--yes` gates ([#172](https://github.com/fabriziosalmi/proxxx/issues/172) — a focused refactor). New GitOps state families + node-level ZFS pool create are v0.10.0 feature work (a patch can't add CLI surface).
+
 ## [0.9.0] — 2026-06-25
 
 Headline: **The GitOps controller, complete — `reconcile {run,converge}` + an unmanned drift-watch that self-heals.** Continuous reconciliation closes end to end: drift *detection* (Layers 1–2 — `reconcile run`, the `watch` daemon pillar, drift → Prometheus + MCP) and drift *convergence* (Layer 3 — `reconcile converge` + the opt-in unmanned `auto_converge` daemon) ship together, making "GitOps for Proxmox" a first-class workflow: `git push` → production converges, behind the same Severe-risk pre-flight gate that guards `state apply` — which the unmanned loop **never** overrides. Also the first release built + distributed through the new signed Debian `.deb` packages and the Homebrew tap.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1000,8 +1000,10 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<crate::api::types::GuestExecResult> {
         use crate::api::types::{AgentExecResponse, AgentExecStatusResponse, GuestExecResult};
 
-        // Broadcast "sh -c command"
-        let cmds = format!("[\"sh\", \"-c\", \"{}\"]", command.replace('"', "\\\""));
+        // Broadcast "sh -c command" — build the argv as proper JSON so any
+        // characters in `command` (quotes, backslashes, newlines, tabs) are
+        // escaped correctly rather than producing malformed JSON.
+        let cmds = serde_json::json!(["sh", "-c", command]).to_string();
 
         // (audit) — QEMU agent exec has its own failure mode:
         // if the guest's QGA daemon is wedged (Linux kernel hang,
@@ -1146,8 +1148,12 @@ impl ProxmoxGateway for PxClient {
             .get("result")
             .cloned()
             .unwrap_or(serde_json::Value::Array(vec![]));
+        // Surface a malformed payload as a typed Parse error rather than
+        // silently returning an empty list (indistinguishable from a guest that
+        // genuinely has no interfaces). Both callers already handle the Err.
         let ifaces: Vec<crate::api::types::GuestAgentNetworkInterface> =
-            serde_json::from_value(result).unwrap_or_default();
+            serde_json::from_value(result)
+                .map_err(|source| crate::api::ApiError::Parse { path, source })?;
         Ok(ifaces)
     }
 

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -139,13 +139,22 @@ impl AuditLogger {
     }
 
     fn last_chain_hmac(&self) -> String {
-        self.conn
-            .query_row(
-                "SELECT chain_hmac FROM audit_log ORDER BY id DESC LIMIT 1",
-                [],
-                |r| r.get::<_, String>(0),
-            )
-            .unwrap_or_default()
+        match self.conn.query_row(
+            "SELECT chain_hmac FROM audit_log ORDER BY id DESC LIMIT 1",
+            [],
+            |r| r.get::<_, String>(0),
+        ) {
+            Ok(h) => h,
+            // Empty log — this is the first entry; an empty prev-hmac is correct.
+            Err(rusqlite::Error::QueryReturnedNoRows) => String::new(),
+            // A real read error must not silently start a fresh chain segment.
+            Err(e) => {
+                tracing::warn!(
+                    "audit: could not read last chain hmac ({e}) — starting a new chain segment"
+                );
+                String::new()
+            }
+        }
     }
 }
 
@@ -171,10 +180,11 @@ fn compute_hmac(
     vmid: &str,
     result: &str,
 ) -> String {
-    // new_from_slice only fails if key is empty; we always pass a 32-byte key.
-    // Fall back to a zeroed key rather than propagating an error through a non-Result fn.
-    let key_used: &[u8] = if key.is_empty() { &[0u8; 32] } else { key };
-    let Ok(mut mac) = HmacSha256::new_from_slice(key_used) else {
+    // The key is validated to be exactly 32 bytes at load time
+    // (`load_or_create_key`), so `new_from_slice` won't fail here. If it somehow
+    // does, return an EMPTY MAC — which makes `audit verify` fail loudly — rather
+    // than silently falling back to a known all-zeros key that anyone could forge.
+    let Ok(mut mac) = HmacSha256::new_from_slice(key) else {
         return String::new();
     };
     mac.update(prev.as_bytes());
@@ -193,6 +203,18 @@ fn load_or_create_key(path: &PathBuf) -> Result<Vec<u8>> {
     if path.exists() {
         let bytes =
             std::fs::read(path).with_context(|| format!("read audit key {}", path.display()))?;
+        // The HMAC chain is only as trustworthy as its key. A truncated or empty
+        // key (e.g. an interrupted first write, or a `touch`'d file) MUST fail
+        // loudly — an empty key would otherwise degrade to a forgeable all-zeros
+        // MAC, and a wrong-length key produces a chain that won't re-derive.
+        anyhow::ensure!(
+            bytes.len() == 32,
+            "audit key {} is {} bytes, expected 32 — refusing to use a malformed key. \
+             Delete the file to regenerate (this starts a new chain; prior entries \
+             will no longer verify under the new key).",
+            path.display(),
+            bytes.len()
+        );
         return Ok(bytes);
     }
     let mut key = vec![0u8; 32];
@@ -510,5 +532,26 @@ mod proptests {
                 col, fail, ok
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod key_tests {
+    use super::*;
+
+    #[test]
+    fn load_or_create_key_rejects_malformed_length() {
+        // A wrong-length key must be refused — an empty/truncated key would
+        // otherwise degrade the HMAC chain to a forgeable all-zeros MAC.
+        let bad = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(bad.path(), b"short").unwrap(); // 5 bytes, not 32
+        let err = load_or_create_key(&bad.path().to_path_buf()).unwrap_err();
+        assert!(err.to_string().contains("expected 32"), "got: {err}");
+
+        // A correct 32-byte key loads fine.
+        let good = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(good.path(), [7u8; 32]).unwrap();
+        let key = load_or_create_key(&good.path().to_path_buf()).unwrap();
+        assert_eq!(key.len(), 32);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1613,8 +1613,8 @@ pub async fn execute(
             McpCommand::ServeHttp { bind, port, token } => {
                 let mut cfg = config;
                 // CLI --token overrides the profile's mcp_token.
-                if token.is_some() {
-                    cfg.mcp_token = token;
+                if let Some(t) = token {
+                    cfg.mcp_token = Some(zeroize::Zeroizing::new(t));
                 }
                 let handle = crate::config::watcher::new_handle(cfg);
                 crate::config::watcher::spawn_reload_on_sighup(

--- a/src/cli/reconcile.rs
+++ b/src/cli/reconcile.rs
@@ -208,6 +208,7 @@ async fn converge_cmd(
             approved,
             opts,
             &audit_user,
+            "reconcile_converge",
         )
         .await
     } else {

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -350,32 +350,43 @@ pub async fn execute_state(
                 prune,
                 continue_on_error,
             };
-            let outcomes = state::apply::apply(client.as_ref(), changes, opts).await;
+            // Apply via the shared converge core so `state apply` writes one
+            // HMAC `state_apply` audit entry per dispatched run — the same
+            // tamper-evident trail `reconcile converge` gets (the gate +
+            // interactive filter already ran above; this only applies + audits).
+            let audit_user = client.profile_config().user.clone();
+            let source = declared.display().to_string();
+            let report = state::converge::apply_and_audit(
+                client.as_ref(),
+                profile_label,
+                &source,
+                changes,
+                opts,
+                &audit_user,
+                "state_apply",
+            )
+            .await;
+            let outcomes = &report.outcomes;
 
             match output {
                 ApplyOutputFormat::Text => {
                     if outcomes.is_empty() {
                         println!("(no changes — live state matches declared)");
                     } else {
-                        for o in &outcomes {
+                        for o in outcomes {
                             println!("{}", apply_summary_line(o));
                         }
                     }
                 }
                 ApplyOutputFormat::Json => {
-                    let json = serde_json::to_string_pretty(&outcomes)?;
+                    let json = serde_json::to_string_pretty(outcomes)?;
                     println!("{json}");
                 }
             }
 
-            // Exit code: 2 if any outcome failed, else 0. 1 is
-            // reserved for hard errors (file unreadable, PVE
-            // unreachable) — those flow through `?` above.
-            let any_failed = outcomes
-                .iter()
-                .any(|o| matches!(o.result, state::apply::ApplyResult::Failed { .. }));
-            let exit = i32::from(any_failed) * 2;
-            Ok((Value::Null, exit))
+            // Exit code: 2 if any outcome failed, else 0. 1 is reserved for hard
+            // errors (file unreadable, PVE unreachable) — those flow through `?`.
+            Ok((Value::Null, report.exit_code()))
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,7 +47,7 @@ pub struct ProfileConfig {
     /// GET /mcp requests must carry `Authorization: Bearer <token>`. Leave
     /// unset (the default) to run the HTTP server without auth — only do this
     /// on a trusted network or behind a reverse proxy that enforces auth.
-    pub mcp_token: Option<String>,
+    pub mcp_token: Option<zeroize::Zeroizing<String>>,
 
     /// Continuous-reconciliation (`reconcile watch`) config. When present,
     /// `proxxx daemon serve` runs a 4th pillar that periodically diffs the

--- a/src/hitl/telegram.rs
+++ b/src/hitl/telegram.rs
@@ -147,7 +147,10 @@ impl TelegramGateway {
     pub fn new(bot_token: String, chat_id: String) -> Result<Self> {
         let hmac_key = crate::hitl::hmac_key::load_or_generate_hmac_key()?;
         Ok(Self {
-            http: Client::new(),
+            // A request timeout so send/edit/approve can't hang forever on a
+            // wedged connection. The long-poll path sets its own (longer)
+            // per-request timeout, which overrides this client default.
+            http: Client::builder().timeout(Duration::from_secs(30)).build()?,
             bot_token,
             chat_id,
             base_url: DEFAULT_TG_API.to_string(),

--- a/src/state/converge.rs
+++ b/src/state/converge.rs
@@ -147,15 +147,26 @@ pub async fn converge_with_changes<C: StateWriteView + ?Sized>(
     if !opts.dry_run {
         enforce_state_preflight(&changes, live, force)?;
     }
-    Ok(apply_and_audit(client, profile, source, changes, opts, audit_user).await)
+    Ok(apply_and_audit(
+        client,
+        profile,
+        source,
+        changes,
+        opts,
+        audit_user,
+        "reconcile_converge",
+    )
+    .await)
 }
 
-/// Apply a **pre-gated** change set and write the converge audit entry. Does NOT
-/// run the pre-flight gate itself — the caller is responsible for gating. The
-/// daemon and the non-interactive CLI reach this via [`converge_with_changes`]
-/// (which gates first); the CLI's `--interactive` path calls it directly after
-/// gating the *full* set and then filtering to the operator-approved subset (so
-/// the approved subset isn't re-gated and double-printed).
+/// Apply a **pre-gated** change set and write ONE HMAC audit entry per dispatched
+/// run. Does NOT run the pre-flight gate itself — the caller is responsible for
+/// gating. Shared by every state-mutating path so each gets a tamper-evident
+/// trail: `reconcile converge` / the unmanned daemon reach it via
+/// [`converge_with_changes`] (which gates first) and the CLI `--interactive`
+/// path calls it directly after gating+filtering; `state apply` calls it with
+/// `action = "state_apply"`. `action` is the audit verb recorded.
+#[allow(clippy::too_many_arguments)]
 pub async fn apply_and_audit<C: StateWriteView + ?Sized>(
     client: &C,
     profile: &str,
@@ -163,6 +174,7 @@ pub async fn apply_and_audit<C: StateWriteView + ?Sized>(
     changes: Vec<Change>,
     opts: ApplyOptions,
     audit_user: &str,
+    action: &str,
 ) -> ConvergeReport {
     if changes.is_empty() {
         return ConvergeReport::in_sync();
@@ -175,9 +187,9 @@ pub async fn apply_and_audit<C: StateWriteView + ?Sized>(
     let report = ConvergeReport::from_outcomes(outcomes);
 
     // One audit entry per run that actually dispatched (not a dry-run, and
-    // something hit PVE). Best-effort — a logging failure never fails converge.
+    // something hit PVE). Best-effort — a logging failure never fails the apply.
     if !opts.dry_run && report.dispatched() {
-        write_converge_audit(audit_user, profile, source, &summary, &report);
+        write_apply_audit(action, audit_user, profile, source, &summary, &report);
     }
 
     report
@@ -196,12 +208,14 @@ fn converge_audit_params(profile: &str, source: &str, summary: &str, total: usiz
     .to_string()
 }
 
-/// Append one HMAC-chained audit entry for a converge run. Best-effort: state
-/// mutations aren't otherwise on the (guest-centric) audit chain, and an
-/// *unmanned* mutation especially deserves a tamper-evident trail. A failure
-/// here is logged and swallowed — the PVE mutation already happened; failing the
-/// run because we couldn't *log* it would be worse.
-fn write_converge_audit(
+/// Append one HMAC-chained audit entry for an apply run (`action` = the verb,
+/// e.g. `reconcile_converge` or `state_apply`). Best-effort: state mutations
+/// aren't otherwise on the (guest-centric) audit chain, and especially an
+/// *unmanned* mutation deserves a tamper-evident trail. A failure here is logged
+/// and swallowed — the PVE mutation already happened; failing the run because we
+/// couldn't *log* it would be worse.
+fn write_apply_audit(
+    action: &str,
     user: &str,
     profile: &str,
     source: &str,
@@ -212,7 +226,7 @@ fn write_converge_audit(
     let write = (|| -> Result<()> {
         let mut logger = crate::audit::AuditLogger::open()?;
         logger.log(
-            "reconcile_converge",
+            action,
             user,
             None,
             None,
@@ -221,7 +235,7 @@ fn write_converge_audit(
         )
     })();
     if let Err(e) = write {
-        tracing::warn!("converge: audit write failed (non-fatal): {e:#}");
+        tracing::warn!("{action}: audit write failed (non-fatal): {e:#}");
     }
 }
 


### PR DESCRIPTION
**v0.9.1 — hardening patch.** A code-health / security pass after the v0.9.0 GitOps-controller release. **No CLI-contract change** (commands, exit codes, `--format json` shapes unchanged); config stays backwards-compatible.

### Security
- **`state apply` now writes an HMAC audit entry** — closes the asymmetry where only the unmanned `reconcile converge` left a tamper-evident trail while operator-driven `state apply` (identical mutations, same `apply()` code) recorded nothing. Both go through the shared `apply_and_audit` core now (`state_apply` / `reconcile_converge`).
- **Audit key length-validated** — a truncated/empty `audit.key` is rejected with an actionable error instead of degrading to a forgeable all-zeros HMAC key; the zeroed-key fallback is removed.
- **`mcp_token` → `Zeroizing<String>`** (parity with every other config secret).

### Fixed
- **QGA `network-get-interfaces`** surfaces a typed `Parse` error instead of swallowing a malformed payload into an empty list.
- **QGA `guest-exec`** builds its argv via `serde_json::json!` (correct escaping) instead of hand-rolled `"`-only escaping.
- **Telegram HTTP client** gets a 30 s request timeout (the long-poll keeps its own).

### Deferred (tracked)
- #173 — fold `user` + `params_json` into the audit chain (needs a chain-format version so existing DBs still verify).
- #172 — test net + shared helper for the destructive `--yes` gates (a focused refactor).
- New GitOps state families + node-level ZFS pool create → v0.10.0 (a patch can't add CLI surface).

### Test plan
- [x] `cargo test` — **1154 green** (incl. new audit key-validation test)
- [x] `cargo clippy --all-targets` — 0 warnings · `cargo fmt --check` — clean
- [x] Live converge e2e on pvetest (`.122`) — **6/6** (the refactored `apply_and_audit` core works end-to-end, audit entry written)
- [ ] Merge → tag `v0.9.1` → `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
