### PR TITLE
chore(release): v0.9.2 — 3 additive ProxmoxGateway methods for proxima (ZFS / serial / disk-IO)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ SemVer contract:
 
 ## [Unreleased]
 
+## [0.9.2] — 2026-06-25
+
+Headline: **Three additive `ProxmoxGateway` methods for the proxima desktop UI — ZFS pool detail, guest serial-device pre-flight, and guest disk-IO rate.** Library-API additions only — **no CLI / MCP / config change** (the user-facing contract is untouched). They let the proxima UI drop three direct-`reqwest` workarounds and route through proxxx's rate-limiter, TLS pinning, and auth-refresh instead.
+
+### Added (library API — `ProxmoxGateway`)
+
+- **`get_node_zfs_detail(node, name)`** — `GET /nodes/{node}/disks/zfs/{name}`: the per-pool `scan` line (scrub progress / last-scrub epoch / error counters) plus the vdev tree, flattened depth-first from PVE's nested shape into `Vec<ZfsVdev>` (`read`/`write`/`cksum` coerced defensively from PVE's number-or-string).
+- **`guest_serial_devices(node, vmid, kind)`** — the `serial0..3` devices configured on a QEMU guest (empty for LXC, which uses `/dev/console` via `lxc-console`). Lets a console pre-flight refuse to open a `termproxy` session that would attach to nothing (no `serial0: socket` → a permanently black terminal).
+- **`guest_disk_io_rate(node, vmid, kind)`** — best-effort read/write bytes-per-second for a guest, from the most recent RRD point. **Verified live:** PVE's RRD already stores `diskread`/`diskwrite` as a *rate* (an idle guest reads 0 while its cumulative `/cluster/resources` counter is non-zero), so this is the latest sample, not a counter delta. `read_iops`/`write_iops` are `None` (PVE guest RRD carries no per-op counts).
+
+New types: `ZfsPoolDetail`, `ZfsVdev`, `SerialDevice`, `DiskIoRate` (all in `proxxx::api::types`). 2 new unit tests (ZFS tree flatten + number-or-string coercion).
+
 ## [0.9.1] — 2026-06-25
 
 Headline: **Hardening patch — `state apply` now leaves an audit trail, and the audit chain's key handling is tightened.** A code-health / security pass after the v0.9.0 GitOps-controller release. No CLI-contract changes (commands, exit codes, and `--format json` shapes are unchanged); the tamper-evident trail and a handful of robustness edges get firmer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -568,6 +568,54 @@ impl PxClient {
     }
 }
 
+/// Raw deserialization shape for `GET /nodes/{node}/disks/zfs/{name}` — PVE
+/// returns the pool with a NESTED vdev `children` tree, flattened depth-first
+/// into the public [`crate::api::types::ZfsPoolDetail`].
+#[derive(serde::Deserialize, Default)]
+#[serde(default)]
+struct RawZfsDetail {
+    name: String,
+    state: String,
+    scan: String,
+    errors: String,
+    children: Vec<RawZfsNode>,
+}
+
+#[derive(serde::Deserialize, Default)]
+#[serde(default)]
+struct RawZfsNode {
+    name: String,
+    state: String,
+    // PVE may send these as numbers OR strings; accept either defensively.
+    read: serde_json::Value,
+    write: serde_json::Value,
+    cksum: serde_json::Value,
+    msg: Option<String>,
+    children: Vec<Self>,
+}
+
+/// Coerce a PVE numeric-or-string JSON value to `u64` (0 on anything else).
+fn zfs_count_to_u64(v: &serde_json::Value) -> u64 {
+    v.as_u64()
+        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        .unwrap_or(0)
+}
+
+/// Flatten the nested vdev tree depth-first into the public flat Vec.
+fn flatten_zfs_children(nodes: &[RawZfsNode], out: &mut Vec<crate::api::types::ZfsVdev>) {
+    for n in nodes {
+        out.push(crate::api::types::ZfsVdev {
+            name: n.name.clone(),
+            state: n.state.clone(),
+            read: zfs_count_to_u64(&n.read),
+            write: zfs_count_to_u64(&n.write),
+            cksum: zfs_count_to_u64(&n.cksum),
+            msg: n.msg.clone(),
+        });
+        flatten_zfs_children(&n.children, out);
+    }
+}
+
 #[async_trait::async_trait]
 impl ProxmoxGateway for PxClient {
     async fn get_nodes(&self) -> Result<Vec<Node>> {
@@ -2499,6 +2547,81 @@ impl ProxmoxGateway for PxClient {
         Ok(resp.data)
     }
 
+    async fn get_node_zfs_detail(
+        &self,
+        node: &str,
+        name: &str,
+    ) -> Result<crate::api::types::ZfsPoolDetail> {
+        let resp: ApiResponse<RawZfsDetail> =
+            self.get(&format!("/nodes/{node}/disks/zfs/{name}")).await?;
+        let raw = resp.data;
+        let mut children = Vec::new();
+        flatten_zfs_children(&raw.children, &mut children);
+        Ok(crate::api::types::ZfsPoolDetail {
+            name: raw.name,
+            state: raw.state,
+            scan: raw.scan,
+            errors: raw.errors,
+            children,
+        })
+    }
+
+    async fn guest_serial_devices(
+        &self,
+        node: &str,
+        vmid: u32,
+        guest_type: &crate::api::types::GuestType,
+    ) -> Result<Vec<crate::api::types::SerialDevice>> {
+        // LXC has no serial-device concept — it's /dev/console via lxc-console.
+        if matches!(guest_type, crate::api::types::GuestType::Lxc) {
+            return Ok(vec![]);
+        }
+        let cfg = self.get_guest_config(node, vmid, guest_type).await?;
+        let mut out: Vec<crate::api::types::SerialDevice> = cfg
+            .iter()
+            .filter_map(|(k, v)| {
+                // serial0..serial3 only (not "serialfoo" or "serial10").
+                let index: u8 = k.strip_prefix("serial")?.parse().ok()?;
+                (index <= 3).then(|| crate::api::types::SerialDevice {
+                    index,
+                    target: v.clone(),
+                })
+            })
+            .collect();
+        out.sort_by_key(|s| s.index);
+        Ok(out)
+    }
+
+    async fn guest_disk_io_rate(
+        &self,
+        node: &str,
+        vmid: u32,
+        guest_type: &crate::api::types::GuestType,
+    ) -> Result<Option<crate::api::types::DiskIoRate>> {
+        use crate::api::types::{RrdCf, RrdTimeframe};
+        let points = self
+            .get_guest_rrddata(node, vmid, *guest_type, RrdTimeframe::Hour, RrdCf::Average)
+            .await?;
+        // PVE RRD stores diskread/diskwrite as a RATE (bytes/sec) — verified
+        // live: rrddata reads 0 on an idle guest whose /cluster/resources
+        // diskread counter is non-zero. So the most recent point carrying IO
+        // data IS the current rate; no counter diffing.
+        let Some(p) = points
+            .iter()
+            .rev()
+            .find(|p| p.diskread.is_some() || p.diskwrite.is_some())
+        else {
+            return Ok(None);
+        };
+        Ok(Some(crate::api::types::DiskIoRate {
+            read_bps: p.diskread.unwrap_or(0.0),
+            write_bps: p.diskwrite.unwrap_or(0.0),
+            read_iops: None,
+            write_iops: None,
+            sampled_at: p.time,
+        }))
+    }
+
     async fn list_ha_groups(&self) -> Result<Vec<crate::api::types::HaGroup>> {
         // PVE 9 migrated `/cluster/ha/groups` → `/cluster/ha/rules`. The old
         // path now returns a 500 with a deprecation message. Until the type
@@ -3239,5 +3362,62 @@ impl ProxmoxGateway for PxClient {
     async fn create_lxc(&self, node: &str, params: &[(&str, &str)]) -> Result<String> {
         let resp: ApiResponse<String> = self.post(&format!("/nodes/{node}/lxc"), params).await?;
         Ok(resp.data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zfs_count_to_u64_accepts_number_or_string() {
+        // PVE may send zpool-status counters as numbers OR strings.
+        assert_eq!(zfs_count_to_u64(&serde_json::json!(42)), 42);
+        assert_eq!(zfs_count_to_u64(&serde_json::json!("7")), 7);
+        assert_eq!(zfs_count_to_u64(&serde_json::json!("oops")), 0);
+        assert_eq!(zfs_count_to_u64(&serde_json::Value::Null), 0);
+    }
+
+    #[test]
+    fn flatten_zfs_children_walks_the_tree_depth_first() {
+        // A mirror group with two leaf disks, the second with a cksum error.
+        let tree = vec![RawZfsNode {
+            name: "mirror-0".into(),
+            state: "ONLINE".into(),
+            read: serde_json::json!(0),
+            write: serde_json::json!(0),
+            cksum: serde_json::json!(0),
+            msg: None,
+            children: vec![
+                RawZfsNode {
+                    name: "/dev/sda".into(),
+                    state: "ONLINE".into(),
+                    read: serde_json::json!(0),
+                    write: serde_json::json!(0),
+                    cksum: serde_json::json!("0"), // string form
+                    msg: None,
+                    children: vec![],
+                },
+                RawZfsNode {
+                    name: "/dev/sdb".into(),
+                    state: "DEGRADED".into(),
+                    read: serde_json::json!(0),
+                    write: serde_json::json!(0),
+                    cksum: serde_json::json!(3),
+                    msg: Some("too many errors".into()),
+                    children: vec![],
+                },
+            ],
+        }];
+        let mut out = Vec::new();
+        flatten_zfs_children(&tree, &mut out);
+        // group + 2 leaves, depth-first.
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].name, "mirror-0");
+        assert_eq!(out[1].name, "/dev/sda");
+        assert_eq!(out[2].name, "/dev/sdb");
+        assert_eq!(out[2].cksum, 3);
+        assert_eq!(out[2].state, "DEGRADED");
+        assert_eq!(out[2].msg.as_deref(), Some("too many errors"));
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1018,6 +1018,36 @@ pub trait ProxmoxGateway: Send + Sync {
     /// Read-only — `GET /nodes/{node}/disks/zfs`.
     async fn list_node_zfs(&self, node: &str) -> Result<Vec<crate::api::types::ZfsPool>>;
 
+    /// Per-pool ZFS detail — `GET /nodes/{node}/disks/zfs/{name}`. Reads the
+    /// `scan` field (scrub progress / last-scrub epoch / error counters) and
+    /// flattens PVE's nested vdev tree into a single `Vec<ZfsVdev>`.
+    async fn get_node_zfs_detail(
+        &self,
+        node: &str,
+        name: &str,
+    ) -> Result<crate::api::types::ZfsPoolDetail>;
+
+    /// Serial devices configured on a guest. QEMU: the `serial0..3` config
+    /// keys; LXC: always empty (LXC uses `/dev/console` via `lxc-console`, not
+    /// a serial device). Callers check `is_empty()` for console pre-flight.
+    async fn guest_serial_devices(
+        &self,
+        node: &str,
+        vmid: u32,
+        guest_type: &crate::api::types::GuestType,
+    ) -> Result<Vec<crate::api::types::SerialDevice>>;
+
+    /// Best-effort instantaneous disk-IO rate for a guest, from the most recent
+    /// RRD point (`rrddata?timeframe=hour`). PVE's RRD already stores
+    /// `diskread`/`diskwrite` as bytes/second, so this is the latest sample.
+    /// `None` when RRD has no point carrying IO data. Resolution ~60 s.
+    async fn guest_disk_io_rate(
+        &self,
+        node: &str,
+        vmid: u32,
+        guest_type: &crate::api::types::GuestType,
+    ) -> Result<Option<crate::api::types::DiskIoRate>>;
+
     // ── HA + replication console (feature #5) ───────────
 
     /// List HA groups (configured failover priority sets).

--- a/src/api/types/guest.rs
+++ b/src/api/types/guest.rs
@@ -123,6 +123,35 @@ pub enum GuestType {
     Lxc,
 }
 
+/// A serial device configured on a guest (QEMU `serial0..3`). Used for console
+/// pre-flight: `termproxy` only attaches if a `serial0: socket` exists, so a
+/// caller can refuse to open a console that would attach to nothing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerialDevice {
+    /// `0..3` for QEMU (`serial0`..`serial3`).
+    pub index: u8,
+    /// The device value: `"socket"` / `"/dev/ttyS0"` / `"/host/path"`. A
+    /// non-`socket` target means `termproxy` console likely won't work.
+    pub target: String,
+}
+
+/// Best-effort instantaneous disk-IO rate for a guest, read from the most
+/// recent RRD point. NOTE: PVE's RRD stores `diskread`/`diskwrite` as a rate
+/// already (bytes/second), so this is the latest sample, NOT a counter delta.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiskIoRate {
+    /// Bytes/second, averaged over the last RRD step (~60 s).
+    pub read_bps: f64,
+    pub write_bps: f64,
+    /// `IOps` when PVE exposes them. PVE guest RRD does not carry per-op counts,
+    /// so this is currently always `None` (kept for forward-compat).
+    pub read_iops: Option<f64>,
+    pub write_iops: Option<f64>,
+    /// Unix seconds of the RRD point this is derived from (so a consumer can
+    /// flag "stale > 2 min").
+    pub sampled_at: u64,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PendingConfigEntry {

--- a/src/api/types/node_hw.rs
+++ b/src/api/types/node_hw.rs
@@ -308,6 +308,37 @@ pub struct ZfsPool {
     pub health: String,
 }
 
+/// Per-pool ZFS detail (`GET /nodes/{node}/disks/zfs/{name}`). Carries the
+/// free-form `scan:` line (scrub progress / last-scrub epoch / error counters)
+/// and a FLATTENED vdev tree (PVE returns it nested; the gateway flattens it
+/// depth-first for ease of consumption).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ZfsPoolDetail {
+    pub name: String,
+    /// `ONLINE` / `DEGRADED` / `FAULTED` / `UNAVAIL`.
+    pub state: String,
+    /// The full `scan:` line — parse scrub progress / last-scrub epoch out of
+    /// this; the structured `children` below are a bonus.
+    pub scan: String,
+    pub errors: String,
+    /// Every vdev group and leaf device, flattened from PVE's nested tree.
+    pub children: Vec<ZfsVdev>,
+}
+
+/// One node in a ZFS pool's device tree — a vdev group (mirror/raidz) or a
+/// leaf device. `read`/`write`/`cksum` are the `zpool status` error counters.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ZfsVdev {
+    pub name: String,
+    pub state: String,
+    pub read: u64,
+    pub write: u64,
+    pub cksum: u64,
+    pub msg: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AptInstalledPackage {

--- a/src/app/patch.rs
+++ b/src/app/patch.rs
@@ -1153,6 +1153,29 @@ mod tests {
         async fn list_node_zfs(&self, _: &str) -> Result<Vec<crate::api::types::ZfsPool>> {
             Ok(vec![])
         }
+        async fn get_node_zfs_detail(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> Result<crate::api::types::ZfsPoolDetail> {
+            Ok(crate::api::types::ZfsPoolDetail::default())
+        }
+        async fn guest_serial_devices(
+            &self,
+            _: &str,
+            _: u32,
+            _: &crate::api::types::GuestType,
+        ) -> Result<Vec<crate::api::types::SerialDevice>> {
+            Ok(vec![])
+        }
+        async fn guest_disk_io_rate(
+            &self,
+            _: &str,
+            _: u32,
+            _: &crate::api::types::GuestType,
+        ) -> Result<Option<crate::api::types::DiskIoRate>> {
+            Ok(None)
+        }
         async fn list_cluster_firewall_rules(
             &self,
         ) -> Result<Vec<crate::api::types::FirewallRule>> {

--- a/tests/hitl_e2e.rs
+++ b/tests/hitl_e2e.rs
@@ -901,6 +901,29 @@ impl ProxmoxGateway for HitlMockGateway {
     async fn list_node_zfs(&self, _: &str) -> Result<Vec<proxxx::api::types::ZfsPool>> {
         Ok(vec![])
     }
+    async fn get_node_zfs_detail(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<proxxx::api::types::ZfsPoolDetail> {
+        Ok(proxxx::api::types::ZfsPoolDetail::default())
+    }
+    async fn guest_serial_devices(
+        &self,
+        _: &str,
+        _: u32,
+        _: &proxxx::api::types::GuestType,
+    ) -> Result<Vec<proxxx::api::types::SerialDevice>> {
+        Ok(vec![])
+    }
+    async fn guest_disk_io_rate(
+        &self,
+        _: &str,
+        _: u32,
+        _: &proxxx::api::types::GuestType,
+    ) -> Result<Option<proxxx::api::types::DiskIoRate>> {
+        Ok(None)
+    }
     async fn list_ha_groups(&self) -> Result<Vec<proxxx::api::types::HaGroup>> {
         Ok(vec![])
     }


### PR DESCRIPTION
**v0.9.2 — three additive `ProxmoxGateway` methods** the proxima desktop UI needs. Library-API only: **no CLI / MCP / config change** (the user-facing SemVer contract is untouched). proxima can now drop three direct-`reqwest` workarounds and route through proxxx's rate-limiter, TLS pinning, and 401-refresh.

### Added — `ProxmoxGateway`
- **`get_node_zfs_detail(node, name)`** → `ZfsPoolDetail` — `GET /nodes/{node}/disks/zfs/{name}`. The `scan` line (scrub progress / last-scrub epoch / errors) + the vdev tree, flattened depth-first from PVE's nested shape into `Vec<ZfsVdev>` (`read`/`write`/`cksum` coerced defensively from number-or-string).
- **`guest_serial_devices(node, vmid, kind)`** → `Vec<SerialDevice>` — `serial0..3` for QEMU, empty for LXC. For console pre-flight: no `serial0: socket` → `termproxy` attaches to nothing (permanently black terminal).
- **`guest_disk_io_rate(node, vmid, kind)`** → `Option<DiskIoRate>` — read/write bytes/sec from the latest RRD point. **Corrected the spec:** PVE's rrddata `diskread`/`diskwrite` are ALREADY a rate (verified live — an idle guest reads 0 while its cumulative `/cluster/resources` counter is non-zero), so this is the latest sample, not a two-point diff (which would've been wrong).

New types `ZfsPoolDetail` / `ZfsVdev` / `SerialDevice` / `DiskIoRate` in `proxxx::api::types`.

### Why patch (not minor)
Additive library API; the project's SemVer contract is CLI + MCP + config, all unchanged. The only `ProxmoxGateway` impls are proxxx-internal (`PxClient` + 2 test mocks); proxima *calls* the trait, doesn't impl it — so no external impl breaks.

### Test plan
- [x] `cargo test` — **1156 green** (2 new: ZFS tree flatten + number-or-string coercion)
- [x] `cargo clippy --all-targets` 0 warnings · `cargo fmt --check` clean
- [x] **Live on pvetest (.122):** Gap 2 confirmed (vmid 8888 has `serial0: socket`, parser returns it); Gap 3 confirmed (rrddata is a rate). Gap 1 shape from the proxima spec + unit-tested flatten (.122 is nested PVE, no ZFS pool to hit).
- [ ] Merge → tag `v0.9.2` → `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
