### PR TITLE
chore(release): v0.12.0 — security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ SemVer contract:
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-07-01
+
+Headline: **Security hardening — tamper-evident audit that now covers WHO/WHAT, tested destructive-confirmation gates, and guardrails on the unmanned converge.** No CLI / config / MCP contract change; an existing `audit.db` migrates in place.
+
 ### Added
 
 - **Unmanned auto-converge guardrails (#171).** Two opt-in restrictions on the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"


### PR DESCRIPTION
Cuts **v0.12.0**, shipping the three hardening PRs merged since v0.11.0.

- **#173** — audit HMAC chain now binds WHO (`user`) and WHAT (`node`, `params_json`) via a v2 format; `chain_version` column migrates an existing `audit.db` in place (legacy rows keep verifying as v1).
- **#172** — the ~30 destructive `--yes` gates centralised into one unit-tested `require_yes()` chokepoint + a behavioural test net (a dropped gate now turns CI red).
- **#171** — opt-in guardrails on the unmanned `auto_converge`: per-family whitelist + `max_unmanned_changes` cap (both only narrow the blast radius).

**No CLI / config / MCP contract change.** `audit.db` migrates transparently. Version bump `0.11.0 → 0.12.0`; CHANGELOG `[Unreleased]` → `[0.12.0]`. 718 lib tests green, clippy `--all-targets` clean, fmt clean.

Merge this to `main`, then tag `v0.12.0` on the squash commit → `release.yml` builds the signed 3-target binaries + SBOM + `.deb` + Homebrew tap bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)