### PR TITLE
ci: keep auto-merge PRs up to date when main advances

### DIFF
--- a/.github/workflows/automerge-update-branch.yml
+++ b/.github/workflows/automerge-update-branch.yml
@@ -1,0 +1,55 @@
+name: Keep auto-merge PRs up to date
+
+# Branch protection on `main` requires PRs to be up to date before merging
+# (`strict`). That guarantee is good — a PR is always tested against the latest
+# main — but it means an auto-merge-armed PR silently stalls the moment another
+# PR merges ahead of it (it goes BEHIND, and GitHub's auto-merge does NOT
+# auto-update the branch). Without this, the dependabot queue needs a manual
+# `gh pr update-branch` after every merge.
+#
+# This job runs when `main` advances and updates the branch of every open PR
+# that has auto-merge enabled, so its checks re-run and auto-merge fires on its
+# own. `update-branch` is a no-op (harmless error, ignored) when a branch is
+# already current, so we update unconditionally rather than racing GitHub's
+# async `mergeStateStatus` computation (which is `UNKNOWN` right after a push).
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: automerge-update-branch
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update branches of auto-merge PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Open PRs that have auto-merge enabled (regardless of BEHIND/UNKNOWN).
+          mapfile -t prs < <(
+            gh pr list --repo "$REPO" --state open \
+              --json number,autoMergeRequest \
+              --jq '.[] | select(.autoMergeRequest != null) | .number'
+          )
+          if [ "${#prs[@]}" -eq 0 ]; then
+            echo "No auto-merge PRs to update."
+            exit 0
+          fi
+          for n in "${prs[@]}"; do
+            if gh pr update-branch "$n" --repo "$REPO" 2>/tmp/err; then
+              echo "PR #$n: branch updated."
+            else
+              # Already up to date, or a fork PR the token can't push to — both fine.
+              echo "PR #$n: no update needed ($(tr -d '\n' </tmp/err))."
+            fi
+          done


### PR DESCRIPTION
The durable fix for the dependabot-queue friction (option **B** — keeps `strict` branch protection, no weakening).

**Problem:** branch protection requires PRs to be up-to-date before merging (`strict`). GitHub's auto-merge does **not** auto-update a branch that goes `BEHIND` after another PR merges ahead of it — so an auto-merge-armed PR silently stalls and needs a manual `gh pr update-branch`. This bit the queue repeatedly.

**Fix:** on push to `main`, update the branch of every open PR that has auto-merge enabled, so its checks re-run and auto-merge fires on its own. `update-branch` is a harmless no-op when a branch is already current, so it updates unconditionally (avoids racing GitHub's async `mergeStateStatus`).

Scoped `contents: write` + `pull-requests: write`, `concurrency` guarded. No change to branch protection — the `strict` guarantee stays intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)