### PR TITLE
harden: close Phase-1 rigor soft-spots (MCP fail-closed auth, audit custody, taxonomy)

### DIFF
--- a/pre-commit/ACCEPTED-RISKS.md
+++ b/pre-commit/ACCEPTED-RISKS.md
@@ -104,6 +104,11 @@ one HMAC-chained audit entry + a Telegram summary).
 **Operator's responsibility:**
 - Set `max_unmanned_changes` to bound every unmanned tick (creates/updates
   included), not only to unlock prune. Recommended for any production profile.
+- **Size it small.** The cap should be the smallest count a legitimate tick
+  would ever apply (single digits for most profiles). A generously-large cap
+  (e.g. `49`) satisfies the gate but re-opens the exact 10–49 unmanned-delete
+  band the guard exists to bound — the cap *unlocks* prune, it does not by
+  itself make a flood safe.
 - Use `allowed_families` for graduated trust — let the daemon converge low-risk
   families unmanned, keep high-blast-radius ones (`acl`, `storage`) human-only.
 - Protect the desired-state repo (branch protection, atomic pushes) so a
@@ -129,11 +134,21 @@ MAC, and produce a chain that `audit verify` accepts.
 the same host — root can read process memory, the keychain, any file. Genuine
 non-repudiation requires the key and/or the log to leave the host's trust domain.
 Refusing to run without that would break the common single-host homelab install.
+The load-path custody check *is* hardened: it fails **closed** (a `stat` error
+refuses the key rather than skipping the check) and fstat's the open fd (no
+TOCTOU / symlink-swap window). It is **unix-only** — non-unix has no POSIX mode
+to enforce; the only supported release targets are darwin + linux-musl.
 
 **Operator's responsibility (defense in depth, pick per threat model):**
-- **Separate the key's trust domain:** set `PROXXX_AUDIT_KEY` to a path on a
-  volume owned by a *different* principal than the proxxx user (e.g. a root-owned
-  `0600` key on a mount the proxxx user can't read), so DB-write ≠ key-read.
+- **Relocate the key — with a caveat.** `PROXXX_AUDIT_KEY` moves the key off the
+  DB's volume, but proxxx must still *read* it on every `AuditLogger::open()`,
+  and the `0o077` check enforces owner-only *access mode* (not *ownership* — a
+  `0600` key owned by another uid still passes the mode check; the audit dir is
+  created `0700` so a different user cannot swap the key in, but a same-uid/root
+  attacker with dir-write can). So a "root-owned key the proxxx
+  user can't read" only helps if proxxx itself runs as that principal;
+  co-location on a single-user host buys little on its own. Prefer log
+  externalisation for real cross-domain separation.
 - **Externalise the log:** ship audit entries to an append-only sink outside the
   host (remote syslog / SIEM / WORM store). A local forge then diverges from the
   external copy — the divergence is the evidence.
@@ -171,5 +186,14 @@ queue. Fail-safe direction: the code errs toward NOT re-dispatching (a stuck
   move-disk with delete-source).
 - This surface is TUI-only: unattended automation uses the daemon/CLI paths,
   which do not carry the op_queue.
+- **The command palette is a present-operator fast path.** Guest-list
+  keypresses (stop/delete/restart/start) *enqueue* — they flow through the queue
+  and its write-ahead persist. The one path that runs a destructive op *outside*
+  the queue is the fuzzy search / command palette (`/`, then e.g. `Delete VM
+  100` → Enter): it dispatches the action immediately with only the HA/lock
+  guard — no queue entry, no write-ahead, and no confirm modal. A crash mid-op
+  there leaves nothing to reconcile. For the durable crash-recovery guarantee,
+  drive destructive intent through the guest list (which enqueues) rather than
+  the palette.
 
 *Accepted by Fabrizio Salmi — 2026-07-05.*

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -313,25 +313,47 @@ fn load_or_create_key(path: &PathBuf) -> Result<Vec<u8>> {
         // `telegram.bot_token_file` 0600 enforcement. (The key we *create*
         // below is already 0600; this catches one restored from a backup, an
         // over-permissive umask, or a hand-placed key on a separate volume.)
+        let bytes;
         #[cfg(unix)]
         {
+            use std::io::Read as _;
             use std::os::unix::fs::PermissionsExt;
-            if let Ok(meta) = std::fs::metadata(path) {
-                let mode = meta.permissions().mode();
-                if mode & 0o077 != 0 {
-                    anyhow::bail!(
-                        "audit key {} has unsafe permissions {:o} — must be 0600 (owner-only). A \
-                         group/world-readable HMAC key lets another local user forge the audit \
-                         chain. Run: chmod 600 {}",
-                        path.display(),
-                        mode & 0o777,
-                        path.display(),
-                    );
-                }
+            // Open ONCE, then fstat the open fd — not a fresh path stat — so the
+            // mode we check and the bytes we read come from the SAME inode. This
+            // closes the TOCTOU / symlink-swap window between a path-based check
+            // and a path-based read.
+            let mut file = std::fs::File::open(path)
+                .with_context(|| format!("open audit key {}", path.display()))?;
+            // FAIL CLOSED: a stat error must REFUSE the key, not skip the check
+            // and read it anyway. Custody we cannot verify is custody we do not
+            // trust. (Was previously `if let Ok(meta)` — silently fail-open.)
+            let mode = file
+                .metadata()
+                .with_context(|| format!("stat audit key {}", path.display()))?
+                .permissions()
+                .mode();
+            if mode & 0o077 != 0 {
+                anyhow::bail!(
+                    "audit key {} has unsafe permissions {:o} — must be 0600 (owner-only). A \
+                     group/world-readable HMAC key lets another local user forge the audit \
+                     chain. Run: chmod 600 {}",
+                    path.display(),
+                    mode & 0o777,
+                    path.display(),
+                );
             }
+            let mut buf = Vec::new();
+            file.read_to_end(&mut buf)
+                .with_context(|| format!("read audit key {}", path.display()))?;
+            bytes = buf;
         }
-        let bytes =
-            std::fs::read(path).with_context(|| format!("read audit key {}", path.display()))?;
+        #[cfg(not(unix))]
+        {
+            // No POSIX mode to enforce custody here. AR-5 scopes the tamper-
+            // evidence guarantee to unix; release targets are darwin + linux-musl.
+            bytes = std::fs::read(path)
+                .with_context(|| format!("read audit key {}", path.display()))?;
+        }
         // The HMAC chain is only as trustworthy as its key. A truncated or empty
         // key (e.g. an interrupted first write, or a `touch`'d file) MUST fail
         // loudly — an empty key would otherwise degrade to a forgeable all-zeros
@@ -371,17 +393,36 @@ fn load_or_create_key(path: &PathBuf) -> Result<Vec<u8>> {
 /// hermetic tests, and for relocating the trail onto a dedicated volume in
 /// ops); otherwise the platform data-local dir. Mirrors the `PROXXX_CONFIG` /
 /// `PROXXX_FREEZE_PATH` override convention. The directory is created if absent.
+///
+/// Custody: on unix the dir is created `0700`. Dir-write is the precondition for
+/// *replacing* the HMAC key with an attacker-owned `0600` key (which the
+/// mode-only load check would otherwise accept), so denying other users write
+/// access to the dir closes that swap vector. Only tightens an existing dir's
+/// perms is out of scope — `create_dir_all` no-ops if it exists; operators who
+/// pre-create a lax `PROXXX_AUDIT_DIR` own that choice (see ACCEPTED-RISKS AR-5).
 fn audit_data_dir() -> Result<PathBuf> {
-    if let Ok(dir) = std::env::var("PROXXX_AUDIT_DIR") {
-        let dir = PathBuf::from(dir);
-        std::fs::create_dir_all(&dir)
-            .with_context(|| format!("create PROXXX_AUDIT_DIR {}", dir.display()))?;
-        return Ok(dir);
+    let dir = if let Ok(dir) = std::env::var("PROXXX_AUDIT_DIR") {
+        PathBuf::from(dir)
+    } else {
+        directories::ProjectDirs::from("dev", "proxxx", "proxxx")
+            .ok_or_else(|| anyhow::anyhow!("cannot resolve data dir"))?
+            .data_local_dir()
+            .to_path_buf()
+    };
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&dir)
+            .with_context(|| format!("create audit dir {}", dir.display()))?;
     }
-    let base = directories::ProjectDirs::from("dev", "proxxx", "proxxx")
-        .ok_or_else(|| anyhow::anyhow!("cannot resolve data dir"))?;
-    let dir = base.data_local_dir().to_path_buf();
-    std::fs::create_dir_all(&dir)?;
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("create audit dir {}", dir.display()))?;
+    }
     Ok(dir)
 }
 

--- a/src/mcp/http_server.rs
+++ b/src/mcp/http_server.rs
@@ -42,6 +42,13 @@ struct McpState {
     /// only the broadcast sender). Cloned per `GET /mcp` SSE
     /// connection to derive a fresh receiver.
     notifications: crate::mcp::notifications::Broker,
+    /// True when the server is bound to a non-loopback interface WITHOUT an
+    /// explicit `--insecure-bind` opt-in. In that mode a missing `mcp_token`
+    /// means FAIL CLOSED (deny every request) — not open. Computed once at
+    /// start; it closes the SIGHUP hole where clearing `mcp_token` on a live
+    /// exposed server would otherwise silently drop all auth (the start-time
+    /// bind preflight does not re-run on reload).
+    require_token: bool,
 }
 
 impl McpState {
@@ -49,38 +56,63 @@ impl McpState {
         client: Arc<PxClient>,
         config: ConfigHandle,
         notifications: crate::mcp::notifications::Broker,
+        require_token: bool,
     ) -> Self {
         Self {
             client,
             config,
             notifications,
+            require_token,
         }
     }
 
-    /// Returns `true` if the request carries a valid bearer token (or if no
-    /// token is configured). Constant-time comparison via XOR fold prevents
-    /// timing side-channels leaking token length or prefix.
-    ///
-    /// Reads `mcp_token` from the live config so a SIGHUP token rotation
-    /// takes effect on the next request without a restart.
+    /// Returns `true` if the request is authorized. Reads `mcp_token` from the
+    /// live config so a SIGHUP token rotation takes effect on the next request.
+    /// When `require_token` is set (exposed bind, no `--insecure-bind`), a
+    /// missing token denies every request instead of opening — see
+    /// [`token_gate`].
     async fn auth_ok(&self, headers: &HeaderMap) -> bool {
         let expected = self.config.read().await.mcp_token.clone();
-        let Some(expected) = expected else {
-            return true; // no token configured → open
-        };
-        let expected_hash = sha256_bytes(&expected);
         let bearer = headers
             .get("authorization")
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "))
             .unwrap_or("");
-        let got_hash = sha256_bytes(bearer);
-        // Constant-time comparison: fold XOR of all bytes, reject if any differ.
-        let diff: u8 = expected_hash
-            .iter()
-            .zip(got_hash.iter())
-            .fold(0u8, |acc, (a, b)| acc | (a ^ b));
-        diff == 0
+        token_gate(
+            expected.as_ref().map(|z| z.as_str()),
+            bearer,
+            self.require_token,
+        )
+    }
+}
+
+/// Pure authorization decision, split out so the fail-closed logic is unit-
+/// testable without spinning a server.
+///
+/// * `expected = Some(tok)` → constant-time compare of the presented bearer
+///   (XOR fold over SHA-256, no length/prefix timing leak).
+/// * `expected = None` → OPEN only when `require_token` is false (loopback bind
+///   or explicit `--insecure-bind`). When `require_token` is true the server is
+///   network-exposed and an absent token FAILS CLOSED — this is what prevents a
+///   SIGHUP that clears `mcp_token` from silently unauthenticating the server.
+fn token_gate(expected: Option<&str>, bearer: &str, require_token: bool) -> bool {
+    // An empty / whitespace-only token counts as ABSENT — mirrors the
+    // `!is_empty()` guards on token_secret/password (config/mod.rs) and closes
+    // the bypass where `--token ""` (an unset env var) or a SIGHUP that sets
+    // `mcp_token = ""` would otherwise be a real `Some("")` that authorizes a
+    // header-less request on an exposed bind (sha256("") == sha256("")).
+    let effective = expected.filter(|t| !t.trim().is_empty());
+    match effective {
+        None => !require_token,
+        Some(tok) => {
+            let expected_hash = sha256_bytes(tok);
+            let got_hash = sha256_bytes(bearer);
+            let diff: u8 = expected_hash
+                .iter()
+                .zip(got_hash.iter())
+                .fold(0u8, |acc, (a, b)| acc | (a ^ b));
+            diff == 0
+        }
     }
 }
 
@@ -244,8 +276,19 @@ pub async fn run_http_server(
     port: u16,
     allow_insecure_bind: bool,
 ) -> Result<()> {
-    if !is_loopback_bind(bind) && !allow_insecure_bind {
-        let has_token = config.read().await.mcp_token.is_some();
+    // Exposed = network-reachable without a conscious --insecure-bind opt-in.
+    // Drives BOTH the start-time refusal below AND the per-request fail-closed
+    // gate in `auth_ok` (so a later SIGHUP that clears the token can't reopen).
+    let require_token = !is_loopback_bind(bind) && !allow_insecure_bind;
+    if require_token {
+        // Non-empty, mirroring token_gate: `--token ""` must NOT be treated as
+        // "authenticated" and start an exposed, effectively-open server.
+        let has_token = config
+            .read()
+            .await
+            .mcp_token
+            .as_ref()
+            .is_some_and(|t| !t.trim().is_empty());
         if !has_token {
             anyhow::bail!(
                 "Refusing to start the MCP HTTP server on non-loopback bind '{bind}' without auth. \
@@ -270,7 +313,7 @@ pub async fn run_http_server(
         notifications.clone(),
     );
 
-    let state = McpState::new(client, config, notifications);
+    let state = McpState::new(client, config, notifications, require_token);
     let addr = format!("{bind}:{port}");
 
     let app = Router::new()
@@ -317,7 +360,67 @@ async fn shutdown_signal() {
 
 #[cfg(test)]
 mod tests {
-    use super::is_loopback_bind;
+    use super::{is_loopback_bind, token_gate};
+
+    #[test]
+    fn token_gate_fails_closed_on_exposed_bind_without_token() {
+        // The SIGHUP hole: server exposed (require_token=true), token cleared
+        // → every request must be DENIED, not opened.
+        assert!(
+            !token_gate(None, "", true),
+            "exposed bind + no token → deny (fail-closed)"
+        );
+        assert!(
+            !token_gate(None, "anything", true),
+            "exposed bind + no token → deny even with a presented bearer"
+        );
+        // An empty / whitespace-only configured token counts as absent — the
+        // `--token ""` / SIGHUP-clear-to-"" bypass must also fail closed.
+        assert!(
+            !token_gate(Some(""), "", true),
+            "empty token on exposed bind → deny (not a real credential)"
+        );
+        assert!(
+            !token_gate(Some("   "), "", true),
+            "whitespace-only token on exposed bind → deny"
+        );
+        assert!(
+            !token_gate(Some(""), "", true) && token_gate(Some(""), "", false),
+            "empty token is treated as absent in both exposure modes"
+        );
+    }
+
+    #[test]
+    fn token_gate_opens_only_when_not_exposed() {
+        // Loopback / --insecure-bind (require_token=false) with no token → open,
+        // matching the documented default.
+        assert!(token_gate(None, "", false));
+        assert!(token_gate(None, "ignored", false));
+    }
+
+    #[test]
+    fn token_gate_matches_and_rejects_bearer() {
+        assert!(
+            token_gate(Some("s3cret-token"), "s3cret-token", true),
+            "exact match authorizes"
+        );
+        assert!(
+            token_gate(Some("s3cret-token"), "s3cret-token", false),
+            "match works regardless of exposure"
+        );
+        assert!(
+            !token_gate(Some("s3cret-token"), "wrong", true),
+            "wrong token denied"
+        );
+        assert!(
+            !token_gate(Some("s3cret-token"), "", true),
+            "empty bearer denied when a token is set"
+        );
+        assert!(
+            !token_gate(Some("s3cret-token"), "s3cret-toke", true),
+            "prefix is not a match"
+        );
+    }
 
     #[test]
     fn loopback_binds_are_recognised() {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -226,7 +226,12 @@ pub const TOOLS: &[ToolDef] = &[
             },
         ],
         action: ToolAction::CreateSnapshot,
-        destructive: false,
+        // Storage-mutating: an unauthenticated caller could loop snapshot
+        // creation to exhaust the storage pool (a DoS on every guest sharing
+        // it), and it is inconsistent to gate create_guest / delete_snapshot
+        // but not this. Gated. (start_guest / resume_guest stay inline: pure
+        // power-on / restore, no new persistent object.)
+        destructive: true,
         timeout_secs: 120,
     },
     ToolDef {
@@ -322,7 +327,12 @@ pub const TOOLS: &[ToolDef] = &[
             required: true,
         }],
         action: ToolAction::SuspendGuest,
-        destructive: false,
+        // Availability-affecting: pausing a running VM freezes it (unresponsive
+        // to users/network) until resumed — a real production impact, so it goes
+        // through the same fail-closed policy gate as stop/delete. (start_guest,
+        // resume_guest, create_snapshot stay inline: additive / restoring /
+        // reversible-low-blast.)
+        destructive: true,
         timeout_secs: 60,
     },
     ToolDef {

--- a/tests/mcp_security_e2e.rs
+++ b/tests/mcp_security_e2e.rs
@@ -158,3 +158,81 @@ async fn mcp_http_nonloopback_without_token_refuses_start() {
         "error must name the fail-closed reason, got: {msg}"
     );
 }
+
+/// Registry contract: the destructive-tool set is an explicit whitelist. Every
+/// entry here is fail-closed (policy-gated) on the MCP path, so a silent flag
+/// flip in either direction changes the security posture — this test forces the
+/// change to be conscious. `suspend_guest` is included (it pauses a running VM).
+#[test]
+fn destructive_tool_set_matches_expected_whitelist() {
+    let mut got: Vec<&str> = proxxx::mcp::tools::TOOLS
+        .iter()
+        .filter(|t| t.destructive)
+        .map(|t| t.name)
+        .collect();
+    got.sort_unstable();
+    let mut want = vec![
+        "clone_guest",
+        "clone_with_cloudinit",
+        "create_guest",
+        "create_snapshot",
+        "delete_guest",
+        "delete_snapshot",
+        "migrate_guest",
+        "restart_guest",
+        "stop_guest",
+        "suspend_guest",
+    ];
+    want.sort_unstable();
+    assert_eq!(
+        got, want,
+        "destructive-tool set changed — update the whitelist consciously (each entry is \
+         policy-gated / fail-closed on MCP)"
+    );
+}
+
+/// The fail-closed gate is uniform (`tool_def.destructive`), not delete-specific.
+/// Prove it for representatives spanning the required-param shapes; the registry
+/// contract above covers the multi-param remainder (create/clone) that share the
+/// identical gate branch.
+#[tokio::test]
+async fn every_destructive_tool_refuses_without_policy() {
+    let client = offline_client().await;
+    let cfg = base_cfg(None); // no policies → the gate must refuse
+
+    let cases: &[(&str, serde_json::Value)] = &[
+        ("stop_guest", json!({ "guest_id": 100 })),
+        ("restart_guest", json!({ "guest_id": 100 })),
+        ("delete_guest", json!({ "guest_id": 100 })),
+        ("suspend_guest", json!({ "guest_id": 100 })),
+        (
+            "migrate_guest",
+            json!({ "guest_id": 100, "target_node": "pve2" }),
+        ),
+        (
+            "delete_snapshot",
+            json!({ "guest_id": 100, "name": "snap1" }),
+        ),
+        (
+            "create_snapshot",
+            json!({ "guest_id": 100, "name": "snap1" }),
+        ),
+        // Highest-blast multi-param tools — proven behaviorally, not just via
+        // the registry flag. create_guest has no guest_id (it mints one), so it
+        // exercises the vmid-absent gate path.
+        ("create_guest", json!({ "node": "pve1", "type": "lxc" })),
+        ("clone_guest", json!({ "guest_id": 100 })),
+        ("clone_with_cloudinit", json!({ "guest_id": 100 })),
+    ];
+
+    for (tool, args) in cases {
+        let out = proxxx::mcp::dispatch::handle_tool_call(&client, &cfg, tool, args)
+            .await
+            .unwrap_or_else(|e| panic!("{tool}: dispatch should return an envelope, got err: {e}"));
+        assert_eq!(
+            out.get("isError").and_then(serde_json::Value::as_bool),
+            Some(true),
+            "{tool}: a destructive tool with no policy MUST refuse (isError=true), got: {out}"
+        );
+    }
+}


### PR DESCRIPTION
Phase 1 of the diamond-state plan. An **adversarial self-review** of today's four merged security fixes (#192/#193) found real gaps; this closes them. Every fix was then re-verified by a second adversarial pass (which caught a live auth bypass + a factually-wrong accepted-risk note before this PR).

## MCP transport
- **SIGHUP auth-drop → fail-closed.** `require_token` (exposed bind && no `--insecure-bind`) is computed once at start and stored on `McpState`; the pure `token_gate` denies every request when the server is exposed and the token is absent. Clearing `mcp_token` at runtime can no longer silently unauthenticate a network server.
- **Empty/whitespace token bypass → closed.** `mcp_token = ""` / `--token ""` (unset env) now counts as absent in both `token_gate` and the start preflight, mirroring the `!is_empty()` guards on `token_secret`/`password`. (Found by the adversarial verify.)
- **Taxonomy.** `suspend_guest` (pauses a running VM) and `create_snapshot` (unbounded storage write) are now `destructive` → policy-gated, consistent with `create_guest`/`delete_snapshot`. `start_guest`/`resume_guest` stay inline (restore-only).
- **Tests.** Registry-contract whitelist + parametrized dispatch refusal across **all 10** destructive tools (incl. `create_guest`/`clone_*`); `token_gate` empty-token units.

## Audit key custody
- **Fail-closed on stat error** (was `if let Ok(meta)` → fail-open); opens the key once and **fstat's the fd** (same inode for check + read → no TOCTOU / symlink-swap).
- **Audit dir created `0700`** (unix) so a *different* user can't swap in an attacker-owned `0600` key the mode-only check would accept.

## Docs
AR-4 (cap "size it small"), AR-5 (owner-only *access mode* ≠ ownership; dir-0700; fail-closed/unix scope), AR-6 (corrected: the non-enqueued fast path is the **command palette** with no confirm modal — the guest list *enqueues*; migrate is enqueue-only).

## ⚠️ Consumer-visible
`suspend_guest` and `create_snapshot` via MCP now require a matching `[[policies]]` entry (were inline). → v0.13.0 CHANGELOG.

## Verification
`cargo test` full suite — 0 failed · `cargo clippy --all-targets` clean · `cargo fmt --check` clean. Fixes were adversarially verified by a 5-agent refutation pass; all HIGH/MED findings closed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)