### PR TITLE
fix(ssh,api): RSA client keys work vs modern sshd + 401 error names the status

### DIFF
--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -31,7 +31,7 @@ pub enum ApiError {
     /// Server returned 401. Token wrong, password expired, ticket
     /// expired post-suspend (V11). Caller may force re-auth and
     /// retry, OR surface "credentials rejected" to the user.
-    #[error("Proxmox rejected our credentials: {0}")]
+    #[error("Proxmox rejected our credentials (HTTP 401 Unauthorized): {0}")]
     Unauthorized(String),
 
     /// Server returned 403. The caller's token is valid but lacks

--- a/src/ssh/session.rs
+++ b/src/ssh/session.rs
@@ -210,14 +210,21 @@ impl SshSession {
         })?
         .with_context(|| format!("ssh connect {host}:{port}"))?;
 
-        // russh 0.60: `authenticate_publickey` now takes a
-        // `PrivateKeyWithHashAlg` (the hash-alg pin lets the client
-        // negotiate rsa-sha2-256/512 instead of the deprecated
-        // ssh-rsa-sha1). Passing `None` lets russh choose the
-        // strongest mutually-supported algorithm — for ed25519 keys
-        // (our only supported type per known_hosts policy) the hash
-        // alg is irrelevant.
-        let key_with_alg = PrivateKeyWithHashAlg::new(Arc::new(key_pair), None);
+        // russh 0.60: `authenticate_publickey` takes a `PrivateKeyWithHashAlg`.
+        // For an RSA key we MUST pin rsa-sha2 (SHA-512) — passing `None` makes
+        // russh sign with the key's default algorithm, which for RSA is the
+        // deprecated `ssh-rsa` (SHA-1). Modern OpenSSH sshd (PVE 9 / Debian 13)
+        // has ssh-rsa out of `PubkeyAcceptedAlgorithms` by default, so a `None`
+        // RSA signature is rejected and RSA keys become unusable — even though
+        // the same key works fine over the OpenSSH client (which negotiates
+        // rsa-sha2 automatically). Ed25519 / ECDSA ignore the hash alg → `None`.
+        let key_pair = Arc::new(key_pair);
+        let hash_alg = if matches!(key_pair.algorithm(), russh::keys::Algorithm::Rsa { .. }) {
+            Some(russh::keys::HashAlg::Sha512)
+        } else {
+            None
+        };
+        let key_with_alg = PrivateKeyWithHashAlg::new(key_pair, hash_alg);
         let auth_result = handle
             .authenticate_publickey(user.clone(), key_with_alg)
             .await


### PR DESCRIPTION
Two real bugs surfaced by the **draconian E2E run against a live PVE 9.1.1 cluster** (pve-test-1). Both confirmed fixed against the cluster.

## 🔴 RSA SSH keys were unusable
`PrivateKeyWithHashAlg::new(key, None)` made russh sign an RSA key with the default **`ssh-rsa` (SHA-1)** signature. Modern OpenSSH sshd (PVE 9 / Debian 13) drops `ssh-rsa` from `PubkeyAcceptedAlgorithms`, so it **rejected the auth** — even though the *same key* works over the OpenSSH client (which negotiates rsa-sha2 automatically). Anyone with an RSA key couldn't use proxxx's SSH features (console, `exec`, cross-node log fanout).

**Fix:** pin **rsa-sha2-512** for RSA keys (`Some(HashAlg::Sha512)`); ed25519/ecdsa keep `None`. `ssh_live` went **0/2 → 2/2** with a 3072-bit RSA key against the cluster.

## 🟡 401 error didn't name the status
`ApiError::Unauthorized` rendered as *"Proxmox rejected our credentials: …"* — no "401"/"Unauthorized" token, so a bad-credential failure wasn't greppable/recognizable as an auth error. Now: *"Proxmox rejected our credentials **(HTTP 401 Unauthorized)**: …"* — clearer for humans, and satisfies the `e2e_beta` bad-token contract.

## Verification
Live suite on the cluster now green: `e2e_alpha` (1) + `e2e_beta` (3) + `feature_coverage_live` (6) + `ssh_live` (2) = **12/12**. Full non-cluster `cargo test` — 0 failed. clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)