### PR TITLE
harden(ci): least-privilege automerge token + concurrency (Scorecard Token-Permissions 0→10)

### DIFF
--- a/.github/workflows/automerge-update-branch.yml
+++ b/.github/workflows/automerge-update-branch.yml
@@ -17,9 +17,10 @@ on:
   push:
     branches: [main]
 
+# Least-privilege at the top; the write scopes live on the one job that needs
+# them (OpenSSF Scorecard Token-Permissions flags top-level write as high-sev).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: automerge-update-branch
@@ -28,6 +29,9 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # `gh pr update-branch` merges main into the PR head
+      pull-requests: write # read auto-merge PRs + update their branches
     steps:
       - name: Update branches of auto-merge PRs
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Cancel superseded runs on the same ref (rapid pushes to a PR) so we don't
+# burn runners on stale commits or race the required-check status.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     name: Build · test · clippy · fmt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same ref so rapid pushes don't stack CodeQL.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyse (rust)


### PR DESCRIPTION
Phase 3 (safe subset) of the diamond plan — the high-leverage OpenSSF Scorecard fix without touching the release pipeline before v0.13.0.

## What
- **Token-Permissions 0 → 10.** `automerge-update-branch.yml` was the only workflow with top-level `contents: write` — Scorecard flags that as high-severity and zeroes the whole check. Moved the write scopes to the single `update` job; top-level is now `contents: read`.
- **Concurrency guards** on `ci.yml` + `codeql.yml` (`cancel-in-progress`) so rapid pushes don't stack redundant runs or race the required-check status.

## Deferred to a post-v0.13.0 follow-up (intentionally not here)
To avoid editing the release pipeline right before cutting v0.13.0:
- **Signed-Releases** recognized artifacts (`.sig`/`.pem` alongside the existing cosign `.bundle` in `release.yml`) — releases *are* already cosign-signed; Scorecard just doesn't read `.cosign.bundle`.
- **Scorecard `repo_token` PAT** — needs a maintainer-created fine-grained secret (Administration:read) so Branch-Protection stops erroring to −1.
- **Pinned-Deps** `curl … | python3` false-positives in `tests/live/*.sh` (parsing API JSON, not running downloaded code).
- **OSV RSA-Marvin** residual — already ignored with justification in `deny.toml`; Scorecard reads OSV, not `deny.toml`, so it stays structural (upstream dep).

YAML validated. No code changes.

