### PR TITLE
docs(v0.13.0): correct now-wrong docs + CHANGELOG breaking block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,39 @@ SemVer contract:
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-07-05
+
+Headline: **Fail-closed by default.** The four declared security-invariant gaps are closed and hardened under adversarial review, and the whole surface was exercised against a live PVE 9.1.1 cluster (which turned up two real bugs, both fixed). No CLI-command, exit-code, `--format json`, or MCP-registry *contract* change — but several runtime **defaults are now stricter**, so read the migration notes.
+
+### ⚠️ Breaking (behavioural — no schema/contract change)
+
+- **Destructive MCP tools now require a policy.** A destructive tool invoked over MCP with **no matching `[[policies]]` entry is REFUSED** (typed `isError`; the PVE gateway is never reached). Previously such a call executed inline. The MCP transport is network-reachable, so this closes the path where an unauthenticated caller could drive a destructive op. **Migration:** add a matching `[[policies]]` entry (which routes the op through HITL approval) for any destructive MCP tool you rely on.
+- **`suspend_guest` and `create_snapshot` are now destructive** (policy-gated over MCP): the first pauses a running VM (availability impact), the second is an unbounded storage write. `start_guest` / `resume_guest` stay inline. **Migration:** as above — add a policy if an agent needs them.
+- **`mcp serve-http` refuses to expose an unauthenticated endpoint.** It will not start on a non-loopback bind (e.g. `0.0.0.0`) unless `mcp_token` is set. **Migration:** set `mcp_token` (or `--token`), bind `127.0.0.1`, or pass the new `--insecure-bind` to override consciously. An empty/whitespace token counts as absent (fail-closed).
+- **Unmanned `converge_prune` holds deletes without a cap.** With `auto_converge = true` and `converge_prune = true` but **no `max_unmanned_changes`**, the daemon now converges creates/updates but **holds all deletes** (a 10–49 delete flood is below the Severe ≥50 breaker and would otherwise auto-apply unmanned). **Migration:** set a *small* `max_unmanned_changes` to re-enable unmanned prune (size it to the smallest count a legit tick applies — a large cap re-opens the band).
+
+### Security
+
+- **MCP dispatch is fail-closed and stays that way (#192, #194).** Destructive tools with no governing policy are refused; the deny is uniform across all 10 destructive tools (registry-contract + parametrized dispatch tests). The HTTP bind preflight and a per-request token gate are **SIGHUP-safe** — clearing (or emptying) `mcp_token` at runtime on an exposed server can no longer silently drop auth.
+- **Audit key custody hardened (#192, #194).** A group/world-readable `audit.key` is refused on load (unix); the check **fails closed** on a stat error and fstat's the open fd (no TOCTOU / symlink-swap); the audit data dir is created `0700`. `PROXXX_AUDIT_KEY` relocates the key off the DB volume. `proxxx audit verify` exits non-zero on any tamper.
+- **Unmanned converge blast radius bounded (#192).** Adversarial tests prove a mass-delete cannot auto-apply; the fail-closed prune guard is above.
+- **Operation-queue crash recovery is idempotent (#193).** A write-ahead persist records intent before any PVE call, so a crash mid-op can't turn into a double-execute of a non-idempotent op on restart.
+- Signed residual risks are catalogued in [`pre-commit/ACCEPTED-RISKS.md`](pre-commit/ACCEPTED-RISKS.md) (AR-1…AR-6).
+
+### Fixed
+
+- **RSA SSH client keys work against a modern sshd (#195).** russh signed RSA keys with the deprecated `ssh-rsa` (SHA-1), which OpenSSH sshd (PVE 9 / Debian 13) rejects — so RSA keys were unusable for the console / `exec` / log-fanout even though the same key works over the OpenSSH client. Now pins `rsa-sha2-512` for RSA keys. Surfaced by the live E2E run.
+- **A 401 now names the status (#195).** `ApiError::Unauthorized` renders as *"Proxmox rejected our credentials (HTTP 401 Unauthorized): …"* — recognizable/greppable as an auth failure.
+
+### Added
+
+- **`--insecure-bind`** flag on `mcp serve-http` — the explicit, conscious opt-out of the non-loopback-without-auth refusal.
+- **`PROXXX_AUDIT_KEY`** env var — relocate the audit HMAC key onto a separate volume/trust domain (complements the existing `PROXXX_AUDIT_DIR`).
+
+### CI / Supply chain
+
+- Least-privilege `automerge` workflow token (top-level → job-level write; OpenSSF Scorecard Token-Permissions) and concurrency guards on `ci` / `codeql` (#196).
+
 ## [0.12.0] — 2026-07-01
 
 Headline: **Security hardening — tamper-evident audit that now covers WHO/WHAT, tested destructive-confirmation gates, and guardrails on the unmanned converge.** No CLI / config / MCP contract change; an existing `audit.db` migrates in place.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Pick the row that matches you and jump straight to the right page.
 - **Upgrade pre-flight** — `proxxx upgrade-check --target 9.x` scans cluster + config against bundled rules; exit code 1 on any block-severity finding (CI-gateable).
 - **Bundled error knowledge base** — `proxxx explain <error-id>` for every typed error proxxx can emit (15 entries; ships with the binary, no network needed).
 - **Cluster digest for LLMs** — `proxxx describe --output llm-context` emits a token-compact prose+key:value paste-pronto for AI chats.
-- **MCP server** — stdio JSON-RPC + HTTP/SSE for LLM agents, compile-time-fixed tool registry, surface SHA-256 pinned. Server-sent `notifications/cluster-event` on both transports (task lifecycle + freeze/thaw events).
+- **MCP server** — stdio JSON-RPC + HTTP/SSE for LLM agents, compile-time-fixed tool registry, surface SHA-256 pinned. Server-sent `notifications/cluster-event` on both transports (task lifecycle + freeze/thaw events). **Security defaults:** destructive tools are fail-closed — refused unless a matching `[[policies]]` entry routes them through HITL approval — and `serve-http` binds loopback-only, refusing a non-loopback bind unless `mcp_token` is set.
 - **Verifiable releases** — every tarball ships with three layers: SHA-256 sidecar, sigstore keyless cosign signature pinned to this exact workflow path (offline-verifiable; transparency-log inclusion proof embedded), and a CycloneDX SBOM generated from `Cargo.lock`. Audit with `cosign verify-blob` + `grype` / `trivy`.
 
 ## EU & compliance
@@ -393,7 +393,8 @@ Pure Elm-pattern TUI over a typed REST client. The reducer is sync, total, and t
     [`01-feature-coverage.md`](pre-commit/01-feature-coverage.md) ·
     [`02-error-handling.md`](pre-commit/02-error-handling.md) ·
     [`03-security-invariants.md`](pre-commit/03-security-invariants.md) ·
-    [`04-resiliency-and-chaos.md`](pre-commit/04-resiliency-and-chaos.md)
+    [`04-resiliency-and-chaos.md`](pre-commit/04-resiliency-and-chaos.md) ·
+    [`ACCEPTED-RISKS.md`](pre-commit/ACCEPTED-RISKS.md) (AR-1..AR-6 residual risks)
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) — one-page module map + data flow + reducer/side-effect bus + process model.
 - [`THREAT_MODEL.md`](THREAT_MODEL.md) — attack surfaces, mitigations, accepted risks, verification ladder.
 - [`SECURITY.md`](SECURITY.md) — vulnerability reporting policy + scope + hardening snapshot.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -23,6 +23,8 @@ Plus the human-facing gates:
 | Pre-flight risk | 11 risk variants, per-op weighting, `--allow-risk` override |
 | HITL approval | Real Telegram round-trip, deny-on-timeout (120 s) |
 | MCP tool registry | Compile-time fixed enum, audit-checksummed |
+| MCP fail-closed | Destructive tool with no matching `[[policies]]` entry → typed refusal, never reaches PVE |
+| MCP HTTP bind | Non-loopback bind refused unless `mcp_token` is set (`--insecure-bind` to override) |
 
 ## Zeroizing&lt;String&gt; everywhere 
 
@@ -197,7 +199,8 @@ no silent bypass.
 pub static TOOL_REGISTRY: &[ToolDef] = &[
     ToolDef { name: "list_nodes", destructive: false, ... },
     ToolDef { name: "stop_guest", destructive: true,  ... },
-    /* … 10 entries total … */
+    ToolDef { name: "create_snapshot", destructive: true, ... },
+    /* … ~25 entries total (13 reads + 12 actions) … */
 ];
 ```
 
@@ -214,6 +217,31 @@ $ proxxx mcp tools --checksum
 
 Pin this in your supply-chain tracker. If it changes between builds,
 the tool surface changed.
+
+### Destructive tools are fail-closed
+
+A destructive MCP tool with **no** matching `[[policies]]` entry is
+**refused** — proxxx returns a typed `isError` envelope and the PVE
+gateway is never reached. The only way to run a destructive tool over
+MCP is a matching `[[policies]]` entry, which routes through the HITL
+approval gate above. There is no ungated inline path.
+
+The destructive set (all policy-gated / fail-closed): `stop_guest`,
+`restart_guest`, `delete_guest`, `delete_snapshot`, `migrate_guest`,
+`clone_guest`, `clone_with_cloudinit`, `create_guest`, and — new in
+v0.13.0 — `suspend_guest` and `create_snapshot`. Non-destructive tools
+stay inline: `start_guest`, `resume_guest`, and every `get_*` / `list_*`
+read.
+
+### HTTP transport bind gate
+
+`proxxx mcp serve-http` **refuses to start** on a non-loopback bind
+(e.g. `0.0.0.0`) unless `mcp_token` is set — pass `--insecure-bind` to
+override consciously. An empty or whitespace `mcp_token` counts as
+absent. The token is a profile config field (or the `--token` CLI flag);
+when the server is network-exposed and the token is absent, every
+request is denied (fail-closed), and this survives a `SIGHUP` that
+clears the token.
 
 ## Panic recovery (+ flight recorder)
 
@@ -274,6 +302,19 @@ surface, all with planned upstream-bumps tracked.
 - In CI on every push and PR
 - In CI nightly via cron (catches CVEs disclosed after last commit)
 
+## Audit-log key custody
+
+The audit log is HMAC-chained; the signing key can be relocated off the
+DB volume so a stolen database is not a stolen chain:
+
+- `PROXXX_AUDIT_KEY` relocates just the HMAC key (keep the key and the
+  DB on separate volumes).
+- `PROXXX_AUDIT_DIR` relocates both the DB and the key.
+- The audit directory is created `0700`.
+- A group- or world-readable `audit.key` is **refused on load** (unix) —
+  tighten the mode before proxxx will read it.
+- `proxxx audit verify` exits non-zero on tamper.
+
 ## What's still ❌
 
 The matrix at `pre-commit/03-security-invariants.md` lists 18
@@ -302,3 +343,4 @@ These are the next round's targets.
 - [HITL via Telegram](/integrations/hitl)
 - [MCP server](/integrations/mcp)
 - [Architecture overview](/architecture/overview)
+- Accepted residual risks: `pre-commit/ACCEPTED-RISKS.md` (AR-1..AR-6)

--- a/docs/guide/production-checklist.md
+++ b/docs/guide/production-checklist.md
@@ -344,6 +344,109 @@ proxxx ls nodes   # expect: HTTP 401 No ticket
 If it doesn't 401, the token wasn't actually scoped — re-issue
 with `--privsep=1` and grant the role to the **token** path.
 
+## 8. Harden the MCP server (if you expose proxxx over MCP)
+
+### `[ ]` Keep the transport on loopback, or set `mcp_token` before exposing it
+
+`proxxx mcp serve-http` **refuses to start** on a non-loopback bind
+(e.g. `0.0.0.0`) unless `mcp_token` is set:
+
+```bash
+# Local-only (default, safe): binds 127.0.0.1
+proxxx mcp serve-http
+
+# Network-exposed without a token → refused
+proxxx mcp serve-http --bind 0.0.0.0:8080
+# → error: refusing to bind a non-loopback address without a token.
+#    Set `mcp_token` (or pass --token), bind to 127.0.0.1, or pass
+#    --insecure-bind to override.
+```
+
+`mcp_token` is a profile config field (or the `--token` flag). An
+**empty or whitespace token counts as absent** — don't set it to `""`
+and think you're covered. When the server is network-exposed and the
+token is absent, every request is denied (fail-closed), and that denial
+**survives a `SIGHUP`** that clears the token from a live config.
+
+`--insecure-bind` overrides the refusal. **Never pass it on an untrusted
+network** — it exists for consciously-chosen trusted-segment cases only
+(see AR-3 in [ACCEPTED-RISKS.md](https://github.com/fabriziosalmi/proxxx/blob/main/pre-commit/ACCEPTED-RISKS.md)).
+
+### `[ ]` Gate every destructive MCP tool with a `[[policies]]` entry
+
+Over MCP, proxxx is **fail-closed**: a destructive tool with **no
+matching `[[policies]]` entry is refused** (a typed `isError` envelope —
+the PVE gateway is never reached). There is no ungated inline path. The
+only way to run a destructive tool over MCP is a matching policy that
+routes it to HITL approval.
+
+Destructive (policy-gated) tools: `stop_guest`, `restart_guest`,
+`suspend_guest`, `delete_guest`, `create_guest`, `clone_guest`,
+`clone_with_cloudinit`, `migrate_guest`, `create_snapshot`,
+`delete_snapshot`. Non-destructive tools stay inline: `start_guest`,
+`resume_guest`, and every `get_*` / `list_*` read.
+
+```toml
+# Without a matching policy, a destructive tool is simply unavailable
+# to the MCP client. Confirm your rules cover every destructive action
+# you intend a client to perform.
+[[policies]]
+when = { action = "delete" }
+require = "telegram"
+channel = "telegram"
+```
+
+## 9. Guard unmanned auto-converge (if you run `reconcile watch --auto-converge`)
+
+### `[ ]` Set a small `max_unmanned_changes` before enabling `converge_prune`
+
+`converge_prune = true` lets unmanned converge **delete** drifted
+resources — but it **holds all deletes** unless `max_unmanned_changes`
+(a per-tick change cap) is **also** set. With prune on and no cap, deletes
+are held and only create/update operations converge.
+
+```toml
+[reconcile]
+auto_converge = true
+converge_prune = true
+max_unmanned_changes = 3       # keep this single-digit
+allowed_families = ["lxc"]     # whitelist which families converge unmanned
+```
+
+Size the cap **small — single digits**. A large cap (e.g. `49`)
+re-opens the 10–49 unmanned-delete band, which is exactly the blast
+radius the cap exists to close (see AR-4). Use `allowed_families` to
+whitelist which resource families are allowed to converge without a human.
+
+## 10. Protect the audit chain
+
+### `[ ]` Keep `audit.key` at 0600, and consider a separate volume
+
+The audit log is HMAC-signed. proxxx creates the audit dir `0700` and
+**refuses to load a group- or world-readable `audit.key`** (Unix), so
+keep it owner-only:
+
+```bash
+chmod 600 <audit-dir>/audit.key
+ls -l <audit-dir>/audit.key    # → -rw------- (0600)
+```
+
+To keep the signing key off the same volume as the database it signs,
+point `PROXXX_AUDIT_KEY` at a separate volume — a same-user/root attacker
+who can rewrite the DB then can't silently re-sign it (AR-5).
+`PROXXX_AUDIT_DIR` relocates the DB **and** key together if you'd rather
+move the whole directory.
+
+### `[ ]` Run `audit verify` from a separate trust context
+
+```bash
+proxxx audit verify        # exits non-zero if the chain has been tampered with
+```
+
+Run this from a host or account that **can't write** the audit DB — a
+verifier that shares the operator's write access can't prove much. Wire
+the non-zero exit into your monitoring.
+
 ## See also
 
 - [Configuration schema](/reference/configuration) — every TOML
@@ -352,6 +455,9 @@ with `--privsep=1` and grant the role to the **token** path.
   invariants.
 - [Pre-commit gate](/guide/pre-commit-gate) — what every release
   passes before tagging.
+- [`ACCEPTED-RISKS.md`](https://github.com/fabriziosalmi/proxxx/blob/main/pre-commit/ACCEPTED-RISKS.md)
+  — residual risks (AR-1…AR-6) knowingly accepted for this release,
+  with the guardrails above cross-referenced.
 - [Troubleshooting](/guide/troubleshooting) — error message → fix
   index.
 - [`SECURITY.md`](https://github.com/fabriziosalmi/proxxx/blob/main/SECURITY.md)

--- a/docs/guide/quickstart-llm-mcp.md
+++ b/docs/guide/quickstart-llm-mcp.md
@@ -33,15 +33,15 @@ proxxx mcp tools
 ```
 
 Returns the full registry as JSON: 25 tools across five clusters —
-inventory (`list_nodes`, `list_guests`, `get_guest_status`,
+inventory / reads (`list_nodes`, `list_guests`, `get_guest_status`,
 `get_storage_pools`, `get_node_resources`, `list_snapshots`,
-`get_task_log`), lifecycle (`start_guest`, `stop_guest`,
+`get_task_log`, `get_cluster_status`, `get_node_status`,
+`get_replication_status`, `list_tasks`, `list_backup_jobs`,
+`list_cluster_events`), lifecycle (`start_guest`, `stop_guest`,
 `restart_guest`, `suspend_guest`, `resume_guest`, `delete_guest`),
-snapshots (`create_snapshot`, `delete_snapshot`,
-`rollback_snapshot`), provisioning (`clone_guest`, `create_guest`,
-`mark_template`), backup (`backup_guest`, `restore_guest`),
-storage / migration (`move_disk`, `migrate_guest`,
-`resize_disk`, `attach_iso`). Each with parameters, descriptions,
+snapshots (`create_snapshot`, `delete_snapshot`), provisioning
+(`clone_guest`, `clone_with_cloudinit`, `create_guest`), and
+migration (`migrate_guest`). Each with parameters, descriptions,
 destructive flag, and per-tool execution timeout.
 
 For supply-chain pinning:
@@ -55,10 +55,14 @@ Pin this hash in your CI / agent config. If the deployed binary's
 registry hash drifts, the tool surface changed — review the
 diff before unpinning.
 
-## 3. Configure HITL on destructive tools (recommended)
+## 3. Configure HITL on destructive tools (required)
 
-Without HITL, the agent can `delete_guest` autonomously. With it,
-every destructive call routes through Telegram approval:
+Destructive tools are **fail-closed**: a destructive call with no
+matching `[[policies]]` entry is **refused** before it ever reaches
+the PVE gateway — the agent gets a typed `isError` envelope, not an
+autonomous `delete_guest`. There is no ungated inline path. The
+*only* way to run a destructive tool over MCP is a matching
+`[[policies]]` entry that routes it through HITL approval:
 
 ```toml
 # config.toml
@@ -81,6 +85,13 @@ The 120 s deny-on-timeout is hardcoded — if you don't approve,
 the op is rejected (NOT auto-approved). Replay protection is
 session-local: a stale callback from yesterday's chat history
 won't re-fire.
+
+The tools flagged destructive — and therefore refused without a
+matching policy — are `stop_guest`, `restart_guest`, `suspend_guest`,
+`delete_guest`, `create_snapshot`, `delete_snapshot`, `clone_guest`,
+`clone_with_cloudinit`, `create_guest`, and `migrate_guest`.
+Everything else — `start_guest`, `resume_guest`, and every
+`get_*` / `list_*` read — runs inline, no approval required.
 
 Test the round-trip:
 
@@ -131,11 +142,22 @@ docs for the exact location.
 
 - **Two transports at parity** — `proxxx mcp serve` (stdio
   JSON-RPC, agent runs as subprocess, no port) or
-  `proxxx mcp serve-http --bind 127.0.0.1:8765` (Streamable
-  HTTP/SSE per MCP 2025-03-26). Same tool registry, same HITL,
-  same audit. HTTP is for hosted agents that can't spawn
+  `proxxx mcp serve-http` (Streamable HTTP/SSE per MCP 2025-03-26;
+  defaults to `--bind 127.0.0.1 --port 3000`). Same tool registry,
+  same HITL, same audit. HTTP is for hosted agents that can't spawn
   subprocesses; stdio for local agents (Claude Desktop, Cursor).
   Pick one per deployment.
+
+- **serve-http is fail-closed on the network** — on a non-loopback
+  bind (e.g. `--bind 0.0.0.0`) the server **refuses to start** unless
+  `mcp_token` is set. Configure it in the profile (`mcp_token = "…"`)
+  or pass `--token`; every `POST /mcp` and `GET /mcp` then demands a
+  matching `Authorization: Bearer` header. An empty / whitespace token
+  counts as absent — so a SIGHUP that clears `mcp_token` leaves the
+  exposed server denying every request instead of silently opening
+  up. To expose a public interface *without* a token (trusted network
+  or an auth-enforcing reverse proxy only) you must consciously pass
+  `--insecure-bind`. Loopback binds need no token.
 
 - **Server-sent notifications** — both transports stream
   `notifications/cluster-event` for `task_state_change`

--- a/docs/integrations/hitl.md
+++ b/docs/integrations/hitl.md
@@ -83,7 +83,7 @@ TUI / CLI / MCP  ──→  enforce_preflight  ──→  check_hitl
                                        no    yes
                                        │     │
                                        ▼     ▼
-                                   execute   HitlCoordinator.register(txn_id)
+                                  execute*   HitlCoordinator.register(txn_id)
                                                                       │
                                                                       ▼
                                                 Telegram::request_approval(...)
@@ -98,6 +98,12 @@ TUI / CLI / MCP  ──→  enforce_preflight  ──→  check_hitl
                                                                           ▼
                                                        execute  OR  refuse
 ```
+
+> `*` **MCP diverges here — fail-closed.** On the MCP transport a *destructive*
+> tool with **no matching policy is REFUSED**, not executed: the transport is
+> network-reachable, so an unauthenticated caller must never reach a destructive
+> op. TUI / CLI keep the present-operator behaviour above (no policy → execute)
+> because a human is already at the keyboard. (v0.13.0)
 
 Internals:
 

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -27,13 +27,13 @@ table from your binary with `proxxx mcp tools --json`:
 | `stop_guest` | **yes** | 60 s | Graceful or hard stop |
 | `restart_guest` | **yes** | 60 s | Restart |
 | `delete_guest` | **yes** | 180 s | Permanent delete (cannot be undone) |
-| `suspend_guest` | no | 60 s | Pause a running guest |
+| `suspend_guest` | **yes** | 60 s | Pause a running guest |
 | `resume_guest` | no | 60 s | Resume a suspended guest |
 | `clone_guest` | **yes** | 180 s | Clone a VM/LXC to a new VMID |
 | `clone_with_cloudinit` | **yes** | 300 s | Clone QEMU template + apply cloud-init (user, sshkey, ipconfig0) in one call |
 | `migrate_guest` | **yes** | 300 s | Live-migrate to another node |
 | `create_guest` | **yes** | 120 s | Create new QEMU VM or LXC (node, type, name, memory, cores, disk, …) |
-| `create_snapshot` | no | 120 s | Create snapshot |
+| `create_snapshot` | **yes** | 120 s | Create snapshot |
 | `list_snapshots` | no | 30 s | List snapshots for a guest |
 | `delete_snapshot` | **yes** | 120 s | Delete snapshot |
 | `get_storage_pools` | no | 30 s | Per-node storage list with usage |
@@ -82,6 +82,26 @@ proxxx mcp serve
 Stdio transport. Speaks JSON-RPC 2.0 framed by Content-Length
 headers — the standard MCP envelope. Pipe-it under whatever client
 your agent uses.
+
+### HTTP transport and `mcp_token`
+
+For clients that speak MCP over HTTP:
+
+```sh
+proxxx mcp serve-http
+```
+
+Because an HTTP listener is reachable off the box, it is
+**fail-closed on authentication**. `serve-http` **refuses to start**
+on a non-loopback bind (e.g. `0.0.0.0`) unless an `mcp_token` is set —
+pass `--insecure-bind` to override that consciously.
+
+Set the token as the `mcp_token` profile config field or with the
+`--token` CLI flag. An empty or whitespace-only token counts as
+**absent**. When the server is network-exposed and the token is
+absent, every request is denied — and this fail-closed state survives
+a `SIGHUP` that clears the token, so a reload cannot silently drop
+authentication.
 
 ## Claude Desktop config
 
@@ -152,22 +172,40 @@ invariant so the budget cannot drift below 120 s by accident.
 
 ## HITL on MCP destructive calls
 
-`stop_guest`, `restart_guest`, `delete_guest`, `delete_snapshot`
-route through `enforce_preflight` and `check_hitl` exactly like CLI
-calls. If `[[policies]]` matches, the agent's request is queued and
-a human approval is required before execution.
+The destructive tool set is **fail-closed** over MCP:
 
-The agent sees a `pending_hitl` response and can poll for completion
-via `get_guest_status` or wait. The exact wait-protocol is documented
-in the MCP spec — proxxx returns a transient error code that
+- `stop_guest`, `restart_guest`, `delete_guest`, `delete_snapshot`,
+  `migrate_guest`, `clone_guest`, `clone_with_cloudinit`, `create_guest`,
+  and — new in v0.13.0 — `suspend_guest` and `create_snapshot`.
+
+A destructive tool call with **no matching `[[policies]]` entry is
+REFUSED**. proxxx returns a typed `isError` envelope and the PVE
+gateway is never reached — nothing is queued, nothing executes. There
+is no ungated inline path for a destructive tool.
+
+The **only** way to run a destructive tool over MCP is a matching
+`[[policies]]` entry, which routes the call through `enforce_preflight`
+and `check_hitl` exactly like CLI calls and requires a human approval
+before execution. When a policy matches, the agent sees a
+`pending_hitl` response and can poll for completion via
+`get_guest_status` or wait — proxxx returns a transient error code
 clients are expected to retry on.
 
-## Why no `migrate` or `move_disk` in the MCP surface
+Non-destructive tools (`start_guest`, `resume_guest`, and the
+`get_*` / `list_*` reads) still run inline without a policy.
 
-These are higher-risk: a misplanned migration can leave a guest in a
-half-migrated state on the target node. They are deliberately not
-exposed via MCP. An agent that needs to migrate proxes through a
-human-driven CLI invocation.
+## Why no `move_disk` in the MCP surface
+
+`migrate_guest` **is** in the registry — it is exposed as a
+destructive, policy-gated tool (see the table and the fail-closed
+rules above), so an agent can only trigger it through a matching
+`[[policies]]` entry and a human approval.
+
+`move_disk` is a different story: it is deliberately **not** exposed
+via MCP. A misplanned disk move can leave a guest straddling two
+storages, and the operation has no clean partial-failure recovery. An
+agent that needs to move a disk proxes through a human-driven CLI
+invocation.
 
 ## Vector framework
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -176,7 +176,7 @@ within a major version.
 | :--- | :--- |
 | `proxxx daemon serve [--no-alerts] [--no-hitl] [--no-schedule] [--schedule-interval-secs N] [--alerts-interval-secs N]` | Unified background-task graph — alerts watcher + HITL Telegram listener + schedule run-due tick under one process with one SIGTERM. Each opt-out individually. |
 | `proxxx mcp serve`                  | Stdio JSON-RPC MCP server for LLM agents — interleaves server-sent `notifications/cluster-event` with the request/response stream. |
-| `proxxx mcp serve-http --bind 0.0.0.0:PORT` | Streamable HTTP MCP transport (spec 2025-03-26). SSE channel at `GET /mcp` emits the same notifications. |
+| `proxxx mcp serve-http --bind 127.0.0.1:PORT [--token T] [--insecure-bind]` | Streamable HTTP MCP transport (spec 2025-03-26). SSE channel at `GET /mcp` emits the same notifications. **Refuses to start on a non-loopback bind (e.g. `0.0.0.0:PORT`) unless `mcp_token` is set** — supply it via `--token T` (or the `mcp_token` profile field) or pass `--insecure-bind` to override consciously. An empty/whitespace token counts as absent. When the server is network-exposed and the token is absent, every request is denied (fail-closed). |
 | `proxxx mcp tools [--checksum]`     | Introspect the tool registry; `--checksum` prints SHA-256 |
 | `proxxx hitl serve`                 | Long-poll Telegram for HITL approval callbacks (also available under `proxxx daemon serve`). |
 | `proxxx alerts watch [--interval N]`| Rule-driven alerting daemon (also available under `proxxx daemon serve`). |
@@ -297,7 +297,7 @@ at `<data_dir>/freeze.lock` (global) and `<data_dir>/freeze.<profile>.lock`.
 | :--- | :--- |
 | `proxxx audit log [--limit N] [--since T]`        | Show recent audit entries (SQLite, append-only) |
 | `proxxx audit export --format {json\|csv}`        | Dump entries for SIEM ingestion |
-| `proxxx audit verify`                             | Walk the full HMAC-SHA256 chain — NIS2/ISO 27001 evidence |
+| `proxxx audit verify`                             | Walk the full HMAC-SHA256 chain — NIS2/ISO 27001 evidence. Exits non-zero on tamper |
 
 ## Guest lifecycle (additional)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -37,6 +37,16 @@ read_only     = false                 # true → refuse all mutations on this
                                       # profile client-side (reads still work);
                                       # exit code 8. Default false. Pair with a
                                       # PVEAuditor PVE token for server-side lock.
+mcp_token     = "..."                 # bearer token for `proxxx mcp serve-http`.
+                                      # Optional; an empty/whitespace value counts as
+                                      # ABSENT. serve-http binds loopback by default; on
+                                      # a non-loopback bind (e.g. 0.0.0.0) it REFUSES to
+                                      # start unless this is set — override consciously
+                                      # with --insecure-bind, in which case a network-
+                                      # exposed server with no token denies every request
+                                      # (fail-closed, and this survives a SIGHUP that
+                                      # clears the token). The --token CLI flag overrides
+                                      # this field.
 ```
 
 ## `[profiles.<name>.reconcile]` (GitOps controller)
@@ -60,10 +70,13 @@ auto_converge  = false                # true → after detecting drift each tick
                                       # freeze (skips quietly, no alert storm). Disable
                                       # per-process with the `--no-converge` flag or the
                                       # PROXXX_NO_CONVERGE env var.
-converge_prune = false                # true → auto-converge also executes deletes (maps to
-                                      # `state apply --prune`). Default false: deletes are
-                                      # previewed but held. Enable only against a repo with
-                                      # branch protection / atomic pushes.
+converge_prune = false                # true → auto-converge MAY execute deletes (maps to
+                                      # `state apply --prune`) — but ONLY when
+                                      # `max_unmanned_changes` is also set. converge_prune=true
+                                      # on its own HOLDS every unmanned delete: creates/updates
+                                      # converge while deletes stay previewed-but-held. Default
+                                      # false: deletes are previewed and held. Enable only
+                                      # against a repo with branch protection / atomic pushes.
 
 # ── Unmanned-converge guardrails (both narrow the blast radius; default = none) ──
 allowed_families = ["pool", "acl"]    # restrict the UNMANNED converge to these state
@@ -74,13 +87,17 @@ allowed_families = ["pool", "acl"]    # restrict the UNMANNED converge to these 
                                       # you auto-converge low-stakes families while keeping
                                       # high-stakes ones human-only. The manual
                                       # `reconcile converge` command is NOT restricted.
-max_unmanned_changes = 20             # hard cap on changes-per-tick for the UNMANNED path,
+max_unmanned_changes = 5              # hard cap on changes-per-tick for the UNMANNED path,
                                       # counted AFTER allowed_families filtering, regardless
                                       # of severity. Absent = no cap. Above it → the daemon
                                       # refuses and alerts "needs human review (too many
                                       # changes)". Catches a Warning-tier flood (e.g. a
                                       # partial git revert) that the Severe bulk-change
-                                      # circuit-breaker (≥50) would miss.
+                                      # circuit-breaker (≥50) would miss. ALSO the gate that
+                                      # unlocks unmanned prune: converge_prune only deletes
+                                      # while this cap is set. Size it SMALL (single digits) —
+                                      # a large cap (e.g. 49) re-opens the 10–49
+                                      # unmanned-delete band.
 ```
 
 ## `[ssh]` (top-level default)
@@ -199,6 +216,17 @@ For each of `token_secret`, `password`, `pbs.token_secret`:
 
 The first one that resolves wins. Loaded values live in
 `Zeroizing<String>` and are wiped from the heap on Drop.
+
+## Environment variables
+
+Beyond the secret env vars above and `PROXXX_CONFIG` (see [File
+location](#file-location)), these tune runtime behaviour:
+
+| Variable | Effect |
+| :--- | :--- |
+| `PROXXX_NO_CONVERGE` | Disable auto-converge for this process (same as `--no-converge`): the drift-watch still detects and alerts, but mutates nothing. |
+| `PROXXX_AUDIT_DIR` | Relocate the audit DB **and** its HMAC key off the default path (e.g. onto a separate volume). The directory is created `0700`. |
+| `PROXXX_AUDIT_KEY` | Relocate only the HMAC key, off the DB volume. A group/world-readable `audit.key` is refused on load (unix); `proxxx audit verify` exits non-zero on tamper. |
 
 ## Defaults summary
 


### PR DESCRIPTION
Phase 5 of the diamond plan. The v0.13.0 fail-closed defaults made several docs factually wrong (the `--bind 0.0.0.0` example now refuses to start; the LLM quickstart said the agent "can delete_guest autonomously"). This sweeps 8 files + writes the CHANGELOG.

Docs were fixed in parallel (one editor per file) against an authoritative v0.13.0 fact sheet, then reviewed. No invented tool names; markdown fences balanced.

- **CHANGELOG** — v0.13.0 with a ⚠️ Breaking (behavioural) block + migration lines (covers #192–#196).
- **integrations/mcp.md** — destructive-with-no-policy → REFUSED; `suspend_guest`/`create_snapshot` now destructive; `mcp_token` + loopback/`--insecure-bind`.
- **guide/quickstart-llm-mcp.md** — HITL "(recommended)" → "(required)"; the "delete autonomously" line corrected; real tool list.
- **reference/configuration.md** — `converge_prune` holds deletes without a cap; small `max_unmanned_changes`; `mcp_token`; `PROXXX_AUDIT_KEY`/`DIR`.
- **reference/cli.md** — `serve-http --bind` example fixed.
- **integrations/hitl.md** — flow diagram branches the MCP path (no policy → REFUSE).
- **guide/production-checklist.md** — MCP exposure, converge cap, audit-key custody + ACCEPTED-RISKS pointer.
- **architecture/security.md** — registry count 10 → ~25; fail-closed row; audit custody.
- **README** — MCP "Security defaults" callout + ACCEPTED-RISKS link.

