### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"


### PR DESCRIPTION
Version bump 0.12.0 → 0.13.0. Release-prep for the fail-closed-hardening release.

Merges alongside the CHANGELOG + docs (#197). Once both are on `main`, tagging `v0.13.0` triggers `release.yml` (aarch64-darwin + x86_64/aarch64 linux-musl builds, cosign signing, CycloneDX SBOM, GitHub release, Homebrew tap auto-bump).

Ships in v0.13.0: #192 (MCP fail-closed + converge blast radius + audit key custody) · #193 (op-queue write-ahead) · #194 (adversarial-review rigor follow-ups) · #195 (RSA SSH + 401 fixes) · #196 (CI Token-Permissions + concurrency) · #197 (docs + CHANGELOG).

