### PR TITLE
harden: close the 4 yellow security doubts (console ticket, cache, keychain, export)

### DIFF
--- a/pre-commit/ACCEPTED-RISKS.md
+++ b/pre-commit/ACCEPTED-RISKS.md
@@ -197,3 +197,70 @@ queue. Fail-safe direction: the code errs toward NOT re-dispatching (a stuck
   the palette.
 
 *Accepted by Fabrizio Salmi — 2026-07-05.*
+
+---
+
+## AR-7 · Console session tickets are emitted by design on the explicit CLI paths
+
+**Context:** [wsterm/url.rs](../src/wsterm/url.rs), [cli/console.rs](../src/cli/console.rs), [cli/node.rs](../src/cli/node.rs)
+
+The Proxmox `vncticket` is a short-lived console credential. Two kinds of exposure existed:
+
+- **Unintentional (FIXED):** the WS connect URL — which carries `?vncticket=…` — was logged at INFO and in connect-error messages on every console attach. That leak is closed: `wsterm::url::redact_ticket` replaces the ticket value with `[REDACTED]` at every log/error site (`wsterm/mod.rs`), keeping host/path/port for diagnostics.
+- **Intentional (accepted):** `proxxx vnc <vmid> --ws-url` and the ticket JSON output deliberately print the full ticket / WS URL to stdout — that IS the feature (hand the URL to a browser noVNC client or an external tool). Redacting it would defeat the purpose.
+
+**Why not closed in code:** the emitting commands exist to *export* the ticket for immediate use; a redacted ticket is useless to the caller.
+
+**Operator's responsibility:** treat `--ws-url` / ticket output like a password on the command line — don't pipe it into a log, a shared terminal recording, or shell history you keep. The ticket's short TTL (seconds–minutes) is the backstop: connect immediately, and a captured ticket is dead soon after.
+
+*Accepted by Fabrizio Salmi — 2026-07-06.*
+
+---
+
+## AR-8 · Cache-at-rest is owner-protected, not encrypted
+
+**Context:** [app/cache.rs](../src/app/cache.rs)
+
+The per-profile SQLite cache holds a cluster-topology snapshot (nodes / guests / storage) plus the operation queue (vmids, nodes, disk/storage targets) — not credentials (secrets never reach the cache schema; see the "exec output not cached" invariant). On unix it is now created owner-only: the parent dir `0700`, and the `{profile}_state.db` **plus its `-wal` / `-shm` sidecars** `0600` (fresh sidecars inherit the db's mode; the explicit tighten also retightens a legacy `0644` `-wal` left by a pre-hardening unclean shutdown). The file tighten is **best-effort / fail-open** — a `stat`/`chmod` error is ignored so the cache still opens (unlike the audit key, which fails *closed*: topology is not a forgery key).
+
+**Why not closed further in code:** `create_dir_all` no-ops on a pre-existing directory and does not tighten its mode, so a dir the operator created lax stays lax; and proxxx does not encrypt the cache at rest — topology is low-sensitivity and encryption would need a key-management story the tool doesn't own. The `0700` **directory** is the real guard: a different user can't enter it to read the db or its sidecars regardless of file modes, which also bounds the brief create-then-chmod TOCTOU window on the main db.
+
+**Operator's responsibility:** on a multi-tenant host, ensure the data dir isn't group/world-writable (proxxx creates it `0700`, but a pre-existing one is yours); if the topology snapshot is sensitive in your environment, place the data dir on an encrypted volume.
+
+*Accepted by Fabrizio Salmi — 2026-07-06.*
+
+---
+
+## AR-9 · Keychain per-profile isolation is opt-in (and stored manually); a flat entry stays shared
+
+**Context:** [config/mod.rs](../src/config/mod.rs) — `keyring_candidates` / `keyring_get_scoped`
+
+The OS-keychain lookup for the primary cluster credentials (`token_secret`, `password`) now tries the profile-scoped item `<profile>/<item>` **first**, then the flat `<item>`. So per-profile isolation is *available* — but honestly scoped:
+
+- **It is opt-in.** You get isolation only by *storing* the secret under the profile-scoped item name. proxxx has **no keychain-write command** — the entry is created by hand (see below).
+- **A flat entry stays shared.** A named profile with no per-profile entry falls back to the flat `<item>`, so an un-migrated flat key has the same cross-cluster sharing as before. This fallback is deliberate back-compat.
+- **Telegram bot-token + PBS token stay flat** (resolved on `TelegramConfig` / `PbsConfig`, which don't carry the profile name; typically one shared bot / one PBS).
+
+**Why not closed further in code:** removing the flat fallback (fail-closed per profile) would break every existing keychain deployment overnight — their named profiles would suddenly stop resolving. The scoped-first-then-flat order is the standard non-breaking migration.
+
+**Operator's responsibility:**
+- To isolate a profile's cluster credential in the keychain, store it under the scoped item. macOS: `security add-generic-password -s proxxx -a "prod/token_secret" -w "<secret>"`. Linux (Secret Service): store an entry with service `proxxx`, account `prod/token_secret`. That profile then resolves its own entry; the flat fallback fires only if the scoped one is absent.
+- If you won't manage per-profile keychain entries (or need per-profile Telegram/PBS secrets), prefer per-profile `token_secret_file` / `bot_token_file` (0600) or the `PROXXX_*` env vars — those already resolve unambiguously per profile.
+
+*Accepted by Fabrizio Salmi — 2026-07-06.*
+
+---
+
+## AR-10 · State export carries no *modelled* secret — but free-text fields pass through verbatim
+
+**Context:** [state/model.rs](../src/state/model.rs), [state/export.rs](../src/state/export.rs), GitHub issue #178
+
+`proxxx state export` emits pools / ACLs / storage / backup-jobs / firewall / mappings / HA. **No `Decl` struct has a secret field** — each exporter copies a fixed *whitelist* of named fields (there is no `#[serde(flatten)]` of a raw API response), and the real secrets (`ApiToken.value`; storage credentials PVE masks on `GET`) are never on the export path. The field-whitelist is the safety mechanism (not, as an earlier wording implied, PVE's masking — that's incidental). Notification *targets* (gotify tokens / SMTP passwords) are **deliberately not modelled** — PVE never returns them on `GET`, so they can't round-trip.
+
+**Residual — free-text passthrough:** ~10 free-text fields (`comment`, `description`, `notes_template`) are exported *verbatim*, unredacted. An operator who embeds a secret in a comment (e.g. a gotify/webhook URL with an inline bearer token in a storage `comment` or a notification `notes_template`) will export it in cleartext. proxxx does not scan free text for secrets. So export is secret-free by *structure*, not by *guarantee* against operator-embedded secrets.
+
+**Why this is an accepted risk and not a fix:** there is nothing to elide today — the risk is *future*. The moment a secret-bearing state family is added (issue #180 users/tokens, #181 metric-servers with API keys), naive export would write secrets to disk / git.
+
+**Gate (the operator/maintainer contract):** issue #178 (secret-ref / elide-on-export convention) is the **mandatory prerequisite** before merging ANY secret-bearing state family. #178 stays frozen until that demand appears — but it must land *first*, not alongside. This entry is the tripwire.
+
+*Accepted by Fabrizio Salmi — 2026-07-06.*

--- a/src/app/cache.rs
+++ b/src/app/cache.rs
@@ -48,14 +48,64 @@ fn open_db(path: &Path) -> anyhow::Result<Connection> {
     // Without this, SQLite returns error code 14 ("unable to open database file")
     // with no indication of the real cause (missing directory vs permissions).
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| {
-            anyhow::anyhow!(
-                "cannot create cache directory {}: {e} — check permissions",
-                parent.display()
-            )
-        })?;
+        // Custody: the cache holds a cluster-topology snapshot + the op_queue.
+        // Create the dir 0700 (unix) so it isn't group/world-readable on a
+        // multi-user host. `create_dir_all` no-ops on an existing dir and does
+        // NOT tighten its mode — an operator who pre-created a lax dir owns that
+        // (see ACCEPTED-RISKS AR-8). The 0700 dir is the real guard: it blocks a
+        // different user from reading the db OR its WAL sidecars regardless of
+        // their own file modes.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            std::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(parent)
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "cannot create cache directory {}: {e} — check permissions",
+                        parent.display()
+                    )
+                })?;
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                anyhow::anyhow!(
+                    "cannot create cache directory {}: {e} — check permissions",
+                    parent.display()
+                )
+            })?;
+        }
     }
     let conn = Connection::open(path)?;
+    // Tighten the DB file — and its WAL/SHM sidecars — to owner-only (0600).
+    // A fresh SQLite file is created with the process umask (~0644); fresh
+    // sidecars inherit the main db's mode, but a legacy 0644 `-wal` left by a
+    // pre-hardening unclean shutdown would otherwise keep receiving topology +
+    // op_queue writes group/world-readable, so tighten them explicitly too.
+    // Best-effort: a perms error must not fail the cache open. (The 0700 parent
+    // dir is the real guard; this is belt-and-suspenders on the files.)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let tighten = |p: &std::path::Path| {
+            if let Ok(meta) = std::fs::metadata(p) {
+                let mut perms = meta.permissions();
+                if perms.mode() & 0o077 != 0 {
+                    perms.set_mode(0o600);
+                    let _ = std::fs::set_permissions(p, perms);
+                }
+            }
+        };
+        tighten(path);
+        for suffix in ["-wal", "-shm"] {
+            let mut side = path.as_os_str().to_owned();
+            side.push(suffix);
+            tighten(std::path::Path::new(&side));
+        }
+    }
 
     // — `auto_vacuum` is sticky: persisted in the DB header,
     // applied at table-creation time, never changeable afterwards.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -276,6 +276,50 @@ async fn keyring_get(
     .map_err(|e| anyhow::anyhow!("keychain spawn_blocking join error: {e}"))?
 }
 
+/// Ordered keychain item names to try for a secret: the per-profile item
+/// `<profile>/<item>` first, then the flat `<item>` as a back-compat fallback.
+///
+/// Two keychain-backed profiles used to collide on the same flat key (both read
+/// `proxxx/token_secret`), so profile B silently resolved profile A's cluster
+/// credential — a cross-cluster isolation gap. Namespacing per profile closes
+/// it; the flat fallback keeps keys stored before this change working. Pure so
+/// the ordering is unit-tested without touching the OS keychain.
+#[must_use]
+fn keyring_candidates(item: &str, profile: Option<&str>) -> Vec<String> {
+    let mut names = Vec::with_capacity(2);
+    if let Some(p) = profile {
+        names.push(format!("{p}/{item}"));
+    }
+    names.push(item.to_string());
+    names
+}
+
+/// Resolve a keychain secret, per-profile-first with a flat fallback (see
+/// [`keyring_candidates`]). The primary cluster credentials (`token_secret`,
+/// `password`) route through here; the shared/secondary bot-token + PBS-token
+/// keychain entries stay flat by design (see ACCEPTED-RISKS AR-8).
+#[cfg(feature = "keychain")]
+async fn keyring_get_scoped(
+    item: &str,
+    profile: Option<&str>,
+) -> anyhow::Result<zeroize::Zeroizing<String>> {
+    let candidates = keyring_candidates(item, profile);
+    tokio::task::spawn_blocking(move || -> anyhow::Result<zeroize::Zeroizing<String>> {
+        let mut last: Option<keyring::Error> = None;
+        for name in &candidates {
+            match keyring::Entry::new("proxxx", name).and_then(|e| e.get_password()) {
+                Ok(v) => return Ok(zeroize::Zeroizing::new(v)),
+                Err(e) => last = Some(e),
+            }
+        }
+        Err(anyhow::anyhow!(
+            "keychain: no entry among {candidates:?}: {last:?}"
+        ))
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("keychain spawn_blocking join error: {e}"))?
+}
+
 /// .10 (audit) — bounded env var read for secrets.
 ///
 /// `std::env::var(name)` returns the entire value as a `String` with
@@ -780,7 +824,8 @@ impl ProfileConfig {
         // call wrapped in spawn_blocking via `keyring_get`.
         #[cfg(feature = "keychain")]
         {
-            if let Ok(val) = keyring_get("proxxx", "token_secret").await {
+            if let Ok(val) = keyring_get_scoped("token_secret", self.profile_name.as_deref()).await
+            {
                 return Ok(val);
             }
         }
@@ -815,7 +860,7 @@ impl ProfileConfig {
 
         #[cfg(feature = "keychain")]
         {
-            if let Ok(val) = keyring_get("proxxx", "password").await {
+            if let Ok(val) = keyring_get_scoped("password", self.profile_name.as_deref()).await {
                 return Ok(val);
             }
         }
@@ -1211,6 +1256,21 @@ mod reconcile_config_tests {
         let rec = cfg.reconcile.unwrap();
         assert!(rec.auto_converge);
         assert!(rec.converge_prune);
+    }
+
+    #[test]
+    fn keyring_candidates_are_profile_first_then_flat() {
+        // A named profile tries `<profile>/<item>` first, then the flat item
+        // (back-compat) — so two keychain-backed profiles no longer collide.
+        assert_eq!(
+            keyring_candidates("token_secret", Some("prod")),
+            vec!["prod/token_secret".to_string(), "token_secret".to_string()],
+        );
+        // No profile (flat/default config) → only the flat key, unchanged.
+        assert_eq!(
+            keyring_candidates("password", None),
+            vec!["password".to_string()],
+        );
     }
 }
 

--- a/src/util/panic_hook.rs
+++ b/src/util/panic_hook.rs
@@ -184,6 +184,10 @@ const KEY_VALUE_MARKERS: &[&str] = &[
     "password=",
     "token_secret=",
     "csrfpreventiontoken=",
+    // Console session credential — if a panic in the wsterm/console path
+    // embeds the WS URL (`?…&vncticket=…`), scrub it here too, so the
+    // defense-in-depth net covers it, not just the 3 hand-redacted log sites.
+    "vncticket=",
 ];
 
 /// `Authorization` style headers use a multi-char separator.

--- a/src/wsterm/mod.rs
+++ b/src/wsterm/mod.rs
@@ -91,7 +91,7 @@ pub async fn connect(
     ws_config.max_frame_size = Some(1 << 20);
     ws_config.max_message_size = Some(4 << 20);
 
-    info!("termproxy WSS connect: {}", target.url);
+    info!("termproxy WSS connect: {}", url::redact_ticket(&target.url));
     // Bound the connect (TCP + TLS + WS handshake). Without this an
     // unreachable / black-holed node leaves the call hanging until the
     // OS TCP timeout (minutes) — and the terminal is already half
@@ -113,10 +113,10 @@ pub async fn connect(
     .map_err(|_| {
         anyhow::anyhow!(
             "WS connect to {} timed out after {WS_CONNECT_TIMEOUT:?} — node unreachable?",
-            target.url
+            url::redact_ticket(&target.url)
         )
     })?
-    .with_context(|| format!("WS connect to {}", target.url))?;
+    .with_context(|| format!("WS connect to {}", url::redact_ticket(&target.url)))?;
 
     // Auth frame — must be a binary frame containing `<user>:<ticket>\n`.
     use futures_util::SinkExt;

--- a/src/wsterm/url.rs
+++ b/src/wsterm/url.rs
@@ -7,7 +7,7 @@
 use crate::api::types::GuestType;
 
 /// Result of building the WebSocket URL + auth payload.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct WsTarget {
     /// Full `wss://...` URL ready for `connect_async`.
     pub url: String,
@@ -15,6 +15,19 @@ pub struct WsTarget {
     /// (`<user>:<ticket>\n`). Must be a binary frame; the trailing
     /// newline is required by the Proxmox protocol.
     pub auth: String,
+}
+
+// Hand-written Debug so the ticket can NEVER reach a log via `{:?}` — both
+// fields carry the credential (url has `?…&vncticket=…`, auth is
+// `user:ticket`). Redaction is thus a property of the type, not just the
+// three hand-patched log sites in `mod.rs`.
+impl std::fmt::Debug for WsTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WsTarget")
+            .field("url", &redact_ticket(&self.url))
+            .field("auth", &"<user>:[REDACTED]")
+            .finish()
+    }
 }
 
 /// Build the WebSocket target from the REST base URL + termproxy reply.
@@ -53,6 +66,30 @@ pub fn build_ws_target(
     );
     let auth = format!("{user}:{ticket}\n");
     WsTarget { url, auth }
+}
+
+/// Redact the `vncticket` value from a WS URL before it reaches a log line or
+/// an error message. The ticket is a short-lived credential; in cleartext logs
+/// it lets anyone who can read the log (or a shipped log) hijack the console
+/// session within the ticket's TTL. Everything else — host, path, port — is
+/// preserved so the log stays diagnostically useful.
+#[must_use]
+pub fn redact_ticket(url: &str) -> String {
+    const KEY: &str = "vncticket=";
+    // Case-insensitive search: a URL is ASCII, so `to_ascii_lowercase` keeps
+    // byte offsets aligned with the original — a future builder emitting a
+    // differently-cased param can't silently defeat redaction.
+    let lower = url.to_ascii_lowercase();
+    match lower.find(KEY) {
+        Some(i) => {
+            let val_start = i + KEY.len();
+            let val_end = url[val_start..]
+                .find('&')
+                .map_or(url.len(), |off| val_start + off);
+            format!("{}[REDACTED]{}", &url[..val_start], &url[val_end..])
+        }
+        None => url.to_string(),
+    }
 }
 
 /// Minimal URL-encode for the ticket query parameter. PVE tickets
@@ -130,6 +167,59 @@ mod tests {
         assert!(t
             .url
             .contains("/api2/json/nodes/pve1/qemu/100/vncwebsocket"));
+    }
+
+    #[test]
+    fn redact_ticket_hides_the_credential_keeps_the_rest() {
+        let t = build_ws_target(
+            "https://pve1.lan:8006",
+            "pve1",
+            100,
+            GuestType::Qemu,
+            5900,
+            "PVE:user@pam:abc/def+xyz",
+            "user@pam",
+        );
+        let red = redact_ticket(&t.url);
+        // The ticket value is gone…
+        assert!(red.contains("vncticket=[REDACTED]"), "got: {red}");
+        assert!(!red.contains("abc"), "ticket residue leaked: {red}");
+        assert!(!red.contains("%2F"), "encoded ticket residue leaked: {red}");
+        // …but the diagnostically-useful parts survive.
+        assert!(red.contains("port=5900"));
+        assert!(red.contains("/qemu/100/vncwebsocket"));
+        // A URL without a ticket passes through unchanged.
+        assert_eq!(redact_ticket("wss://x/y?port=1"), "wss://x/y?port=1");
+        // Case-insensitive: a differently-cased param is still redacted.
+        assert_eq!(
+            redact_ticket("wss://x/y?port=1&VNCTICKET=secretvalue"),
+            "wss://x/y?port=1&VNCTICKET=[REDACTED]"
+        );
+        // A trailing param after the ticket is preserved (value-run stops at &).
+        assert_eq!(
+            redact_ticket("wss://x?vncticket=abc&extra=1"),
+            "wss://x?vncticket=[REDACTED]&extra=1"
+        );
+    }
+
+    #[test]
+    fn wstarget_debug_never_leaks_the_ticket() {
+        let t = build_ws_target(
+            "https://x:8006",
+            "n",
+            1,
+            GuestType::Qemu,
+            5900,
+            "SUPER-SECRET-TICKET",
+            "alice@pve",
+        );
+        let dbg = format!("{t:?}");
+        assert!(
+            !dbg.contains("SUPER-SECRET-TICKET"),
+            "ticket leaked in Debug: {dbg}"
+        );
+        assert!(dbg.contains("vncticket=[REDACTED]"));
+        assert!(dbg.contains("[REDACTED]")); // auth field redacted too
     }
 
     #[test]


### PR DESCRIPTION
Closes the 4 remaining "yellow" security doubts from the diamond recon, in the exemplary format (fix or signed residual). Each was then **adversarially re-verified** by a 5-agent refutation pass — which found real latent gaps (also closed here) and corrected two over-claiming accepted-risk notes.

## Fixes
- **🔴 Console ticket log leak** — the `vncticket` was logged in cleartext at INFO + two connect-error sites on every console attach. `redact_ticket` (case-insensitive) masks it at all three; `WsTarget` gets a hand-written `Debug` so `{:?}` can't leak url/auth; `vncticket=` added to the panic-hook scrubber (defense-in-depth against a persisted-log panic). The intentional `vnc --ws-url` output is signed **AR-7** — that's the feature.
- **🟡 Cache-at-rest** — data dir `0700`, `{profile}_state.db` + `-wal`/`-shm` sidecars `0600` (best-effort). The 0700 dir is the real guard. **AR-8** signs the fail-open / no-encryption residual.
- **🟡 Keychain isolation** — two keychain-backed profiles resolved the *same* flat secret. Now `<profile>/<item>` first, flat fallback for back-compat. **AR-9** is honest: isolation is opt-in (store the scoped entry — no keychain-write command), a flat entry stays shared, Telegram/PBS stay flat.
- **🟡 Secret-elision on export (#178)** — verified secret-free by structure (field-whitelist, no serde-flatten). **AR-10** is the tripwire (#178 is the mandatory gate before any secret-bearing state family) and notes free-text (comment/notes) passes through verbatim.

## Adversarial pass caught (and this PR fixes)
panic-hook didn't know `vncticket=`; WAL/SHM sidecars weren't tightened (legacy 0644 residual); AR-9 over-claimed automatic isolation; AR-10 over-promised "secret-free by construction".

## Verification
`cargo test` (default + `keychain`) — 0 failed · clippy `--all-targets` (both features) clean · fmt clean. New unit tests: redact_ticket (case-insensitive + trailing-param), WsTarget Debug redaction, keyring_candidates ordering.

