### PR TITLE
test(e2e): make the live harness turnkey — synth CLI config + self-contained beta

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -395,20 +395,56 @@ async fn cleanup_one(client: &Arc<PxClient>, r: &Resource) {
 
 // ── CLI binary contract runner ──────────────────────────
 
+/// Lazily synthesize a proxxx `config.toml` from the E2E env, written once per
+/// test process (0600). The CLI loads a config FILE (`PROXXX_CONFIG` or the
+/// default path) — it does NOT build a connection from `PROXXX_E2E_*` — so
+/// without this every `run_proxxx` subprocess call exits 3 ("Config not found").
+/// Returns `None` on a dev machine where the E2E token env isn't set.
+pub fn e2e_cli_config_path() -> Option<&'static std::path::Path> {
+    use std::sync::OnceLock;
+    static PATH: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    PATH.get_or_init(|| {
+        let url = std::env::var("PROXXX_E2E_API_URL").ok()?;
+        let user = std::env::var("PROXXX_E2E_USER").ok()?;
+        let token_id = std::env::var("PROXXX_E2E_TOKEN_ID").ok()?;
+        let token_secret = std::env::var("PROXXX_E2E_TOKEN_SECRET").ok()?;
+        let toml = format!(
+            "url = \"{url}\"\nuser = \"{user}\"\nauth = \"token\"\n\
+             token_id = \"{token_id}\"\ntoken_secret = \"{token_secret}\"\nverify_tls = false\n"
+        );
+        let dir = std::env::temp_dir().join("proxxx-e2e");
+        std::fs::create_dir_all(&dir).ok()?;
+        let path = dir.join("cli-config.toml");
+        std::fs::write(&path, toml).ok()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        }
+        Some(path)
+    })
+    .as_deref()
+}
+
 /// Run the proxxx binary with the given args and return its
 /// `std::process::Output`. `CARGO_BIN_EXE_proxxx` is set by Cargo
 /// for integration tests, so the binary is always built before the
 /// test runs.
 ///
-/// The subprocess inherits PROXXX_* env vars from the test, so the
-/// CLI sees the same E2E credentials as the test process.
+/// The subprocess gets `PROXXX_CONFIG` pointing at a config synthesized from the
+/// E2E env (see [`e2e_cli_config_path`]) so CLI calls are turnkey — unless the
+/// caller already pinned `PROXXX_CONFIG`, which is respected.
 pub fn run_proxxx(args: &[&str]) -> std::process::Output {
     let bin = env!("CARGO_BIN_EXE_proxxx");
     eprintln!("[cli] {bin} {}", args.join(" "));
-    std::process::Command::new(bin)
-        .args(args)
-        .output()
-        .expect("spawn proxxx binary")
+    let mut cmd = std::process::Command::new(bin);
+    cmd.args(args);
+    if std::env::var_os("PROXXX_CONFIG").is_none() {
+        if let Some(cfg) = e2e_cli_config_path() {
+            cmd.env("PROXXX_CONFIG", cfg);
+        }
+    }
+    cmd.output().expect("spawn proxxx binary")
 }
 
 /// Invoke `proxxx` and return `(stdout_str, stderr_str, exit_code)`.

--- a/tests/e2e_beta.rs
+++ b/tests/e2e_beta.rs
@@ -54,17 +54,35 @@ async fn beta_destructive_without_yes_refuses() {
     };
     let client = env.build_client().await.expect("PxClient");
 
+    // Beta-1 mutates NOTHING — the delete refuses client-side, before any API
+    // call. So we don't need PROXXX_E2E_VMID to persist (Alpha creates+deletes
+    // it) — we just need SOME existing guest to (a) aim the refused delete at
+    // and (b) witness "unchanged before/after". Discover one; this makes the
+    // test self-contained and immune to Alpha's ephemeral-VMID lifecycle.
+    let guests = client
+        .get_guests(&env.node)
+        .await
+        .expect("list guests on the test node");
+    let Some(target) = guests.first() else {
+        eprintln!(
+            "[beta-1] no guest on node {} — skipping (nothing to witness)",
+            env.node
+        );
+        return;
+    };
+    let vmid = target.vmid;
+
     // Snapshot status BEFORE — we'll compare after the CLI invocation
     // to prove no mutation happened.
     let before = client
-        .get_guest_status(&env.node, env.vmid)
+        .get_guest_status(&env.node, vmid)
         .await
-        .expect("guest must exist for Beta-1");
+        .expect("status of the witness guest");
 
     // Run `proxxx delete <vmid>` WITHOUT --yes. The CLI's hard-coded
     // refusal at `cli/mod.rs:610` should bail with a non-zero exit
     // code BEFORE any HTTP request lands at PVE.
-    let (stdout, stderr, code) = common::run_proxxx_capture(&["delete", &env.vmid.to_string()]);
+    let (stdout, stderr, code) = common::run_proxxx_capture(&["delete", &vmid.to_string()]);
     assert_ne!(
         code, 0,
         "destructive delete WITHOUT --yes must exit non-zero \
@@ -79,9 +97,9 @@ async fn beta_destructive_without_yes_refuses() {
     // Verify state is unchanged. status == before.status, vmid is
     // still observable, no mid-flight lock error.
     let after = client
-        .get_guest_status(&env.node, env.vmid)
+        .get_guest_status(&env.node, vmid)
         .await
-        .expect("guest must still be observable");
+        .expect("witness guest must still be observable");
     assert_eq!(
         before.status, after.status,
         "guest status changed after a refused destructive op — \
@@ -114,12 +132,21 @@ async fn beta_bad_token_surfaces_401_cleanly() {
     // (no infinite retry, no panic, no hang).
     let bin = env!("CARGO_BIN_EXE_proxxx");
     let started = Instant::now();
-    let out = std::process::Command::new(bin)
-        .args(["ls", "guests", "--format", "json"])
+    // This test builds its own Command (to inject the bad creds), so it doesn't
+    // go through run_proxxx — wire the same synthesized config so the CLI has a
+    // profile to authenticate against. PROXXX_TOKEN_SECRET (env) overrides the
+    // config's token, so the connection is attempted with the WRONG secret → the
+    // 401 we assert on (not "Config not found"). Respect a caller-set config.
+    let mut cmd = std::process::Command::new(bin);
+    cmd.args(["ls", "guests", "--format", "json"])
         .env("PROXXX_TOKEN_SECRET", "this-is-deliberately-wrong-xxxxxxxx")
-        .env("PROXXX_PASSWORD", "this-is-deliberately-wrong-xxxxxxxx")
-        .output()
-        .expect("spawn proxxx with bad creds");
+        .env("PROXXX_PASSWORD", "this-is-deliberately-wrong-xxxxxxxx");
+    if std::env::var_os("PROXXX_CONFIG").is_none() {
+        if let Some(cfg) = common::e2e_cli_config_path() {
+            cmd.env("PROXXX_CONFIG", cfg);
+        }
+    }
+    let out = cmd.output().expect("spawn proxxx with bad creds");
     let elapsed = started.elapsed();
 
     let code = out.status.code().unwrap_or(-1);


### PR DESCRIPTION
Polishes the E2E harness so the draconian live suite runs from `env.local` alone — the two friction points found during the v0.13.0 cluster runs.

## 1. `run_proxxx` synthesizes the CLI config
The binary loads a config *file* (`PROXXX_CONFIG` / default path), not `PROXXX_E2E_*`, so every CLI subprocess call exited **3 ("Config not found")** unless you hand-wrote a config and exported `PROXXX_CONFIG`. Now `run_proxxx` (and the bad-token test's own `Command`) synthesize a `0600` config from the E2E env once per process and set `PROXXX_CONFIG` — unless the caller already pinned one.

## 2. `beta_destructive_without_yes` is self-contained
It assumed `PROXXX_E2E_VMID` persisted, but Alpha creates+deletes that VMID — so Beta panicked ("guest must exist") when run after/alongside Alpha, and needed a manual VMID override. Beta mutates nothing (the delete refuses client-side), so it now **discovers an existing guest** to target + witness. Alpha (9999) and Beta (an existing guest) run together with no override, no collision.

## Verified
Against pve-test-1 (PVE 9.1.1) with `PROXXX_CONFIG` **unset**: `e2e_alpha` 1/1 + `e2e_beta` 3/3 in one invocation. Non-cluster `cargo test` green, clippy/fmt clean.

