### PR TITLE
deps(cargo): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Why

The 2026-07-07 daily supply-chain sweep (scheduled ci.yml run) went **red** on **RUSTSEC-2026-0204**: crossbeam-epoch < 0.9.20, invalid pointer dereference in `fmt::Pointer`. Both `cargo audit` and `cargo deny` jobs failed; the push-CI on 466e11e was green — this is purely the newly-disclosed advisory.

## What

- `cargo update -p crossbeam-epoch` → 0.9.18 → 0.9.20. Lockfile-only diff.

## Notes

- Transitive dependency; the vulnerable code path is not triggerable via proxxx's usage → no emergency release, rides into v0.13.2.
- Verified locally: `cargo deny check advisories` → ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)