### PR TITLE
chore(release): v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ SemVer contract:
 
 ## [Unreleased]
 
+## [0.13.2] — 2026-07-07
+
+Patch: secret-hygiene hardening (redaction as a type property, closing a latent log-leak class the v0.13.1 `WsTarget` fix only covered for one type), plus two untested security-relevant paths now proven. No CLI / config / MCP contract change; config stays backward compatible.
+
+### Security
+
+- **Credential redaction is now a type property, not call-site discipline.** A new `SecretString` (redacting `Debug` → `[REDACTED]`, no `Display`, no `Serialize`, zeroize-on-drop) backs every credential field — PVE/PBS token secrets, password, `mcp_token`, `AuthMethod` token/ticket/CSRF, `TelegramConfig.bot_token` (previously a plain unwiped `String`), `PbsClient.auth_header`, SSH passphrases, init-wizard blocks. `Zeroizing<String>` delegates `Debug` to its inner `String`, so a derived `{:?}` on any config/auth struct previously printed live secrets — the same leak class the v0.13.1 `WsTarget` fix closed for one type, now closed at the type level everywhere.
+- **Telegram bot token no longer reachable in the persistent log.** The Bot API embeds the token in the request URL; reqwest's error `Display` appends `for url (…)`, and the HITL long-poll / alert paths log those errors — so a transport blip wrote the live token to the 14-day file log. Every Telegram request now scrubs the URL from its errors (`Error::without_url`) before they can reach a `tracing` event. Found by an adversarial-review pass; proven by a hermetic connection-refused test.
+- **Console / token wire types redact `Debug`.** `VncTicket`, `TermproxyTicket`, `SpiceConfig.password` and `ApiToken.value` keep `Serialize` (they ride the wire / `--json` output by design) but their live-credential fields are now hand-redacted in `Debug`, so a future `{:?}` log can't leak them.
+- **SIGHUP config hot-reload proven (AR-1 dependency).** The `mcp_token`-rotation path AR-1 relies on had zero tests. `reload_once` is extracted and unit-tested (a successful reload swaps `mcp_token` / `policies` / `rate_limit`; a failed parse keeps last-known-good), plus a real-signal end-to-end test (`PROXXX_CONFIG` tempfile + `libc::raise(SIGHUP)`).
+- **Env-var secret 64 KiB cap proven.** The `ENV_SECRET_MAX_BYTES` OOM guard, previously matrix-cited by constant only, now has executable proofs (over-cap refused, at-cap accepted, empty → None).
+
+### Dependencies
+
+- `crossbeam-epoch` 0.9.18 → 0.9.20 (RUSTSEC-2026-0204, transitive; not triggerable via proxxx's usage — the daily supply-chain sweep caught it).
+- `vite` (docs tooling, dev-only) → ≥ 7.3.5 (GHSA-fx2h-pf6j-xcff high + GHSA-v6wh-96g9-6wx3).
+- `github/codeql-action` v4.36.2 → v4.36.3 (CI).
+
+### Docs
+
+- `THREAT_MODEL.md` refreshed to v0.13.x reality: MCP dispatch is fail-closed (10 destructive tools, refuse-without-policy), keychain per-profile scoping, cache-at-rest perms, and vncticket redaction added; a new `tests/docs_consistency_test.rs` fails CI if the destructive-tool count drifts from the registry again.
+- Corrected the stale "8 flagged destructive" → 10 across the README / asset captions (the MCP demo SVG re-rendered) and "8 of the 10 state families" in the mutation-harness wording. Test counts refreshed to the actual `cargo test` totals (745 lib + 478 integration).
+
+### Internal
+
+- Security-invariants matrix: new rows for the redacting-`Debug` and SIGHUP-reload invariants; row 1 (zeroize-on-drop) reworded to its honest compile-time-type-property scope.
+
 ## [0.13.1] — 2026-07-06
 
 Patch: security hardening of the residual "yellow" doubts + dependency bumps. No CLI / config / MCP contract change; keychain resolution stays backward compatible.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Eight stages, run as both a pre-commit hook and the CI contract in [`.github/wor
 | 2 | `cargo clippy --release --all-targets` | 10–60 s |
 | 3 | `cargo audit --deny warnings` | 3–5 s |
 | 4 | `cargo deny check` (license / banned crates / sources / wildcards) | 2–4 s |
-| 5 | `cargo test --release --all-targets` (646 lib tests + 447 integration tests including ~25 proptest properties × 256 cases each) | 10–90 s |
+| 5 | `cargo test --release --all-targets` (745 lib tests + 478 integration tests including ~25 proptest properties × 256 cases each) | 10–90 s |
 | 6 | `tests/live/test_run.sh` (67 read-only probes against the live cluster) | ~30 s |
 | 7 | `tests/live/test_mutation.sh` (34 mutation probes: LXC + cluster-level CRUD across 8 of the 10 state families + QEMU; opt-in QGA via `PROXXX_E2E_QGA_VMID=<vmid>`) | ~60 s |
 

--- a/docs/guide/pre-commit-gate.md
+++ b/docs/guide/pre-commit-gate.md
@@ -38,7 +38,7 @@ anything reaches the remote.
 | 2 | `cargo clippy --release --all-targets` | 10–60 s | lint policy: `unwrap_used`, `expect_used`, `panic`, `todo`, `await_holding_lock` are `deny` |
 | 3 | `cargo audit --deny warnings` | 3–5 s | new CVEs in `Cargo.lock`, against a documented advisory ignore policy in `.cargo/audit.toml` |
 | 4 | `cargo deny check` | 2–4 s | license whitelist, banned crates (`openssl`, `native-tls`, etc.), crates.io-only sources, wildcard ban — policy in `deny.toml` |
-| 5 | `cargo test --release --all-targets` | 10–90 s | full unit + integration + wiremock + TUI snapshot suites (646 lib tests + 447 integration tests + ~25 proptest properties × 256 cases each) |
+| 5 | `cargo test --release --all-targets` | 10–90 s | full unit + integration + wiremock + TUI snapshot suites (745 lib tests + 478 integration tests + ~25 proptest properties × 256 cases each) |
 | 6 | `tests/live/test_run.sh` | ~30 s | 67 read-only probes against a live cluster |
 | 7 | `tests/live/test_mutation.sh` | ~60 s | 34 mutation probes covering full lifecycle: LXC 9999 (create → start → snapshot → stop → delete), cluster-level CRUD across 8 of the 10 state families (pools / ACL / storage-defs / backup-jobs / firewall-cluster / notifications / HA rules / HA resources), QEMU 9998 from alpine ISO, opt-in QGA round-trips via `PROXXX_E2E_QGA_VMID=<vmid>` |
 
@@ -50,7 +50,7 @@ the developer's primary workstation where the cluster lives.
 ## Why integration tests in the gate
 
 A previous gate ran `cargo test --release --lib` only. That covered
-the lib tests but missed the 447 tests in `tests/*.rs` that CI catches.
+the lib tests but missed the 478 tests in `tests/*.rs` that CI catches.
 A developer could land a stale-mock regression locally, push, and CI
 would fail in remote — wasting a round trip.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ features:
   - title: No agent on the cluster
     details: Direct REST against PVE (token or password) and PBS (token only), with typed error categories so callers match on the failure shape instead of grepping prose. SSH only for the paths PVE never exposed over REST — patch apply, full effective-permissions, per-guest interactive sessions, per-node journalctl tailing, GPU/IOMMU readiness probing.
   - title: Eight-stage commit gate, no skip flags
-    details: secret-shape scan, cargo fmt, cargo clippy --all-targets at deny tier, cargo audit against a pinned advisory policy, cargo deny check (license whitelist + banned crates + crates.io-only sources + wildcard ban), the full test suite (646 lib tests + 447 integration tests including ~25 proptest properties at 256 random cases each, ~6 400 invariant checks total), 67 read-only probes against a live cluster, and a full mutation lifecycle covering LXC, cluster-level CRUD across 8 of the 10 state families, QEMU, and opt-in QGA agent-required round-trips. Every commit on main passes locally and in CI.
+    details: secret-shape scan, cargo fmt, cargo clippy --all-targets at deny tier, cargo audit against a pinned advisory policy, cargo deny check (license whitelist + banned crates + crates.io-only sources + wildcard ban), the full test suite (745 lib tests + 478 integration tests including ~25 proptest properties at 256 random cases each, ~6 400 invariant checks total), 67 read-only probes against a live cluster, and a full mutation lifecycle covering LXC, cluster-level CRUD across 8 of the 10 state families, QEMU, and opt-in QGA agent-required round-trips. Every commit on main passes locally and in CI.
   - title: Pre-flight risk gate plus HITL
     details: 11 risk variants — running, long-uptime, locked, HA-managed, tagged prod, active net traffic, listening on service, many snapshots, backup age warning, no backup found, deep-check skipped — refuse destructive operations on guests that look like production unless overridden explicitly. Above that, a real Telegram round-trip with deny-on-timeout for any op marked destructive by policy. The same gate fires on `state apply` for non-empty pool deletes, root-role ACL deletes, shared-storage removal, and batches ≥ 50.
   - title: GitOps loop for Proxmox
@@ -108,7 +108,7 @@ onMounted(() => {
 
 | Surface               | Today                                                    |
 | :-------------------- | :------------------------------------------------------- |
-| Source                | ~72 KLOC Rust · ~17 KLOC tests · 646 lib tests + 447 integration tests (error-handling + resilience-chaos sweeps)           |
+| Source                | ~72 KLOC Rust · ~17 KLOC tests · 745 lib tests + 478 integration tests (error-handling + resilience-chaos sweeps)           |
 | Quality gate          | 8 stages · ~340–480 s wall time (live cluster path)      |
 | Live cluster coverage | 67 read probes + 34 mutation probes per gate run         |
 | Property testing      | ~25 proptest properties × 256 random cases = ~6 400 invariant checks per `cargo test` |


### PR DESCRIPTION
## Release v0.13.2

Patch: secret-hygiene hardening (redaction as a **type property**, closing a latent log-leak class the v0.13.1 `WsTarget` fix only covered for one type) + two untested security-relevant paths now proven. No CLI / config / MCP contract change.

### Payload (already merged to main)
- **#209** SecretString redacting-`Debug` for every credential + adversarial-review fixes (Telegram bot-token log leak via reqwest error `Display` → `without_url` scrub; console/token wire-type `Debug` redaction) + env-cap proofs
- **#211** SIGHUP config hot-reload proofs (AR-1 dependency)
- **#207** THREAT_MODEL refresh + registry drift-proof test
- **#208** destructive-count sweep (8 → 10) + mutation wording
- **#205/#206/#210** deps: crossbeam-epoch (RUSTSEC-2026-0204), vite (2 GHSAs), codeql-action

### This PR
- version 0.13.1 → **0.13.2** (Cargo.toml + lock)
- CHANGELOG `[0.13.2]` section
- **test counts refreshed** to actual `cargo test` totals: **745 lib + 478 integration** (was the stale 646 + 447) across README + docs

### Validation
- **22 live tests green** against PVE 9.1.1 (pve-test-1): e2e_alpha CRUD, e2e_beta, feature_coverage (6), rbac_live (10), ssh_live (2) — the SecretString auth swap is byte-identical on the wire
- `cargo fmt --check` + `cargo clippy --all-targets` clean; full non-ignored suite green (1223 tests)

Tagging `v0.13.2` after merge fires release.yml (cross-build, cosign, SBOM, GH release, Homebrew tap bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)