### PR TITLE
docs(seo): sitemap.xml + robots.txt + OpenGraph/Twitter cards

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,6 +19,18 @@ export default defineConfig({
     hostname: 'https://fabriziosalmi.github.io/proxxx/',
   },
 
+  // Per-page og:url. Crawlers treat og:url as the canonical URL, so a
+  // single global value would advertise every subpage as the homepage;
+  // this derives the canonical from the page path instead (cleanUrls
+  // form: strip .md, collapse index to the directory root).
+  transformPageData(pageData) {
+    const canonical =
+      'https://fabriziosalmi.github.io/proxxx/' +
+      pageData.relativePath.replace(/(^|\/)index\.md$/, '$1').replace(/\.md$/, '')
+    pageData.frontmatter.head ??= []
+    pageData.frontmatter.head.push(['meta', { property: 'og:url', content: canonical }])
+  },
+
   head: [
     // Everything this site loads is first-party. 'unsafe-inline' is required
     // because VitePress emits an inline appearance script and inline styles.
@@ -58,7 +70,6 @@ export default defineConfig({
         content: 'Terminal cockpit for Proxmox VE and Backup Server, gated on a real cluster.',
       },
     ],
-    ['meta', { property: 'og:url', content: 'https://fabriziosalmi.github.io/proxxx/' }],
     ['meta', { property: 'og:image', content: 'https://fabriziosalmi.github.io/proxxx/proxxx-overview.jpg' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
     ['meta', { name: 'twitter:image', content: 'https://fabriziosalmi.github.io/proxxx/proxxx-overview.jpg' }],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -12,6 +12,13 @@ export default defineConfig({
   cleanUrls: true,
   lastUpdated: true,
 
+  // Emit sitemap.xml at build time. The hostname must carry the
+  // /proxxx/ base — vitepress joins it with base-less route paths,
+  // so leaving it at the origin would emit URLs that 404 on GH Pages.
+  sitemap: {
+    hostname: 'https://fabriziosalmi.github.io/proxxx/',
+  },
+
   head: [
     // Everything this site loads is first-party. 'unsafe-inline' is required
     // because VitePress emits an inline appearance script and inline styles.
@@ -38,6 +45,23 @@ export default defineConfig({
     // the favicon 404s on the deployed site.
     ['link', { rel: 'icon', href: '/proxxx/favicon.ico', sizes: 'any' }],
     ['meta', { name: 'theme-color', content: '#2563eb' }],
+    // Social cards. Absolute URLs on purpose: og:image/og:url must be
+    // absolute per the OG spec, and absolute hrefs also sidestep the
+    // base-prefix pitfall described above.
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:site_name', content: 'proxxx' }],
+    ['meta', { property: 'og:title', content: 'proxxx — terminal cockpit for Proxmox VE & PBS' }],
+    [
+      'meta',
+      {
+        property: 'og:description',
+        content: 'Terminal cockpit for Proxmox VE and Backup Server, gated on a real cluster.',
+      },
+    ],
+    ['meta', { property: 'og:url', content: 'https://fabriziosalmi.github.io/proxxx/' }],
+    ['meta', { property: 'og:image', content: 'https://fabriziosalmi.github.io/proxxx/proxxx-overview.jpg' }],
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ['meta', { name: 'twitter:image', content: 'https://fabriziosalmi.github.io/proxxx/proxxx-overview.jpg' }],
   ],
 
   themeConfig: {

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://fabriziosalmi.github.io/proxxx/sitemap.xml


### PR DESCRIPTION
The docs site had no sitemap, no robots.txt and no social-card meta. This adds all three:

- **sitemap.xml** via the vitepress `sitemap` option, with the `/proxxx/` base baked into the hostname (vitepress joins base-less route paths, so the origin alone would emit URLs that 404 on GH Pages). 26 URLs verified in the built output.
- **robots.txt** in `docs/public/`, pointing crawlers at the sitemap.
- **OpenGraph + Twitter card meta** in `head`, absolute URLs per the OG spec; `og:image` reuses the existing `proxxx-overview.jpg`.

Verified with a local `npm run build`: sitemap URLs correct, tags present in `dist/index.html`, robots.txt copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)