### PR TITLE
test(live): un-rot the url-info probe — jammy/current instead of a dated snapshot

### DIFF
--- a/tests/live/test_run.sh
+++ b/tests/live/test_run.sh
@@ -197,7 +197,7 @@ probe "access permissions"             access permissions
 # url-info preflight requires a node to do the HEAD request from. Pick the
 # first cluster node — content of the URL doesn't matter beyond reachable.
 FIRST_NODE=$(echo "$NODES" | awk '{print $1}')
-probe "url-info --node $FIRST_NODE" url-info --node "$FIRST_NODE" --url "https://cloud-images.ubuntu.com/jammy/20260320/SHA256SUMS"
+probe "url-info --node $FIRST_NODE" url-info --node "$FIRST_NODE" --url "https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS"
 for node in $NODES; do
     probe "tasks --node $node"        tasks --node "$node"
     probe "aplinfo list --node $node" aplinfo list --node "$node"


### PR DESCRIPTION
The only red probe in today's full live run (86/87 on pve-test-1): `url-info` points at `jammy/20260320/SHA256SUMS`, which cloud-images.ubuntu.com has since pruned (404 upstream). `jammy/current/SHA256SUMS` always exists, so the probe tests proxxx rather than Ubuntu's retention policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)