### PR TITLE
harden: SSH passphrase redacts Debug as a type property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ SemVer contract:
 
 ## [Unreleased]
 
+### Security
+
+- **The TUI-typed SSH passphrase redacts `Debug` as a type property.** `Action::SshPassphraseInput` and `SideEffect::SetSshPassphraseAndOpen` carried the typed passphrase as a plain `String` inside `Debug`-derived enums — no site logs actions today and the op queue persists through the closed `PersistedOp` set, so nothing leaked, but the invariant since v0.13.2 is that redaction never depends on call-site discipline. Both now carry `SecretString` (`{:?}` → `[REDACTED]`, proven by test), the submit path moves the input buffer into the wrapper via `mem::take` so the plaintext is zeroized instead of surviving in a freed allocation, and `ssh_handler.set_passphrase` accepts the wrapper end-to-end. Flagged while triaging CodeQL's new Rust queries (alert #45).
+
 ## [0.13.3] — 2026-08-29
 
 Patch: supply-chain catch-up (the scheduled audit had been red since 2026-08-25) plus docs-site SEO. No CLI / config / MCP contract change; config stays backward compatible.

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,7 @@ pub mod search;
 pub mod snaptree;
 
 use crate::api::types::{Guest, Node, StoragePool};
+use crate::util::secret::SecretString;
 
 /// The single source of truth for the entire application.
 ///
@@ -406,7 +407,11 @@ pub enum Action {
     },
     /// A keystroke in the passphrase prompt — carries the full buffer so
     /// far (same shape as `CommandInput`, but does not change mode).
-    SshPassphraseInput(String),
+    /// `SecretString`, so a `{:?}` of an `Action` can never print the
+    /// passphrase. No site Debug-logs actions today and the op queue
+    /// persists through the closed `PersistedOp` set — but redaction is
+    /// a type property here, not call-site discipline.
+    SshPassphraseInput(SecretString),
     /// Submit the typed passphrase: cache it and (re)open the session.
     SshPassphraseSubmit,
     /// Abandon the passphrase prompt (Esc) — pops back to the prior view.
@@ -1354,13 +1359,16 @@ pub fn update(state: &mut AppState, action: Action) -> Option<SideEffect> {
             // Only meaningful while prompting; ignore otherwise (a stray
             // keystroke shouldn't hijack `command_input`).
             if matches!(state.mode, AppMode::SshPassphrase { .. }) {
-                state.command_input = input;
+                state.command_input = input.expose().to_string();
             }
         }
         Action::SshPassphraseSubmit => {
             if let AppMode::SshPassphrase { vmid } = state.mode {
-                let passphrase = state.command_input.clone();
-                state.command_input.clear();
+                // `take` moves the buffer into the wrapper (leaving the
+                // input empty, as before) so the plaintext is zeroized
+                // with the SecretString instead of surviving in a freed
+                // allocation the way clone-then-clear left it.
+                let passphrase = SecretString::new(std::mem::take(&mut state.command_input));
                 // Back to session mode — the GuestSshSession view is
                 // still on the stack from OpenGuestSsh.
                 state.mode = AppMode::SshSession { vmid };
@@ -1766,7 +1774,7 @@ pub enum SideEffect {
     /// open the session — the retry's key load now has the passphrase.
     SetSshPassphraseAndOpen {
         vmid: u32,
-        passphrase: String,
+        passphrase: SecretString,
     },
     /// Tell the TUI loop to drop the active `PtySession`.
     CloseSshSession,
@@ -1978,6 +1986,24 @@ mod ssh_passphrase_tests {
     }
 
     #[test]
+    fn passphrase_never_reaches_debug_output() {
+        // Redaction as a type property: a `{:?}` of the action or of the
+        // side effect must not contain the typed passphrase.
+        let action = Action::SshPassphraseInput("hunter2".into());
+        let rendered = format!("{action:?}");
+        assert!(!rendered.contains("hunter2"), "leaked in {rendered}");
+        assert!(rendered.contains("[REDACTED]"));
+
+        let eff = SideEffect::SetSshPassphraseAndOpen {
+            vmid: 42,
+            passphrase: "hunter2".into(),
+        };
+        let rendered = format!("{eff:?}");
+        assert!(!rendered.contains("hunter2"), "leaked in {rendered}");
+        assert!(rendered.contains("[REDACTED]"));
+    }
+
+    #[test]
     fn input_appends_only_while_prompting() {
         let mut state = AppState::new();
         // Outside the prompt, a stray input action must not hijack the buffer.
@@ -1998,7 +2024,7 @@ mod ssh_passphrase_tests {
         match eff {
             Some(SideEffect::SetSshPassphraseAndOpen { vmid, passphrase }) => {
                 assert_eq!(vmid, 42);
-                assert_eq!(passphrase, "s3cret");
+                assert_eq!(passphrase.expose(), "s3cret");
             }
             _ => panic!("expected SetSshPassphraseAndOpen side effect"),
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1359,7 +1359,11 @@ pub fn update(state: &mut AppState, action: Action) -> Option<SideEffect> {
             // Only meaningful while prompting; ignore otherwise (a stray
             // keystroke shouldn't hijack `command_input`).
             if matches!(state.mode, AppMode::SshPassphrase { .. }) {
-                state.command_input = input.expose().to_string();
+                // Reuse the buffer: overwriting in place avoids a fresh
+                // plaintext allocation per keystroke and never frees the
+                // previous buffer unwiped (review note on this PR).
+                state.command_input.clear();
+                state.command_input.push_str(input.expose());
             }
         }
         Action::SshPassphraseSubmit => {

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -130,7 +130,9 @@ require = 1
         assert!(swapped, "a successful reload must return true");
         let live = handle.read().await;
         assert_eq!(
-            live.mcp_token.as_ref().map(|s| s.as_str()),
+            live.mcp_token
+                .as_ref()
+                .map(crate::util::secret::SecretString::as_str),
             Some("new-token")
         );
         assert_eq!(live.rate_limit, Some(20));
@@ -157,7 +159,12 @@ mcp_token = "keep-me"
 
         assert!(!swapped, "a failed reload must return false");
         assert_eq!(
-            handle.read().await.mcp_token.as_ref().map(|s| s.as_str()),
+            handle
+                .read()
+                .await
+                .mcp_token
+                .as_ref()
+                .map(crate::util::secret::SecretString::as_str),
             Some("keep-me"),
             "the last-known-good token must survive a failed reload"
         );

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -408,12 +408,12 @@ pub fn map_key(key: KeyEvent, state: &crate::app::AppState) -> Option<crate::app
             KeyCode::Char(c) => {
                 let mut q = state.command_input.clone();
                 q.push(c);
-                Some(Action::SshPassphraseInput(q))
+                Some(Action::SshPassphraseInput(q.into()))
             }
             KeyCode::Backspace => {
                 let mut q = state.command_input.clone();
                 q.pop();
-                Some(Action::SshPassphraseInput(q))
+                Some(Action::SshPassphraseInput(q.into()))
             }
             _ => None,
         },

--- a/src/tui/ssh_handler.rs
+++ b/src/tui/ssh_handler.rs
@@ -84,10 +84,10 @@ impl SshSessionHandler {
     /// Store a passphrase entered via the interactive prompt. Reused for
     /// every subsequent connection this session, so the operator is
     /// prompted at most once.
-    pub fn set_passphrase(&self, passphrase: String) {
+    pub fn set_passphrase(&self, passphrase: crate::util::secret::SecretString) {
         match self.passphrase.lock() {
-            Ok(mut g) => *g = Some(crate::util::secret::SecretString::new(passphrase)),
-            Err(p) => *p.into_inner() = Some(crate::util::secret::SecretString::new(passphrase)),
+            Ok(mut g) => *g = Some(passphrase),
+            Err(p) => *p.into_inner() = Some(passphrase),
         }
     }
 

--- a/tests/config_reload_e2e.rs
+++ b/tests/config_reload_e2e.rs
@@ -54,7 +54,10 @@ async fn sighup_hot_reloads_and_a_bad_edit_keeps_last_known_good() {
     );
     let initial = proxxx::config::load_config(None).expect("v1 loads");
     assert_eq!(
-        initial.mcp_token.as_ref().map(|s| s.as_str()),
+        initial
+            .mcp_token
+            .as_ref()
+            .map(proxxx::util::secret::SecretString::as_str),
         Some("v1-token")
     );
     let handle = new_handle(initial);
@@ -72,7 +75,14 @@ async fn sighup_hot_reloads_and_a_bad_edit_keeps_last_known_good() {
     for _ in 0..20 {
         unsafe { libc::raise(libc::SIGHUP) };
         tokio::time::sleep(Duration::from_millis(100)).await;
-        if handle.read().await.mcp_token.as_ref().map(|s| s.as_str()) == Some("v2-rotated") {
+        if handle
+            .read()
+            .await
+            .mcp_token
+            .as_ref()
+            .map(proxxx::util::secret::SecretString::as_str)
+            == Some("v2-rotated")
+        {
             reloaded = true;
             break;
         }
@@ -90,7 +100,12 @@ async fn sighup_hot_reloads_and_a_bad_edit_keeps_last_known_good() {
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
     assert_eq!(
-        handle.read().await.mcp_token.as_ref().map(|s| s.as_str()),
+        handle
+            .read()
+            .await
+            .mcp_token
+            .as_ref()
+            .map(proxxx::util::secret::SecretString::as_str),
         Some("v2-rotated"),
         "a failed reload must keep the last-known-good token, not clear it"
     );


### PR DESCRIPTION
Closes the latent half of CodeQL alert #45 (the flow itself was dismissed as infeasible — the op queue persists through the closed `PersistedOp` set).

`Action::SshPassphraseInput` and `SideEffect::SetSshPassphraseAndOpen` carried the TUI-typed SSH passphrase as a plain `String` inside `Debug`-derived enums. Nothing logs actions today, so nothing leaked — but the invariant since v0.13.2 is that redaction is a **type property**, never call-site discipline.

- Both enums now carry `SecretString` → `{:?}` prints `[REDACTED]`, proven by the new `passphrase_never_reaches_debug_output` test.
- Submit moves the input buffer into the wrapper via `mem::take`, so the plaintext is zeroized on drop instead of surviving in a freed allocation the way clone-then-clear left it.
- `ssh_handler.set_passphrase` accepts the wrapper end-to-end (it already stored `SecretString` internally).
- Second commit: mechanical clippy `redundant_closure_for_method_calls` cleanup on the five `mcp_token` `as_str` sites — the crate's only remaining clippy warnings.

Gate run locally on the pinned 1.95.0 toolchain: `cargo fmt --check` clean, `cargo clippy --all-targets` zero warnings, `cargo test --release --all-targets` **1224 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)