### PR TITLE
deps(cargo): update der and wnaf off their yanked releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,9 +1001,9 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -5359,13 +5359,14 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
 dependencies = [
  "ff",
  "group",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]


### PR DESCRIPTION
CI has been red on `main` since 2026-09-04, on a commit that passed on 09-03. Nothing in the repository changed in between: `der` 0.8.0 and `wnaf` 0.14.0 were yanked from crates.io.

```
error[yanked]: detected yanked crate (try `cargo update -p der`)
error[yanked]: detected yanked crate (try `cargo update -p wnaf`)
error: 2 denied warnings found!
```

Both supply-chain jobs fail on it, reporting the same thing twice: `cargo audit --deny warnings` escalates a yanked notice to a failure by design, and cargo-deny denies it through `deny.toml`.

## The fix

Both crates arrive transitively through russh:

```
der  <- ecdsa <- p256/p384 <- russh <- proxxx
wnaf <- primeorder <- p256/p384 <- russh <- proxxx
```

Each has a non-yanked patch release inside the same semver range:

| crate | yanked | available |
|---|---|---|
| der | 0.8.0 | **0.8.2** |
| wnaf | 0.14.0 | **0.14.1** |

So this is `cargo update -p der -p wnaf` and nothing else: five lines of `Cargo.lock`. No manifest change, no other dependency moved.

## Verified locally

- **Every package in the lockfile checked against the crates.io API**: 538 of 539 resolved (the missing one is `proxxx` itself), none yanked. That covers the whole file rather than just the two the tools happened to name today.
- `cargo build --locked` passes
- `cargo test --locked`: 30 suites, no failures
- `cargo clippy --locked --all-targets -- -D warnings` clean

## Worth knowing

This class of failure will recur: a crate you depend on transitively can be yanked at any time, and both jobs are configured to treat that as a hard error. That is a defensible posture for a tool that holds cluster credentials, and it means a red `main` that nobody caused. The pattern is always the same, `cargo update -p <crate>`, but it needs someone to notice. A scheduled run already exists, so the gap is only that its failure is not routed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)