### PR TITLE
fix: close the 2026-09-09 audit remediation milestone (v0.14.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,32 @@ updates:
   # rather than letting the pin drift past a published release. This
   # closes the tj-actions/changed-files-style attack window where a
   # compromised tag (e.g. `@v4`) could re-point at malicious code.
+  # Audit #280: the docs site has a committed package-lock.json and is
+  # built and deployed by docs.yml, but no ecosystem watched it — the
+  # Rust half had three independent mechanisms and the JavaScript half
+  # had none. A compromised vitepress transitive dependency ships its
+  # output to the public documentation site, which is where operators
+  # are told how to install a security-sensitive tool.
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Rome"
+    open-pull-requests-limit: 5
+    labels:
+      - "deps"
+      - "javascript"
+    commit-message:
+      prefix: "deps(npm)"
+      include: "scope"
+    groups:
+      patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           shared-key: coverage
 
       - name: Install cargo-llvm-cov
-        run: cargo install --locked --version 0.6.16 cargo-llvm-cov
+        run: cargo install --locked --version 0.9.1 cargo-llvm-cov
 
       - name: Measure
         run: cargo llvm-cov --all-targets --lcov --output-path lcov.info
@@ -184,7 +184,14 @@ jobs:
           shared-key: audit
 
       - name: Install cargo-audit
-        run: cargo install --locked cargo-audit
+        # Audit #280 — pinned. `--locked` fixes the tool's own transitive
+        # dependencies but not WHICH version of the tool is installed, so
+        # the code deciding whether the build passes its security gate
+        # changed on every run without review. `cross` and `cargo-deb` in
+        # release.yml were already pinned; the tools with the most
+        # authority were the ones left floating. Dependabot's cargo
+        # cadence carries the bumps as reviewable PRs.
+        run: cargo install --locked --version 0.22.2 cargo-audit
 
       - name: Audit Cargo.lock for CVEs
         # The `--deny warnings` flag escalates yanked-crate notices
@@ -219,7 +226,7 @@ jobs:
           shared-key: deny
 
       - name: Install cargo-deny
-        run: cargo install --locked cargo-deny
+        run: cargo install --locked --version 0.20.2 cargo-deny
 
       - name: Check supply-chain policy (advisories + licenses + bans + sources)
         run: cargo deny check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,20 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
 
-      - name: Clippy (deny tier)
-        # The `[lints.clippy]` block in Cargo.toml already declares
-        # `unwrap_used`, `expect_used`, `panic`, `todo` as deny. We
-        # also surface pedantic/nursery as warnings (informational).
+      - name: Clippy (deny tier + warnings)
+        # `-D warnings` is the point (audit #272). The `[lints.clippy]`
+        # block in Cargo.toml declares `unwrap_used`, `expect_used`,
+        # `panic`, `todo` and `await_holding_lock` as deny, and surfaces
+        # pedantic + nursery as warnings — but without this flag those
+        # warnings printed and CI exited zero, so the entire curated
+        # pedantic/nursery configuration was decorative. In particular
+        # `cognitive_complexity` (nursery) fired on exactly the functions
+        # it was enabled for and blocked nothing.
+        #
+        # The tree is clean at this level, so there is no backlog to work
+        # through: a new warning means a new regression.
         # `--all-targets` covers tests + examples + benches.
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Build (debug)
         run: cargo build --all-targets
@@ -76,6 +84,88 @@ jobs:
 
       - name: Build (release, stripped)
         run: cargo build --release
+
+  lint-scripts:
+    name: Lint shell + Python
+    runs-on: ubuntu-latest
+    # Audit #274: 10 shell files and 2 Python files shipped unchecked.
+    # One of them (scripts/repin-cloudimg.py) rewrites Rust source in
+    # place and opens supply-chain-sensitive re-pin PRs on a schedule;
+    # the live harnesses under tests/live/ decide what a mutation test
+    # asserts against a real cluster, where an unquoted expansion changes
+    # the answer silently.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: ruff (Python)
+        uses: astral-sh/ruff-action@0c50076f12c38c3d0115b7b519b54a91cb9cf0ad  # v3.5.1
+
+      - name: shellcheck
+        # `-S error` only: the tree currently carries style and warning
+        # findings (SC2155, SC2086 …) that are real but not worth
+        # blocking a release over today. Tighten to `-S warning` once
+        # they are cleared — the point of starting at `error` is that the
+        # gate is green and therefore trusted, rather than red and
+        # routinely ignored.
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          shellcheck -S error tests/live/*.sh scripts/*.sh
+
+  secret-scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    # Audit #274. GitHub's native secret scanning covers provider
+    # patterns on push; this covers the rest, and covers history — which
+    # matters here specifically: tests/live/test_mutation.sh records that
+    # an earlier revision of that script committed a real PVE token to
+    # public git history (rotated and revoked when discovered).
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0   # gitleaks scans history, not just the tree
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3  # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  coverage:
+    name: Coverage report
+    runs-on: ubuntu-latest
+    # Audit #275: nothing measured which code the ~1250 tests execute, so
+    # the distribution of that effort was chosen by judgement and could
+    # not be checked. Deliberately NO threshold: the value is the
+    # per-file view of which modules the suite never enters, which is the
+    # input needed to decide where the next test belongs. A threshold set
+    # below current reality would never bite, and one set above it would
+    # block unrelated work.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (HEAD as of 2026-03-27)
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          shared-key: coverage
+
+      - name: Install cargo-llvm-cov
+        run: cargo install --locked --version 0.6.16 cargo-llvm-cov
+
+      - name: Measure
+        run: cargo llvm-cov --all-targets --lcov --output-path lcov.info
+
+      - name: Summary
+        run: cargo llvm-cov report --summary-only | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: coverage-lcov
+          path: lcov.info
 
   audit:
     name: Supply-chain audit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,6 +63,20 @@ jobs:
         working-directory: docs
         run: npm ci
 
+      - name: npm audit
+        # Audit #280 — the Rust tree is gated by cargo-audit and
+        # cargo-deny; this half had nothing. The output of `npm ci` is
+        # deployed to the public documentation site, so a compromised
+        # build dependency reaches the page that tells operators how to
+        # install proxxx.
+        #
+        # `--audit-level=high` rather than `low`: the vitepress tree
+        # carries a long tail of low findings in dev-only transitive
+        # packages, and a gate that is red by default is a gate people
+        # learn to click past.
+        working-directory: docs
+        run: npm audit --audit-level=high
+
       - name: Build
         working-directory: docs
         run: npx vitepress build

--- a/.github/workflows/live-tier.yml
+++ b/.github/workflows/live-tier.yml
@@ -1,0 +1,83 @@
+# Live-cluster verification, on demand.
+#
+# Audit #275: `cargo test --all-targets` skips every `#[ignore]`d test —
+# 24 of them across five files — and never invokes the ten shell
+# harnesses under tests/live/. Those cover the highest-consequence
+# behaviour in the project: real guest mutations, RBAC against three
+# token identities, PBS backup and restore, and the Severe delete gate
+# actually refusing. A regression in any of them merged green.
+#
+# They need a real PVE cluster, which a hosted runner does not have, so
+# this cannot be a push gate. What it can be is a recorded one: the run
+# is keyed to a commit SHA and its summary is uploaded, so "the live
+# tier passed" stops resting on the maintainer's memory.
+#
+# Requires a self-hosted runner with network reach to the test cluster,
+# and these repository secrets:
+#   PROXXX_E2E_PVE_URL, PROXXX_E2E_PVE_TOKEN, PROXXX_E2E_NODE
+
+name: live tier
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_mutations:
+        description: "Run the mutating suites (creates and destroys guests)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  live:
+    name: Live cluster (${{ github.sha }})
+    runs-on: [self-hosted, proxxx-live]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (HEAD as of 2026-03-27)
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Read-only suites
+        env:
+          PROXXX_E2E_PVE_URL: ${{ secrets.PROXXX_E2E_PVE_URL }}
+          PROXXX_E2E_PVE_TOKEN: ${{ secrets.PROXXX_E2E_PVE_TOKEN }}
+          PROXXX_E2E_NODE: ${{ secrets.PROXXX_E2E_NODE }}
+        # `--ignored` is the whole point: without it these are exactly
+        # the tests the push gate already ran and skipped.
+        run: cargo test --release --test feature_coverage_live -- --ignored --nocapture
+
+      - name: Mutating suites
+        if: ${{ inputs.run_mutations }}
+        env:
+          PROXXX_E2E_PVE_URL: ${{ secrets.PROXXX_E2E_PVE_URL }}
+          PROXXX_E2E_PVE_TOKEN: ${{ secrets.PROXXX_E2E_PVE_TOKEN }}
+          PROXXX_E2E_NODE: ${{ secrets.PROXXX_E2E_NODE }}
+        run: |
+          cargo test --release --test e2e_alpha -- --ignored --nocapture
+          cargo test --release --test e2e_beta  -- --ignored --nocapture
+          bash tests/live/test_mutation.sh
+
+      - name: Record the result against this commit
+        if: always()
+        run: |
+          {
+            echo "# Live tier — ${{ github.sha }}"
+            echo
+            echo "- Ref: \`${{ github.ref_name }}\`"
+            echo "- Mutating suites: ${{ inputs.run_mutations }}"
+            echo "- Outcome: ${{ job.status }}"
+            echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } | tee -a "$GITHUB_STEP_SUMMARY" > live-tier-result.md
+
+      - name: Upload the record
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: live-tier-${{ github.sha }}
+          path: live-tier-result.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,38 @@ jobs:
           mkdir -p dist/"$NAME"
           cp target/${{ matrix.target }}/release/proxxx dist/"$NAME"/
           cp LICENSE README.md SECURITY.md dist/"$NAME"/
-          tar -C dist -czf "dist/${NAME}.tar.gz" "$NAME"
+          # Audit #279 — reproducible archive. A plain `tar -czf` records
+          # file mtimes and gzip stamps its header, so two builds of the
+          # same commit produced different bytes and different digests.
+          # The .sha256 beside the tarball then attested to one
+          # particular CI run rather than to the source, and nobody could
+          # rebuild the commit and confirm the result matched.
+          #
+          # --sort=name      stable member order
+          # --mtime          all members at the commit's own timestamp
+          # --owner/--group  no build-account identity in the archive
+          # gzip -n          no timestamp in the gzip header
+          #
+          # GNU tar specifically: bsdtar (the default `tar` on macOS)
+          # supports none of --sort, --mtime or --numeric-owner, so the
+          # macOS runner uses `gtar`. Failing loudly beats silently
+          # emitting a non-reproducible archive that still gets a
+          # .sha256 and a signature.
+          SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)"
+          export SOURCE_DATE_EPOCH
+          if tar --version 2>/dev/null | head -1 | grep -q 'GNU tar'; then
+            TAR=tar
+          elif command -v gtar >/dev/null 2>&1; then
+            TAR=gtar
+          else
+            echo "::error::GNU tar not found — refusing to build a non-reproducible archive" >&2
+            exit 1
+          fi
+          "$TAR" --sort=name \
+              --mtime="@${SOURCE_DATE_EPOCH}" \
+              --owner=0 --group=0 --numeric-owner \
+              --format=gnu \
+              -C dist -cf - "$NAME" | gzip -n > "dist/${NAME}.tar.gz"
           # SHA256 alongside the tarball so users can pin the artefact
           # without GitHub-API round-trips.
           ( cd dist && shasum -a 256 "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256" )
@@ -295,7 +326,7 @@ jobs:
         run: |
           set -e
           VERSION="${GITHUB_REF_NAME#v}"
-          cargo install --locked cargo-cyclonedx
+          cargo install --locked --version 0.5.9 cargo-cyclonedx
           cargo cyclonedx --format json
           # cargo-cyclonedx emits `bom.json` next to Cargo.toml. Move
           # to dist/ with the proxxx-versioned name so it sits

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,32 +15,45 @@ state machine**: a CLI (scriptable, JSON-friendly), a TUI
 Proxmox VE and Proxmox Backup Server over REST + SSH + WebSocket.
 No agent on the cluster.
 
-## The three callers, one core
+## The three callers, one set of gates
 
 ```
-                    ┌─────────────────────────────┐
-                    │     pure state machine      │
-                    │       (src/app/*.rs)        │
-                    │   Action → State + SideEff  │
-                    └──────────────┬──────────────┘
-                                   │
-                       Action / SideEffect bus
-                                   │
-              ┌───────────────────┼────────────────────┐
-              │                   │                    │
         ┌───────┐         ┌───────────┐          ┌───────────┐
         │  CLI  │         │   TUI     │          │   MCP     │
         │ (clap)│         │ (ratatui) │          │ (stdio +  │
         │       │         │           │          │  HTTP)    │
-        └───────┘         └───────────┘          └───────────┘
+        └───┬───┘         └─────┬─────┘          └─────┬─────┘
+            │           Action / SideEffect bus        │
+            │            ┌──────┴──────┐               │
+            │            │ app.rs      │               │
+            │            │ reducer     │  TUI only     │
+            │            │ (pure, sync)│               │
+            │            └──────┬──────┘               │
+            │                   │                      │
+            └───────────────────┼──────────────────────┘
+                                │
+                    ┌───────────┴────────────┐
+                    │  the shared gates      │
+                    │  preflight → policy    │
+                    │  → gateway → audit     │
+                    └────────────────────────┘
 ```
 
 All three callers go through the same:
-* `app::reducer` (pure: Action × AppState → AppState + SideEffect)
-* `api::ProxmoxGateway` trait (network I/O)
+* `api::ProxmoxGateway` trait (network I/O), and inside its `post`/`put`/
+  `delete` helpers the read-only guard and the incident-freeze check —
+  so all 234 methods inherit them and a new one cannot skip them
 * `app::preflight::assess()` (11-variant risk gate)
 * `hitl::policy` (Telegram approval gate)
 * `audit::AuditLogger` (HMAC-chain mutation log)
+
+**The reducer is TUI-only.** `app.rs` holds a genuinely pure
+Action × AppState → AppState + SideEffect state machine (2059 lines,
+zero `.await`), but `AppState` is referenced only by `src/tui/`: the CLI
+and MCP paths are imperative and reach the gates directly. An earlier
+version of this document showed all three callers behind the reducer,
+which sent contributors looking for a bus that was not there — corrected
+per the 2026-09-09 audit (#282).
 
 Same gates apply to every mutation, regardless of which caller
 initiated it. There is no "skip the risk gate for MCP" path.
@@ -56,7 +69,8 @@ initiated it. There is no "skip the risk gate for MCP" path.
 | [`access/`](src/access/) | `pveum` shell-out + parser for effective permissions. `shell_quote` defends injection | sync (parser), async (shellout) |
 | [`config/`](src/config/) | TOML profile loader + secret resolution (env → file → inline → keychain). Watcher for SIGHUP reload | sync (load), async (watch) |
 | [`audit/`](src/audit/) | Append-only SQLite audit log with HMAC-SHA256 chain | sync |
-| [`app/`](src/app/) | **Pure state**. Reducer, preflight (11 risk variants), snaptree builder, cache, HA preview, batch policy. Zero I/O — testable end-to-end without a cluster | sync |
+| [`app.rs`](src/app.rs) | **Pure state**: the TUI reducer, `Action × AppState → AppState + SideEffect`. Zero I/O, zero `.await` — testable end-to-end without a cluster | sync |
+| [`app/`](src/app/) | Risk and planning helpers used by every caller: preflight (11 risk variants), snaptree builder, cache, HA preview, batch policy. `preflight`, `patch` and `cache` DO perform gateway I/O (#282 — this row previously claimed the whole module was zero-I/O, which was true only of `app.rs`) | mixed |
 | [`alerts/`](src/alerts/) | Alert daemon: engine (predicates over cluster snapshots) + dedup + notifier (slack/discord/telegram/webhook) | async |
 | [`hitl/`](src/hitl/) | Telegram daemon: long-poll, callback HMAC, replay-rejection, deny-on-timeout | async |
 | [`mcp/`](src/mcp/) | MCP server: stdio JSON-RPC + Streamable HTTP. Compile-time tool registry, SHA-256 pinned | async |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,6 +74,8 @@ initiated it. There is no "skip the risk gate for MCP" path.
 argv ─► clap ─► cli::execute_delete
               │
               ├─► find_guest(client, vmid=100) ── REST /cluster/resources
+              │      (one request; falls back to a per-node walk only
+              │       when that endpoint is unavailable — #276)
               │
               ├─► assess_deep(client, pbs, Op::Delete, &guest)
               │      └─ 11 risk variants checked; if SEVERE without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,183 @@ SemVer contract:
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-09-09
+
+Headline: **the 2026-09-09 audit backlog, closed.** A 20-category audit
+of `32e10020` produced 72 verified findings; the 36 with a concrete,
+bounded fix are all in this release. Several are behavioural breaks and
+are listed first — read those before upgrading an unattended deployment.
+
+### ⚠️ Breaking (behavioural — no schema or CLI contract change)
+
+- **The HITL daemon refuses every callback without `allowed_approvers`.**
+  The callback HMAC proved proxxx minted the approval keyboard; it never
+  established who pressed the button, so any member of `chat_id` —
+  including someone added to the group later — could approve a
+  destructive operation, which then ran with the daemon's full PVE
+  credentials. **Migration:** add the approving Telegram numeric user ids
+  to the profile's `[telegram]` section (`@userinfobot` gives you one).
+  Usernames are deliberately not accepted: a handle can be released and
+  re-registered by someone else. Absent or empty is treated as "refuse
+  everything" rather than "allow anyone", matching the posture v0.13.0
+  took for destructive MCP tools with no matching policy.
+- **`verify_tls` now defaults to `true`.** Omitting the key used to mean
+  `false`, so a minimal config silently accepted any certificate —
+  including one presented by whoever sat between proxxx and the cluster,
+  who then received the API token. **Migration:** Proxmox ships a
+  self-signed certificate, so a homelab needs an explicit
+  `verify_tls = false` or, better, `tls_pin_mode = "tofu"`. The `[pbs]`
+  block has defaulted to `true` all along; this aligns the two.
+- **An unrecognised `auth` or `tls_pin_mode` value no longer starts.**
+  Both were matched rather than validated: `auth` fell through to token
+  auth for anything that was not exactly `"password"`, and a misspelled
+  `tls_pin_mode` warned into a log file and ran unpinned. Both are now
+  rejected at load with the key and its accepted values named.
+- **`Policy.require` is enforced.** It was never compared against
+  anything — `require = 3` was satisfied by one press while the CLI
+  printed "requires 3 approval(s)". Approvals are now counted as a set of
+  distinct approver ids. **Migration:** none if you used `require = 1`;
+  otherwise the quorum now actually applies.
+
 ### Security
+
+- **Approver authentication and quorum for HITL** (#249, #250). The
+  quorum rides in the signed callback payload as a fourth segment, so a
+  keyboard minted by an older proxxx still parses and means one approver.
+- **An unreadable freeze lock now refuses the operation** (#252). Any
+  read or parse error mapped to "not frozen", so a torn write, a
+  truncated copy or a full disk silently disarmed the cluster-wide write
+  kill-switch at exactly the moment it was being relied on. Only a
+  *missing* file means thawed; a file that exists and cannot be read is
+  unknown state, and for a kill-switch unknown means stopped.
+- **Caller-supplied path segments are percent-encoded** (#253), across
+  all 111 path-building sites, plus a traversal guard at the transport
+  that applies to every request regardless of which of the 234 gateway
+  methods built the path.
+- **MCP string parameters carry a shape** (#254), enforced in the
+  dispatcher and published as a JSON Schema `pattern` in `tools/list`.
+  Not added to `registry_json`, so `registry_checksum()` — the contract
+  fingerprint callers pin — is unchanged.
+- **The audit actor is anchored on `getuid()`** (#256), not `$USER`,
+  which the calling process controls. A disagreement between the two is
+  recorded as unverified rather than silently believed.
+- **MCP HTTP authorization is a router layer** (#258), not a per-handler
+  call; `/health` is exempted explicitly rather than by omission.
+- **`--token-secret-file`** (#283), so the credential need not appear in
+  the process listing, shell history or CI logs.
+- **The audit HMAC key can be rotated without invalidating history**
+  (#281). Each row records the key that signed it, retired keys are
+  archived beside the primary, and `proxxx audit rotate-key` does the
+  swap. Previously rotating meant starting a new chain — so the correct
+  response to a host compromise destroyed the evidence. `proxxx doctor`
+  now verifies the chain rather than reporting OK when the DB merely
+  opened, which is what the README already claimed.
+- **Secret resolution order corrected in the docs** (#257) — they said
+  file-then-inline; the code does inline-then-file. An operator moving a
+  secret into a `0600` file without deleting the inline value kept using
+  the inline one. proxxx now warns when both are set.
+
+### Fixed
+
+- **`state`: a family the document never mentions is left alone** (#259).
+  It was indistinguishable from one declared empty, and an empty declared
+  family means "delete every live member" — so a dropped or mistyped
+  section header destroyed that family under `--prune`.
+- **All declaration structs reject unknown fields** (#262), so a
+  misspelled key is a parse error rather than a silently-defaulted one.
+- **Duplicate identities within a family are refused** (#261); they were
+  silently discarded by the diff's `HashMap`.
+- **The state document carries `meta.schema_version`** (#263); a document
+  newer than the binary understands is refused rather than reinterpreted.
+- **`get_guest_status` stamps `guest_type` and `node`** (#260). Every
+  container came back labelled as a QEMU VM on node `""`, and the MCP
+  tool serialised that verbatim. A 403 on the QEMU probe now surfaces
+  instead of falling through to an LXC 404 that names the wrong cause.
+- **The daemon supervises its components** (#264). Nothing polled the
+  handles, so a panicked pillar left the process alive and exiting zero —
+  and `Restart=on-failure` never fired. An unexpected exit now stops the
+  rest and exits non-zero.
+- **An interrupted converge leaves an audit record** (#265), via a Drop
+  guard, which runs on abort where a cancellation token would not.
+- **A per-node listing failure is no longer reported as "Guest not
+  found"** (#266); it is reported as indeterminate, naming the
+  unreachable nodes.
+- **Atomic writes fsync the parent directory** (#268), so the rename that
+  puts a file in place survives a power loss.
+- **`describe` says which sections it could not read** (#278) instead of
+  rendering a 403 as "this cluster has no users".
+
+### Observability
+
+- **Log records reach stderr as well as the rotating file** outside the
+  TUI (#270), so `journalctl` is no longer empty for a daemon. `RUST_LOG`
+  is honoured; the default level drops to `info`.
+- **`proxxx_daemon_component_up` and `…_last_tick_timestamp`** (#271), so
+  a stopped pillar is visible to monitoring rather than looking like a
+  quiet one.
+
+### Performance
+
+- **Guest lookup is one request** (#276) via `/cluster/resources`, not
+  1 + 2N. It runs before almost every per-vmid command and at seventeen
+  MCP dispatch sites.
+- **The TUI refresh adapts** (#277): it sleeps the remainder of its
+  target period rather than a flat 5 s on top of the cycle, warns on
+  screen when it cannot keep up, and bounds its per-node fan-out.
+
+### CI and verification
+
+- **`cargo clippy` runs with `-D warnings`** (#272). The curated
+  pedantic/nursery configuration was decorative; the tree turned out to be
+  clean at that level, so there is no backlog.
+- **ruff, shellcheck and gitleaks gates** (#274) — 10 shell and 2 Python
+  files shipped unchecked, including the script that rewrites Rust source
+  and opens supply-chain PRs.
+- **A coverage job and an on-demand live-tier workflow** (#275), the
+  latter recording its result against a commit SHA.
+- **npm is watched by Dependabot and gated by `npm audit`** (#280), and
+  `cargo-audit`, `cargo-deny` and `cargo-cyclonedx` are version-pinned —
+  the tools deciding whether the build passes its security gate were
+  fetched unpinned on every run.
+- **Two tests that could not fail now can** (#273). One asserted on two
+  local variables while named for lock detection; it passed with lock
+  detection deleted.
+
+### Packaging
+
+- **Release tarballs are reproducible** (#279): `--sort=name`,
+  `--mtime=@SOURCE_DATE_EPOCH`, normalised ownership and `gzip -n`. The
+  published `.sha256` now attests to the source rather than to one CI run.
+
+### Contract
+
+- **The Rust library API is a declared surface** (#284), enumerated in
+  `src/lib.rs` and named in the SemVer contract above. It is linked by
+  the proxima desktop UI and previously had no policy at all.
+- **`--format json-envelope`** wraps the payload in
+  `{"proxxx": "<version>", "data": …}` for consumers that must work
+  against several versions at once. `--format json` is unchanged.
+
+### Documentation
+
+- **ARCHITECTURE.md describes this system** (#282). Its diagram put all
+  three callers behind `app::reducer`, which is TUI-only, and called all
+  of `app/` zero-I/O, which is true only of `app.rs`.
+- **The production checklist gains upgrade, rollback and backup**
+  (#269), including which files must survive a host rebuild and that the
+  cache DB refuses to open under an older binary.
+- **The shipped systemd unit no longer claims** that replay protection
+  survives a restart (#267) — it does not, and the unit's own
+  `Restart=on-failure` makes those restarts routine.
+
+### Dependencies
+
+- `der` 0.8.0 → 0.8.2 and `wnaf` 0.14.0 → 0.14.1, both yanked upstream
+  and reached transitively through russh. Pre-existing drift, unrelated
+  to the audit work; `cargo deny check` and `cargo audit --deny warnings`
+  are green again.
+
+### Also in this release
 
 - **The TUI-typed SSH passphrase redacts `Debug` as a type property.** `Action::SshPassphraseInput` and `SideEffect::SetSshPassphraseAndOpen` carried the typed passphrase as a plain `String` inside `Debug`-derived enums — no site logs actions today and the op queue persists through the closed `PersistedOp` set, so nothing leaked, but the invariant since v0.13.2 is that redaction never depends on call-site discipline. Both now carry `SecretString` (`{:?}` → `[REDACTED]`, proven by test), the submit path moves the input buffer into the wrapper via `mem::take` so the plaintext is zeroized instead of surviving in a freed allocation, and `ssh_handler.set_passphrase` accepts the wrapper end-to-end. Flagged while triaging CodeQL's new Rust queries (alert #45).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ SemVer contract:
   major bump).
 - Config schema is backwards compatible.
 - MCP tool registry is append-only.
+- **Rust library API** — the crate is linked by the proxima desktop UI.
+  The supported surface (`api`, `config`, `app::preflight`,
+  `state::model`) is additive within a minor; everything else is an
+  implementation detail. Enumerated in `src/lib.rs`.
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,9 +188,9 @@ are listed first — read those before upgrading an unattended deployment.
 ### Dependencies
 
 - `der` 0.8.0 → 0.8.2 and `wnaf` 0.14.0 → 0.14.1, both yanked upstream
-  and reached transitively through russh. Pre-existing drift, unrelated
-  to the audit work; `cargo deny check` and `cargo audit --deny warnings`
-  are green again.
+  and reached transitively through russh. Landed separately in #245
+  while this branch was open — noted here because it is what took
+  `cargo deny check` green again for this release.
 
 ### Also in this release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ either with `--no-verify` is owned by the bypasser. Stages:
 | - | --- | --- | --- |
 | 0 | secret regression scan | Looks for tokens / passwords accidentally committed | <1 s |
 | 1 | `cargo fmt --check` | Code style | ~3 s |
-| 2 | `cargo clippy --release --all-targets` | Lints, deny tier (`unwrap_used`, `expect_used`, `panic`, `todo`, `await_holding_lock`) | 10–60 s |
+| 2 | `cargo clippy --release --all-targets -- -D warnings` | Lints, deny tier (`unwrap_used`, `expect_used`, `panic`, `todo`, `await_holding_lock`) | 10–60 s |
 | 3 | `cargo audit --deny warnings` | Supply-chain CVEs from `Cargo.lock` | 3–5 s |
 | 4 | `cargo deny check` | License whitelist + banned crates + crates.io-only sources + wildcard ban | 2–4 s |
 | 5 | `cargo test --release --all-targets` | All unit + integration + wiremock + proptest cases (~25 properties × 256 random cases) | 10–90 s |
@@ -82,6 +82,20 @@ cp tests/live/env.local.example tests/live/env.local
 Stages 6 + 7 require a reachable PVE cluster. If you don't have one,
 **explicitly skip stages 6 + 7** in your PR description — a maintainer
 will run them. Don't silently bypass.
+
+### Script gates (CI also runs these)
+
+| # | Command | What it enforces | Time |
+| :-- | :--- | :--- | :--- |
+| 6 | `ruff check .` | Python lint (`scripts/`, `assets/`) | ~1 s |
+| 7 | `shellcheck -S error tests/live/*.sh scripts/*.sh` | Shell errors in the live harnesses | ~1 s |
+| 8 | `gitleaks detect` | Committed secrets (CI scans history too) | ~2 s |
+
+Added by the 2026-09-09 audit (#274): these three surfaces shipped
+unchecked. `shellcheck` starts at `-S error` deliberately — the tree
+carries style and warning findings that are real but not worth blocking
+on today, and a gate that is red by default is a gate people learn to
+ignore.
 
 ## Live-cluster verification
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "proxxx"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,14 @@ tokio = { version = "1", features = ["full"] }
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "cookies", "stream", "multipart"] }
 
+# Real-uid + passwd lookup for the audit trail's operator field: `$USER`
+# is caller-controlled, so the identity written into the HMAC-chained log
+# is anchored on `getuid()` instead (audit #256). Also used by
+# tests/resilience_chaos_e2e.rs to raise signals at the current pid.
+# Already in the build graph transitively via tokio + rustls, so this
+# declaration costs nothing.
+libc = "0.2"
+
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -168,11 +176,6 @@ serial_test = "4"
 # terminate on any graph (incl. cycles); the audit HMAC chain must
 # detect a single-byte mutation anywhere in any sequence.
 proptest = { version = "1", default-features = false, features = ["std"] }
-# Used by tests/resilience_chaos_e2e.rs to raise SIGTERM/SIGHUP at
-# the current pid so the signal-handler invariants can be verified
-# in-process. `libc` is already pulled in transitively by tokio +
-# rustls — declaring it as a dev-dep doesn't add to the build graph.
-libc = "0.2"
 
 # ── Benchmark binaries ──────────────────────────────────
 # Each `[[bench]]` produces an isolated binary so failures or

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxxx"
-version = "0.13.3"
+version = "0.14.0"
 edition = "2021"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 description = "The ultimate Proxmox TUI — fast, secure, uncompromising"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,13 @@ cast_possible_wrap = "allow"
 # `too_many_arguments` flags clap dispatchers and the `ProxmoxGateway`
 # trait — both have wide signatures because the underlying PVE API
 # does. Re-evaluate per-fn if a real legibility issue surfaces.
-too_many_lines = "allow"
+# Audit #272: back to `warn` — the blanket allow also covered
+# `tui::dispatch_side_effect` and `tui::run`, which are deep rather than
+# flat, so nothing reported when a function doubled in size. The genuine
+# exemptions (wide, flat, exhaustive dispatch over a closed enum) now
+# carry a per-function `#[allow]` naming themselves, which is a visible
+# decision rather than a silence.
+too_many_lines = "warn"
 too_many_arguments = "allow"
 
 # Layout: a const or struct decl colocated with its first use is

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ proxxx is designed for operators who need auditability, data sovereignty, and su
 | **Cryptographic chain verification** | `proxxx audit verify` walks every entry, recomputes the HMAC chain from the keyed root, and reports the first broken link. CI-friendly: exits 0 on pass, 1 on violation — wire it into your compliance pipeline. |
 | **Export for SIEM** | `proxxx audit export --format json` or `--format csv` — pipe into Splunk, Elastic, Wazuh, or any log aggregator without an agent. |
 | **Supply-chain** | Every release ships: SHA-256 sidecar, sigstore keyless cosign signature (pinned to the exact workflow path, offline-verifiable, transparency-log proof embedded), and a CycloneDX SBOM from `Cargo.lock`. Audit with `cosign verify-blob` + `grype` / `trivy`. |
-| **Self-diagnostic** | `proxxx doctor` validates config, cluster connectivity, auth, Telegram HITL, PBS, SSH key, and audit log integrity in one pass. Exits 0 if all critical checks pass. |
-| **Secrets hygiene** | All secret values live in `Zeroizing<String>` (heap-wiped on Drop). HMAC and audit keys are stored at 0600 paths; proxxx refuses to start if a key file has world-readable permissions. |
+| **Self-diagnostic** | `proxxx doctor` validates config, cluster connectivity, auth, Telegram HITL, PBS, SSH key, and audit-chain integrity (it recomputes the HMAC chain, not just that the DB opens) in one pass. Exits 0 if all critical checks pass. |
+| **Secrets hygiene** | All secret values live in `SecretString` — `Debug` prints `[REDACTED]` (not even the length), no `Display` and no `Serialize` so interpolating or serialising one is a *compile error*, and the heap bytes are zeroized on drop. HMAC and audit keys are stored at 0600 paths; proxxx refuses to use a key file with looser permissions. |
 
 > **Note:** proxxx is a management tool, not a compliance product. `proxxx audit verify` provides integrity assurance for the local mutation log; it does not replace a SIEM or a formal audit trail required by a certification body. Use it as one control layer in a broader NIS2 / ISO 27001 implementation.
 
@@ -309,7 +309,7 @@ Default location follows the `directories` project-dirs convention:
 | Linux | `~/.config/proxxx/config.toml` |
 | macOS | `~/Library/Application Support/dev.proxxx.proxxx/config.toml` |
 
-Secrets resolve in order: CLI flag → `PROXXX_TOKEN_SECRET` env → `token_secret_file` (0600 enforced) → inline TOML → OS keychain. Loaded values live in `Zeroizing<String>` and are wiped from the heap on `Drop`.
+Secrets resolve in order: CLI flag → `PROXXX_TOKEN_SECRET` env → inline TOML → `token_secret_file` (0600 enforced) → OS keychain. **Inline beats the file reference** — when moving a secret into a file, delete the inline value or it keeps winning (proxxx warns when both are set). Loaded values live in `SecretString`: redacting `Debug`, no `Display`, no `Serialize`, zeroized on drop.
 
 | Optional section | Unlocks |
 | :--- | :--- |

--- a/assets/build.py
+++ b/assets/build.py
@@ -36,6 +36,7 @@ Idempotent: re-run after editing the source PNG to refresh everything.
 """
 
 from pathlib import Path
+
 from PIL import Image, ImageDraw
 
 ROOT = Path(__file__).resolve().parent

--- a/docs/guide/production-checklist.md
+++ b/docs/guide/production-checklist.md
@@ -159,6 +159,30 @@ The bot token resolves with the same hierarchy as the PVE
 token: `PROXXX_TELEGRAM_BOT_TOKEN` env, `bot_token_file`,
 keychain, inline.
 
+### `[ ]` Set `allowed_approvers` — without it the daemon refuses every callback
+
+The callback signature proves *proxxx* minted the approval keyboard. It
+does not establish *who pressed the button*: Telegram delivers the
+buttons to everyone who can see the message. Without an allowlist, any
+member of `chat_id` — including someone added to the group later — could
+approve a destructive operation, which then runs with the daemon's full
+PVE credentials.
+
+```toml
+[telegram]
+chat_id = "-1001234567890"
+allowed_approvers = [123456789, 987654321]   # numeric ids, not usernames
+```
+
+Get each approver's numeric id by having them message `@userinfobot`.
+Usernames are deliberately not accepted: a Telegram handle can be
+released and re-registered by someone else, so an allowlist keyed on
+handles is forgeable.
+
+An absent or empty list is treated as "refuse everything" rather than
+"allow anyone" — the same fail-closed posture as a destructive MCP tool
+with no matching policy.
+
 ### `[ ]` Configure `[[policies]]` rules
 
 ```toml
@@ -192,9 +216,12 @@ User=proxxx-ops
 ExecStart=/usr/local/bin/proxxx hitl serve
 Restart=on-failure
 RestartSec=5
-# Replay protection survives single-process restart via
-# session-local consumed-txn-id set; no persistence layer
-# needed.
+# NOTE: replay protection is session-local — a restart clears
+# the consumed-txn-id set, so an approval callback that was
+# already used becomes usable again until the keyboard is
+# superseded. Approver authorisation (allowed_approvers) and
+# the per-request txn_id nonce are the controls that survive
+# a restart. See src/hitl/pending.rs ("Scope honesty").
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/guide/production-checklist.md
+++ b/docs/guide/production-checklist.md
@@ -216,6 +216,12 @@ User=proxxx-ops
 ExecStart=/usr/local/bin/proxxx hitl serve
 Restart=on-failure
 RestartSec=5
+# Log records go to stderr as well as the rotating file, so
+# `journalctl -u proxxx-hitl` shows warnings and errors — including
+# the freeze lock becoming unreadable and TLS pinning being skipped.
+# Raise verbosity per-crate when debugging:
+#   Environment=RUST_LOG=proxxx=debug,russh=debug
+Environment=RUST_LOG=proxxx=info
 # NOTE: replay protection is session-local — a restart clears
 # the consumed-txn-id set, so an approval callback that was
 # already used becomes usable again until the keyboard is
@@ -473,6 +479,71 @@ proxxx audit verify        # exits non-zero if the chain has been tampered with
 Run this from a host or account that **can't write** the audit DB — a
 verifier that shares the operator's write access can't prove much. Wire
 the non-zero exit into your monitoring.
+
+## 11. Upgrade, rollback and backup
+
+### `[ ]` Know what must survive the host
+
+proxxx keeps two kinds of state in the platform data directory, and only
+one of them matters if the machine is rebuilt.
+
+| Path | Must be preserved? | Why |
+| :--- | :--- | :--- |
+| `audit.db` | **Yes** | The only record of who issued which mutation. Not reconstructible from anything else. |
+| `audit.key` | **Yes** | 32 bytes. Without it no surviving copy of `audit.db` can be verified — losing the key alone is enough to make the trail worthless. |
+| `freeze.lock`, `freeze.<profile>.lock` | No | Runtime kill-switch state. Absent means thawed, which is the correct default after a rebuild. |
+| `cache.db` | No | Cluster snapshots and the operation queue. Regenerates from the cluster on next start. |
+| `proxxx.log*` | No | 14 daily rotations, forensic convenience only. |
+
+Config lives separately under the config directory and is recreatable
+with `proxxx init`, though backing it up saves re-entering the profile.
+
+Point `PROXXX_AUDIT_DIR` at a volume that is already backed up if you
+would rather not add a new backup target:
+
+```bash
+# systemd unit
+Environment=PROXXX_AUDIT_DIR=/var/lib/proxxx/audit
+```
+
+### `[ ]` Upgrade
+
+```bash
+systemctl stop proxxx-hitl          # let in-flight approvals settle
+# verify + install the new binary (section 1)
+systemctl start proxxx-hitl
+proxxx doctor                       # confirms config, auth and audit chain
+```
+
+Stopping first is deliberate: an approval that is parked when the
+process is replaced is lost from the daemon's in-memory replay window,
+and a request approved during the swap has nothing listening for the
+callback.
+
+What is compatible across an upgrade:
+
+- **Config** — backwards compatible. New keys default; old keys keep working.
+- **Audit DB** — backwards compatible. v1 rows keep verifying under the
+  v1 formula while new rows are written as v2.
+- **Declared state TOML** — carries `meta.schema_version`. A document
+  newer than the binary understands is refused rather than reinterpreted.
+- **Cache DB** — **not** backwards compatible; see rollback.
+
+### `[ ]` Rollback
+
+```bash
+systemctl stop proxxx-hitl
+# reinstall the previous binary
+rm -f "$(proxxx doctor --json | jq -r '.cache_path // empty')"   # or delete cache.db by hand
+systemctl start proxxx-hitl
+```
+
+The cache database records a schema version and **refuses to open when
+that version is newer than the running binary** — an older proxxx will
+report `cache DB schema version N is newer than this binary's M` rather
+than silently misreading it. Deleting `cache.db` is safe: it is
+regenerated from the cluster on the next start. The audit DB and its key
+need no action, and must not be deleted.
 
 ## See also
 

--- a/docs/guide/production-checklist.md
+++ b/docs/guide/production-checklist.md
@@ -480,6 +480,27 @@ Run this from a host or account that **can't write** the audit DB — a
 verifier that shares the operator's write access can't prove much. Wire
 the non-zero exit into your monitoring.
 
+### `[ ]` Rotate the audit key after a compromise — it no longer costs you the history
+
+The HMAC key is 32 bytes beside the database it protects, so anyone who
+can read that file can forge the chain. If the host is ever compromised,
+rotate:
+
+```bash
+proxxx audit rotate-key      # archives the old key, starts signing with a new one
+proxxx audit verify          # every entry still verifies, old and new
+```
+
+Until v0.13.4 rotating meant deleting the key and starting a new chain,
+which destroyed the verifiability of exactly the history an
+investigation needs — so in practice the key was permanent. Each row now
+records which key signed it, and retired keys are archived beside the
+primary as `audit.key.<id>`.
+
+**Back up the retired keys.** They are part of the trail: without one,
+the rows it signed can no longer be verified, and `proxxx audit verify`
+counts them as failures rather than skipping them.
+
 ## 11. Upgrade, rollback and backup
 
 ### `[ ]` Know what must survive the host
@@ -491,6 +512,7 @@ one of them matters if the machine is rebuilt.
 | :--- | :--- | :--- |
 | `audit.db` | **Yes** | The only record of who issued which mutation. Not reconstructible from anything else. |
 | `audit.key` | **Yes** | 32 bytes. Without it no surviving copy of `audit.db` can be verified — losing the key alone is enough to make the trail worthless. |
+| `audit.key.retired-*` | **Yes** | Keys retired by `audit rotate-key`. Each still proves the rows it signed; losing one turns those rows into verification failures. |
 | `freeze.lock`, `freeze.<profile>.lock` | No | Runtime kill-switch state. Absent means thawed, which is the correct default after a rebuild. |
 | `cache.db` | No | Cluster snapshots and the operation queue. Regenerates from the cluster on next start. |
 | `proxxx.log*` | No | 14 daily rotations, forensic convenience only. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,14 @@
 # CLI reference
 
-Every command supports `--format json|table|plain`. Default is `table`.
+Every command supports `--format json|json-envelope|table|plain`. Default
+is `table`.
+
+`json-envelope` wraps the same payload as `json` in
+`{"proxxx": "<version>", "data": …}`. Use it when a consumer must work
+against more than one proxxx version at once — a CI fleet mid-rollout, a
+wrapper supporting the last two releases — so the output says which
+contract produced it instead of the caller having to shell out to
+`proxxx --version`. `json` itself is unchanged and stays additive-only.
 JSON output is part of the public contract — additive-only changes
 within a major version.
 
@@ -8,8 +16,15 @@ within a major version.
 
 ```
 --profile <NAME>           Connection profile name (default: top-level)
---format <FORMAT>          Output format: json | table | plain (default: table)
---token-secret <VALUE>     Override token from config / env / keychain
+--format <FORMAT>          Output format: json | json-envelope | table | plain
+                           (default: table)
+--token-secret <VALUE>     Override token from config / env / keychain.
+                           VISIBLE IN THE PROCESS LISTING — prefer the
+                           flag below, PROXXX_TOKEN_SECRET, or the
+                           keychain, especially for `daemon serve`.
+--token-secret-file <PATH> Read the token secret from a file. Leaves
+                           nothing in argv. Wins over --token-secret
+                           when both are given.
 --secure                   Require Telegram approval for every destructive op
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -221,12 +221,28 @@ For each of `token_secret`, `password`, `pbs.token_secret`:
 1. CLI flag (`--token-secret VALUE`)
 2. Env var (`PROXXX_TOKEN_SECRET`, `PROXXX_PASSWORD`,
    `PROXXX_PBS_TOKEN_SECRET`)
-3. File reference (`<...>_secret_file = "..."`)
-4. Inline TOML value (`<...>_secret = "..."`)
+3. **Inline TOML value** (`<...>_secret = "..."`)
+4. **File reference** (`<...>_secret_file = "..."`)
 5. OS keychain (service `proxxx`, key matches the field name)
 
-The first one that resolves wins. Loaded values live in
-`Zeroizing<String>` and are wiped from the heap on Drop.
+The first one that resolves wins.
+
+::: warning Inline beats the file reference
+Steps 3 and 4 were documented in the opposite order until v0.13.4. If
+you are moving a secret out of the TOML into a `0600` file, **delete the
+inline value** — otherwise the stale inline secret keeps winning, your
+file is never read, and rotating it has no effect. proxxx logs a warning
+when both are set.
+:::
+
+Loaded values live in [`SecretString`](https://github.com/fabriziosalmi/proxxx/blob/main/src/util/secret.rs):
+`Debug` prints `[REDACTED]` (not even the length, which would leak which
+credential class it is), there is no `Display` and no `Serialize`, so
+interpolating one into a string or a JSON dump is a compile error, and
+the wrapped value is zeroized on drop. Note the guarantee covers the
+value once constructed — the `toml` parse tree still holds an unwiped
+copy of any inline secret until config load completes, which is another
+reason to prefer the file or the keychain.
 
 ## Environment variables
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -35,7 +35,15 @@ verify_tls    = true                  # validate the cluster cert. DEFAULT true
                                       # since v0.13.4 (was false). Proxmox ships
                                       # a self-signed cert: set false deliberately
                                       # for a homelab, or prefer tls_pin_mode.
-rate_limit    = 10                    # max API requests/second (default 10)
+rate_limit    = 10                    # max API requests/second (default 10).
+                                      # ALSO governs TUI refresh latency: a
+                                      # refresh costs ~3 requests per node, so
+                                      # on an N-node cluster a cycle takes
+                                      # roughly 3N/rate_limit seconds. The TUI
+                                      # targets a 5 s refresh and warns on
+                                      # screen when it cannot keep up (#277).
+                                      # 3 nodes ≈ 1 s; 20 nodes ≈ 6 s;
+                                      # 50 nodes ≈ 15 s at the default.
 read_only     = false                 # true → refuse all mutations on this
                                       # profile client-side (reads still work);
                                       # exit code 8. Default false. Pair with a

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -31,7 +31,10 @@ token_secret  = "..."                 # plain string OR
 token_secret_file = "/etc/proxxx/token"
 password      = "..."                 # only if auth = "password"
 password_file = "..."
-verify_tls    = false
+verify_tls    = true                  # validate the cluster cert. DEFAULT true
+                                      # since v0.13.4 (was false). Proxmox ships
+                                      # a self-signed cert: set false deliberately
+                                      # for a homelab, or prefer tls_pin_mode.
 rate_limit    = 10                    # max API requests/second (default 10)
 read_only     = false                 # true → refuse all mutations on this
                                       # profile client-side (reads still work);
@@ -149,6 +152,14 @@ Used by HITL and alert routing.
 [telegram]
 bot_token = "123456:ABC..."           # from @BotFather
 chat_id   = -1001234567890            # from getUpdates response
+allowed_approvers = [123456789]       # REQUIRED. Telegram numeric user ids
+                                      # permitted to approve/deny. The callback
+                                      # HMAC proves proxxx minted the keyboard,
+                                      # not who pressed it — without this list
+                                      # any member of chat_id could approve a
+                                      # destructive op. Numeric ids only
+                                      # (usernames are mutable). Absent or
+                                      # empty => every callback is refused.
 ```
 
 ## `[[policies]]` (HITL)

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -45,7 +45,10 @@ path is reachable, and its keymap is navigation-only.
 | `Esc` | Clear an active filter; quit when there's none |
 | `q` | Quit |
 
-Scales to hundreds of guests: type `/` to narrow, `s` to surface the
+Scales to hundreds of guests (guest count does not affect request
+count — guests arrive in per-node list responses). What does bind is
+NODE count: see `rate_limit` in [configuration](/reference/configuration)
+for the refresh-latency arithmetic. Type `/` to narrow, `s` to surface the
 busy ones (cpu↓ / mem↓). Search and sort are pure view-state — still
 strictly read-only.
 

--- a/scripts/repin-cloudimg.py
+++ b/scripts/repin-cloudimg.py
@@ -42,7 +42,8 @@ UA = {"User-Agent": "proxxx-repin-cloudimg/1.0 (+https://github.com/fabriziosalm
 
 def fetch(url: str) -> str:
     req = urllib.request.Request(url, headers=UA)
-    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310 (https only, official hosts)
+    # https only, official hosts — the URL comes from the pinned registry.
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
         return resp.read().decode("utf-8", errors="replace")
 
 

--- a/src/alerts/engine.rs
+++ b/src/alerts/engine.rs
@@ -44,6 +44,7 @@ pub struct ClusterSnapshot {
 /// Evaluate every rule against the snapshot. Returns:
 /// - the events that should fire NOW (subject to caller-side dedup)
 /// - the updated `EngineState` to feed back into the next call
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub fn evaluate(
     rules: &[AlertRuleConfig],
     snap: &ClusterSnapshot,

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -38,6 +38,72 @@ const fn type_path(t: crate::api::types::GuestType) -> &'static str {
 /// surface accepts user ids like `root@pam` — the `@` MUST be encoded
 /// in the URL path or some PVE versions misroute. We don't pull a
 /// crate for this; the rules are simple.
+/// Refuse a request path containing a relative segment.
+///
+/// Percent-encoding each caller-supplied segment is what stops these
+/// from being constructed; this is the chokepoint that makes a forgotten
+/// call site loud instead of exploitable. Checked on a lowercased,
+/// partially percent-decoded view so `%2e%2e` cannot slip past.
+fn reject_path_traversal(path: &str) -> Result<()> {
+    let normalised = path
+        .to_ascii_lowercase()
+        .replace("%2e", ".")
+        .replace("%2f", "/");
+    let suspicious = normalised
+        .split(|c| c == '/' || c == '?' || c == '&' || c == '=')
+        .any(|seg| seg == ".." || seg == ".");
+    if suspicious {
+        anyhow::bail!(
+            "refusing request path containing a relative segment: {path:?} — \
+             a path component was built from an unencoded caller-supplied value"
+        );
+    }
+    Ok(())
+}
+
+/// Percent-encode a value being placed in a **path segment**.
+///
+/// Deliberately more permissive than [`urlenc`], which is for query
+/// values. RFC 3986 `pchar` allows `:` `@` and the sub-delims inside a
+/// segment, and PVE identifiers use them heavily — a UPID is
+/// `UPID:node:hex:hex:name:type:id:user@realm:`. Encoding those would
+/// change the path PVE receives for every task call.
+///
+/// What this DOES encode is anything that could end the segment or
+/// change its meaning: `/`, `?`, `#`, `%`, and every control or
+/// non-ASCII byte. Combined with [`reject_path_traversal`] at the
+/// transport, a caller-supplied value can no longer escape the segment
+/// it was written into.
+fn urlenc_segment(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'_'
+            | b'.'
+            | b'~'
+            | b':'
+            | b'@'
+            | b'!'
+            | b'$'
+            | b'&'
+            | b'\''
+            | b'('
+            | b')'
+            | b'*'
+            | b'+'
+            | b','
+            | b';'
+            | b'=' => out.push(b as char),
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
 fn urlenc(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for b in s.bytes() {
@@ -138,11 +204,18 @@ async fn resolve_tofu_cert(config: &ProfileConfig) -> Result<Option<Vec<u8>>> {
         None => return Ok(None),
     };
     if mode != "tofu" {
-        warn!(
-            "tls_pin_mode = {:?} is not recognised (expected \"tofu\"); skipping pinning",
+        // #255 — refuse rather than silently downgrade. The operator who
+        // sets this key is precisely the one who decided the default
+        // trust posture was insufficient; a misspelling that quietly
+        // disables pinning is the worst outcome. `load_config` rejects
+        // this earlier, so reaching here means the config was built
+        // programmatically — still not a reason to run unpinned.
+        anyhow::bail!(
+            "tls_pin_mode = {:?} is not recognised (expected \"tofu\", or omit the \
+             key for no pinning) — refusing to connect rather than silently \
+             skipping certificate pinning",
             config.tls_pin_mode
         );
-        return Ok(None);
     }
     if let Some(der) =
         crate::api::tls_pin::load_pinned_cert(&config.url).context("loading pinned TLS cert")?
@@ -311,6 +384,18 @@ impl PxClient {
     where
         F: FnMut(&Client) -> RequestBuilder,
     {
+        // Audit 2026-09-09 (#253) — traversal guard, applied to every
+        // request regardless of which of the 234 gateway methods built
+        // the path.
+        //
+        // The per-segment `urlenc` calls are the real fix; this is the
+        // net that catches a method that forgets one, or a new method
+        // added later. A `..` segment survives as a dot-segment and is
+        // resolved away by the URL parser, so a value carrying one
+        // silently retargets the request at an endpoint the calling
+        // method never names.
+        reject_path_traversal(path)?;
+
         let mut attempt: u32 = 0;
         let mut auth_retry_done = false;
         loop {
@@ -627,12 +712,18 @@ impl ProxmoxGateway for PxClient {
         // Fetch both QEMU and LXC in parallel
         let (qemu_result, lxc_result) = tokio::join!(
             async {
-                self.get::<ApiResponse<Vec<Guest>>>(&format!("/nodes/{node}/qemu"))
-                    .await
+                self.get::<ApiResponse<Vec<Guest>>>(&format!(
+                    "/nodes/{node}/qemu",
+                    node = urlenc_segment(node)
+                ))
+                .await
             },
             async {
-                self.get::<ApiResponse<Vec<Guest>>>(&format!("/nodes/{node}/lxc"))
-                    .await
+                self.get::<ApiResponse<Vec<Guest>>>(&format!(
+                    "/nodes/{node}/lxc",
+                    node = urlenc_segment(node)
+                ))
+                .await
             }
         );
 
@@ -660,18 +751,28 @@ impl ProxmoxGateway for PxClient {
 
     async fn get_guest_status(&self, node: &str, vmid: u32) -> Result<Guest> {
         // Try QEMU first, then LXC
-        let qemu_path = format!("/nodes/{node}/qemu/{vmid}/status/current");
+        let qemu_path = format!(
+            "/nodes/{node}/qemu/{vmid}/status/current",
+            node = urlenc_segment(node)
+        );
         if let Ok(resp) = self.get::<ApiResponse<Guest>>(&qemu_path).await {
             return Ok(resp.data);
         }
-        let lxc_path = format!("/nodes/{node}/lxc/{vmid}/status/current");
+        let lxc_path = format!(
+            "/nodes/{node}/lxc/{vmid}/status/current",
+            node = urlenc_segment(node)
+        );
         let resp: ApiResponse<Guest> = self.get(&lxc_path).await?;
         Ok(resp.data)
     }
 
     async fn get_storage_pools(&self, node: &str) -> Result<Vec<StoragePool>> {
-        let resp: ApiResponse<Vec<StoragePool>> =
-            self.get(&format!("/nodes/{node}/storage")).await?;
+        let resp: ApiResponse<Vec<StoragePool>> = self
+            .get(&format!(
+                "/nodes/{node}/storage",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -684,7 +785,9 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<TaskLog> {
         let resp: ApiResponse<Vec<super::types::TaskLogLine>> = self
             .get(&format!(
-                "/nodes/{node}/tasks/{upid}/log?start={start}&limit={limit}"
+                "/nodes/{node}/tasks/{upid}/log?start={start}&limit={limit}",
+                node = urlenc_segment(node),
+                upid = urlenc_segment(upid)
             ))
             .await?;
         Ok(TaskLog {
@@ -703,7 +806,10 @@ impl ProxmoxGateway for PxClient {
             crate::api::types::GuestType::Qemu => "qemu",
             crate::api::types::GuestType::Lxc => "lxc",
         };
-        let path = format!("/nodes/{node}/{type_str}/{vmid}/config");
+        let path = format!(
+            "/nodes/{node}/{type_str}/{vmid}/config",
+            node = urlenc_segment(node)
+        );
         let resp: ApiResponse<std::collections::HashMap<String, serde_json::Value>> =
             self.get(&path).await?;
 
@@ -734,7 +840,11 @@ impl ProxmoxGateway for PxClient {
         // accepts the raw UPID in the path — no URL-encoding needed
         // for these specific characters in PVE's pveproxy.
         let resp: ApiResponse<crate::api::types::TaskStatus> = self
-            .get(&format!("/nodes/{node}/tasks/{upid}/status"))
+            .get(&format!(
+                "/nodes/{node}/tasks/{upid}/status",
+                node = urlenc_segment(node),
+                upid = urlenc_segment(upid)
+            ))
             .await?;
         Ok(resp.data)
     }
@@ -747,7 +857,13 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<String> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<String> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/status/start"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/status/start",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
@@ -784,7 +900,13 @@ impl ProxmoxGateway for PxClient {
         let _ = force;
         let kind = type_path(guest_type);
         let resp: ApiResponse<String> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/status/stop"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/status/stop",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
@@ -807,7 +929,10 @@ impl ProxmoxGateway for PxClient {
         };
         let resp: ApiResponse<String> = self
             .post(
-                &format!("/nodes/{node}/{kind}/{vmid}/status/shutdown"),
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/status/shutdown",
+                    node = urlenc_segment(node)
+                ),
                 params,
             )
             .await?;
@@ -822,7 +947,13 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<String> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<String> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/status/reboot"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/status/reboot",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
@@ -835,7 +966,13 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<String> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<String> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/status/suspend"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/status/suspend",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
@@ -848,24 +985,44 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<String> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<String> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/status/resume"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/status/resume",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
 
     async fn startall_node(&self, node: &str) -> Result<String> {
-        let resp: ApiResponse<String> = self.post(&format!("/nodes/{node}/startall"), &[]).await?;
+        let resp: ApiResponse<String> = self
+            .post(
+                &format!("/nodes/{node}/startall", node = urlenc_segment(node)),
+                &[],
+            )
+            .await?;
         Ok(resp.data)
     }
 
     async fn stopall_node(&self, node: &str) -> Result<String> {
-        let resp: ApiResponse<String> = self.post(&format!("/nodes/{node}/stopall"), &[]).await?;
+        let resp: ApiResponse<String> = self
+            .post(
+                &format!("/nodes/{node}/stopall", node = urlenc_segment(node)),
+                &[],
+            )
+            .await?;
         Ok(resp.data)
     }
 
     async fn suspendall_node(&self, node: &str) -> Result<String> {
-        let resp: ApiResponse<String> =
-            self.post(&format!("/nodes/{node}/suspendall"), &[]).await?;
+        let resp: ApiResponse<String> = self
+            .post(
+                &format!("/nodes/{node}/suspendall", node = urlenc_segment(node)),
+                &[],
+            )
+            .await?;
         Ok(resp.data)
     }
 
@@ -877,8 +1034,12 @@ impl ProxmoxGateway for PxClient {
         // digest. For a MVP "show me what's there" view, returning
         // the raw `data` value keeps the wire format honest and lets
         // the CLI pretty-print without lossy conversion.
-        let resp: ApiResponse<serde_json::Value> =
-            self.get(&format!("/nodes/{node}/apt/repositories")).await?;
+        let resp: ApiResponse<serde_json::Value> = self
+            .get(&format!(
+                "/nodes/{node}/apt/repositories",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -889,7 +1050,8 @@ impl ProxmoxGateway for PxClient {
         let resp: ApiResponse<String> = self
             .get(&format!(
                 "/nodes/{node}/apt/changelog?name={}",
-                urlenc(package)
+                urlenc(package),
+                node = urlenc_segment(node)
             ))
             .await?;
         Ok(resp.data)
@@ -899,8 +1061,12 @@ impl ProxmoxGateway for PxClient {
         &self,
         node: &str,
     ) -> Result<Vec<crate::api::types::AptInstalledPackage>> {
-        let resp: ApiResponse<Vec<crate::api::types::AptInstalledPackage>> =
-            self.get(&format!("/nodes/{node}/apt/versions")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::AptInstalledPackage>> = self
+            .get(&format!(
+                "/nodes/{node}/apt/versions",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -917,6 +1083,7 @@ impl ProxmoxGateway for PxClient {
             "/nodes/{node}/{kind}/{vmid}/rrddata?timeframe={}&cf={}",
             timeframe.as_pve_str(),
             cf.as_pve_str(),
+            node = urlenc_segment(node),
         );
         let resp: ApiResponse<Vec<crate::api::types::RrdPoint>> = self.get(&path).await?;
         Ok(resp.data)
@@ -932,6 +1099,7 @@ impl ProxmoxGateway for PxClient {
             "/nodes/{node}/rrddata?timeframe={}&cf={}",
             timeframe.as_pve_str(),
             cf.as_pve_str(),
+            node = urlenc_segment(node),
         );
         let resp: ApiResponse<Vec<crate::api::types::RrdPoint>> = self.get(&path).await?;
         Ok(resp.data)
@@ -949,6 +1117,7 @@ impl ProxmoxGateway for PxClient {
             urlenc(storage),
             timeframe.as_pve_str(),
             cf.as_pve_str(),
+            node = urlenc_segment(node),
         );
         let resp: ApiResponse<Vec<crate::api::types::RrdPoint>> = self.get(&path).await?;
         Ok(resp.data)
@@ -996,7 +1165,13 @@ impl ProxmoxGateway for PxClient {
             params.push(("with-local-disks", "1"));
         }
         let resp: ApiResponse<String> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/migrate"), &params)
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/migrate",
+                    node = urlenc_segment(node)
+                ),
+                &params,
+            )
             .await?;
         Ok(resp.data)
     }
@@ -1022,7 +1197,8 @@ impl ProxmoxGateway for PxClient {
         // than risk a force-delete on a now-running guest.
         let pre = self
             .get::<ApiResponse<crate::api::types::Guest>>(&format!(
-                "/nodes/{node}/{kind}/{vmid}/status/current"
+                "/nodes/{node}/{kind}/{vmid}/status/current",
+                node = urlenc_segment(node)
             ))
             .await
             .with_context(|| format!("pre-flight status check for delete of {kind} {vmid}"))?;
@@ -1034,8 +1210,12 @@ impl ProxmoxGateway for PxClient {
             );
         }
 
-        let resp: ApiResponse<String> =
-            self.delete(&format!("/nodes/{node}/{kind}/{vmid}")).await?;
+        let resp: ApiResponse<String> = self
+            .delete(&format!(
+                "/nodes/{node}/{kind}/{vmid}",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -1073,7 +1253,10 @@ impl ProxmoxGateway for PxClient {
             crate::api::types::GuestType::Qemu => {
                 // Step 1: submit the command — agent forks it and
                 // returns the PID immediately.
-                let exec_path = format!("/nodes/{node}/qemu/{vmid}/agent/exec");
+                let exec_path = format!(
+                    "/nodes/{node}/qemu/{vmid}/agent/exec",
+                    node = urlenc_segment(node)
+                );
                 let exec_resp = tokio::time::timeout(
                     QGA_EXEC_TIMEOUT,
                     self.post::<ApiResponse<AgentExecResponse>>(&exec_path, &params),
@@ -1091,7 +1274,10 @@ impl ProxmoxGateway for PxClient {
                 // we run out of time. Without this, we'd return the
                 // PID and lose the exit code + stdout + stderr — the
                 // pre-fix behaviour that broke shell-pipeline UX.
-                let status_path = format!("/nodes/{node}/qemu/{vmid}/agent/exec-status?pid={pid}");
+                let status_path = format!(
+                    "/nodes/{node}/qemu/{vmid}/agent/exec-status?pid={pid}",
+                    node = urlenc_segment(node)
+                );
                 let deadline = tokio::time::Instant::now() + QGA_EXEC_TIMEOUT;
                 loop {
                     if tokio::time::Instant::now() >= deadline {
@@ -1160,7 +1346,8 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<crate::api::types::GuestAgentFileContent> {
         let path = format!(
             "/nodes/{node}/qemu/{vmid}/agent/file-read?file={}",
-            urlenc(file)
+            urlenc(file),
+            node = urlenc_segment(node)
         );
         let resp: ApiResponse<crate::api::types::GuestAgentFileContent> = self.get(&path).await?;
         Ok(resp.data)
@@ -1173,7 +1360,10 @@ impl ProxmoxGateway for PxClient {
         file: &str,
         content: &str,
     ) -> Result<()> {
-        let path = format!("/nodes/{node}/qemu/{vmid}/agent/file-write");
+        let path = format!(
+            "/nodes/{node}/qemu/{vmid}/agent/file-write",
+            node = urlenc_segment(node)
+        );
         let _resp: ApiResponse<Option<String>> = self
             .post(&path, &[("file", file), ("content", content)])
             .await?;
@@ -1189,7 +1379,10 @@ impl ProxmoxGateway for PxClient {
         // returning the array directly. We hop through serde_json::Value
         // to peel that wrapper before deserializing the typed shape, so
         // the trait surface stays clean.
-        let path = format!("/nodes/{node}/qemu/{vmid}/agent/network-get-interfaces");
+        let path = format!(
+            "/nodes/{node}/qemu/{vmid}/agent/network-get-interfaces",
+            node = urlenc_segment(node)
+        );
         let resp: ApiResponse<serde_json::Value> = self.get(&path).await?;
         let result = resp
             .data
@@ -1208,19 +1401,25 @@ impl ProxmoxGateway for PxClient {
     // ── Node system layer impls ────────────────────────────
 
     async fn get_node_dns(&self, node: &str) -> Result<crate::api::types::NodeDns> {
-        let resp: ApiResponse<crate::api::types::NodeDns> =
-            self.get(&format!("/nodes/{node}/dns")).await?;
+        let resp: ApiResponse<crate::api::types::NodeDns> = self
+            .get(&format!("/nodes/{node}/dns", node = urlenc_segment(node)))
+            .await?;
         Ok(resp.data)
     }
     async fn update_node_dns(&self, node: &str, params: &[(&str, &str)]) -> Result<()> {
-        let _resp: ApiResponse<Option<String>> =
-            self.put(&format!("/nodes/{node}/dns"), params).await?;
+        let _resp: ApiResponse<Option<String>> = self
+            .put(
+                &format!("/nodes/{node}/dns", node = urlenc_segment(node)),
+                params,
+            )
+            .await?;
         Ok(())
     }
 
     async fn get_node_hosts(&self, node: &str) -> Result<crate::api::types::NodeHosts> {
-        let resp: ApiResponse<crate::api::types::NodeHosts> =
-            self.get(&format!("/nodes/{node}/hosts")).await?;
+        let resp: ApiResponse<crate::api::types::NodeHosts> = self
+            .get(&format!("/nodes/{node}/hosts", node = urlenc_segment(node)))
+            .await?;
         Ok(resp.data)
     }
     async fn update_node_hosts(&self, node: &str, data: &str, digest: Option<&str>) -> Result<()> {
@@ -1228,8 +1427,12 @@ impl ProxmoxGateway for PxClient {
         if let Some(d) = digest {
             params.push(("digest", d));
         }
-        let _resp: ApiResponse<Option<String>> =
-            self.post(&format!("/nodes/{node}/hosts"), &params).await?;
+        let _resp: ApiResponse<Option<String>> = self
+            .post(
+                &format!("/nodes/{node}/hosts", node = urlenc_segment(node)),
+                &params,
+            )
+            .await?;
         Ok(())
     }
 
@@ -1237,7 +1440,7 @@ impl ProxmoxGateway for PxClient {
         // Concatenate after the literal path so the static-analysis
         // map gate sees `/nodes/{node}/journal` instead of treating
         // the query placeholder as a path segment.
-        let mut path = format!("/nodes/{node}/journal");
+        let mut path = format!("/nodes/{node}/journal", node = urlenc_segment(node));
         append_query(&mut path, query);
         let resp: ApiResponse<Vec<String>> = self.get(&path).await?;
         Ok(resp.data)
@@ -1248,26 +1451,35 @@ impl ProxmoxGateway for PxClient {
         node: &str,
         query: &[(&str, &str)],
     ) -> Result<Vec<crate::api::types::NodeSyslogLine>> {
-        let mut path = format!("/nodes/{node}/syslog");
+        let mut path = format!("/nodes/{node}/syslog", node = urlenc_segment(node));
         append_query(&mut path, query);
         let resp: ApiResponse<Vec<crate::api::types::NodeSyslogLine>> = self.get(&path).await?;
         Ok(resp.data)
     }
 
     async fn get_node_time(&self, node: &str) -> Result<crate::api::types::NodeTime> {
-        let resp: ApiResponse<crate::api::types::NodeTime> =
-            self.get(&format!("/nodes/{node}/time")).await?;
+        let resp: ApiResponse<crate::api::types::NodeTime> = self
+            .get(&format!("/nodes/{node}/time", node = urlenc_segment(node)))
+            .await?;
         Ok(resp.data)
     }
     async fn update_node_timezone(&self, node: &str, timezone: &str) -> Result<()> {
         let _resp: ApiResponse<Option<String>> = self
-            .put(&format!("/nodes/{node}/time"), &[("timezone", timezone)])
+            .put(
+                &format!("/nodes/{node}/time", node = urlenc_segment(node)),
+                &[("timezone", timezone)],
+            )
             .await?;
         Ok(())
     }
 
     async fn wakeonlan_node(&self, node: &str) -> Result<String> {
-        let resp: ApiResponse<String> = self.post(&format!("/nodes/{node}/wakeonlan"), &[]).await?;
+        let resp: ApiResponse<String> = self
+            .post(
+                &format!("/nodes/{node}/wakeonlan", node = urlenc_segment(node)),
+                &[],
+            )
+            .await?;
         Ok(resp.data)
     }
 
@@ -1275,25 +1487,39 @@ impl ProxmoxGateway for PxClient {
         &self,
         node: &str,
     ) -> Result<crate::api::types::NodeSubscription> {
-        let resp: ApiResponse<crate::api::types::NodeSubscription> =
-            self.get(&format!("/nodes/{node}/subscription")).await?;
+        let resp: ApiResponse<crate::api::types::NodeSubscription> = self
+            .get(&format!(
+                "/nodes/{node}/subscription",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
     async fn set_node_subscription_key(&self, node: &str, key: &str) -> Result<()> {
         let _resp: ApiResponse<Option<String>> = self
-            .post(&format!("/nodes/{node}/subscription"), &[("key", key)])
+            .post(
+                &format!("/nodes/{node}/subscription", node = urlenc_segment(node)),
+                &[("key", key)],
+            )
             .await?;
         Ok(())
     }
     async fn refresh_node_subscription(&self, node: &str) -> Result<()> {
         let _resp: ApiResponse<Option<String>> = self
-            .put(&format!("/nodes/{node}/subscription"), &[])
+            .put(
+                &format!("/nodes/{node}/subscription", node = urlenc_segment(node)),
+                &[],
+            )
             .await?;
         Ok(())
     }
     async fn delete_node_subscription(&self, node: &str) -> Result<()> {
-        let _resp: ApiResponse<Option<String>> =
-            self.delete(&format!("/nodes/{node}/subscription")).await?;
+        let _resp: ApiResponse<Option<String>> = self
+            .delete(&format!(
+                "/nodes/{node}/subscription",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(())
     }
 
@@ -1302,7 +1528,10 @@ impl ProxmoxGateway for PxClient {
         node: &str,
     ) -> Result<Vec<crate::api::types::NodeCertificateInfo>> {
         let resp: ApiResponse<Vec<crate::api::types::NodeCertificateInfo>> = self
-            .get(&format!("/nodes/{node}/certificates/info"))
+            .get(&format!(
+                "/nodes/{node}/certificates/info",
+                node = urlenc_segment(node)
+            ))
             .await?;
         Ok(resp.data)
     }
@@ -1312,13 +1541,22 @@ impl ProxmoxGateway for PxClient {
         params: &[(&str, &str)],
     ) -> Result<()> {
         let _resp: ApiResponse<serde_json::Value> = self
-            .post(&format!("/nodes/{node}/certificates/custom"), params)
+            .post(
+                &format!(
+                    "/nodes/{node}/certificates/custom",
+                    node = urlenc_segment(node)
+                ),
+                params,
+            )
             .await?;
         Ok(())
     }
     async fn delete_node_custom_certificate(&self, node: &str, restart: bool) -> Result<()> {
         let restart_str = if restart { "1" } else { "0" };
-        let path = format!("/nodes/{node}/certificates/custom?restart={restart_str}");
+        let path = format!(
+            "/nodes/{node}/certificates/custom?restart={restart_str}",
+            node = urlenc_segment(node)
+        );
         let _resp: ApiResponse<Option<String>> = self.delete(&path).await?;
         Ok(())
     }
@@ -1326,7 +1564,10 @@ impl ProxmoxGateway for PxClient {
         let force_str = if force { "1" } else { "0" };
         let resp: ApiResponse<String> = self
             .post(
-                &format!("/nodes/{node}/certificates/acme/certificate"),
+                &format!(
+                    "/nodes/{node}/certificates/acme/certificate",
+                    node = urlenc_segment(node)
+                ),
                 &[("force", force_str)],
             )
             .await?;
@@ -1334,7 +1575,12 @@ impl ProxmoxGateway for PxClient {
     }
 
     async fn get_node_report(&self, node: &str) -> Result<String> {
-        let resp: ApiResponse<String> = self.get(&format!("/nodes/{node}/report")).await?;
+        let resp: ApiResponse<String> = self
+            .get(&format!(
+                "/nodes/{node}/report",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -1416,7 +1662,10 @@ impl ProxmoxGateway for PxClient {
         let kind = type_path(guest_type);
         let resp: ApiResponse<String> = self
             .post(
-                &format!("/nodes/{node}/{kind}/{vmid}/snapshot"),
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/snapshot",
+                    node = urlenc_segment(node)
+                ),
                 &[("snapname", name)],
             )
             .await?;
@@ -1432,7 +1681,11 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<String> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<String> = self
-            .delete(&format!("/nodes/{node}/{kind}/{vmid}/snapshot/{name}"))
+            .delete(&format!(
+                "/nodes/{node}/{kind}/{vmid}/snapshot/{name}",
+                node = urlenc_segment(node),
+                name = urlenc_segment(name)
+            ))
             .await?;
         Ok(resp.data)
     }
@@ -1447,7 +1700,11 @@ impl ProxmoxGateway for PxClient {
         let kind = type_path(guest_type);
         let resp: ApiResponse<String> = self
             .post(
-                &format!("/nodes/{node}/{kind}/{vmid}/snapshot/{name}/rollback"),
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/snapshot/{name}/rollback",
+                    node = urlenc_segment(node),
+                    name = urlenc_segment(name)
+                ),
                 &[],
             )
             .await?;
@@ -1471,7 +1728,13 @@ impl ProxmoxGateway for PxClient {
             .map(|(k, v)| (k.as_str(), v.as_str()))
             .collect();
         let resp: ApiResponse<Option<String>> = self
-            .put(&format!("/nodes/{node}/{kind}/{vmid}/config"), &pairs)
+            .put(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/config",
+                    node = urlenc_segment(node)
+                ),
+                &pairs,
+            )
             .await?;
         Ok(resp.data)
     }
@@ -1480,7 +1743,13 @@ impl ProxmoxGateway for PxClient {
         // PVE's regen endpoint accepts no body params — it just
         // re-emits the cloud-init ISO from the current ci* fields.
         let resp: ApiResponse<Option<String>> = self
-            .put(&format!("/nodes/{node}/qemu/{vmid}/cloudinit"), &[])
+            .put(
+                &format!(
+                    "/nodes/{node}/qemu/{vmid}/cloudinit",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
@@ -1493,7 +1762,10 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<Vec<crate::api::types::PendingConfigEntry>> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<Vec<crate::api::types::PendingConfigEntry>> = self
-            .get(&format!("/nodes/{node}/{kind}/{vmid}/pending"))
+            .get(&format!(
+                "/nodes/{node}/{kind}/{vmid}/pending",
+                node = urlenc_segment(node)
+            ))
             .await?;
         Ok(resp.data)
     }
@@ -1510,7 +1782,13 @@ impl ProxmoxGateway for PxClient {
         // Use `Option<String>` so the deserializer accepts null
         // instead of failing the whole call with a parse error.
         let resp: ApiResponse<Option<String>> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/template"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/template",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data.unwrap_or_default())
     }
@@ -1559,7 +1837,13 @@ impl ProxmoxGateway for PxClient {
             params.push(("description", d));
         }
         let resp: ApiResponse<String> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/clone"), &params)
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/clone",
+                    node = urlenc_segment(node)
+                ),
+                &params,
+            )
             .await?;
         Ok(resp.data)
     }
@@ -1597,8 +1881,12 @@ impl ProxmoxGateway for PxClient {
         if let Some(c) = compress {
             params.push(("compress", c));
         }
-        let resp: ApiResponse<String> =
-            self.post(&format!("/nodes/{node}/vzdump"), &params).await?;
+        let resp: ApiResponse<String> = self
+            .post(
+                &format!("/nodes/{node}/vzdump", node = urlenc_segment(node)),
+                &params,
+            )
+            .await?;
         Ok(resp.data)
     }
 
@@ -1610,7 +1898,10 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<Vec<crate::api::types::Snapshot>> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<Vec<crate::api::types::Snapshot>> = self
-            .get(&format!("/nodes/{node}/{kind}/{vmid}/snapshot"))
+            .get(&format!(
+                "/nodes/{node}/{kind}/{vmid}/snapshot",
+                node = urlenc_segment(node)
+            ))
             .await?;
         Ok(resp.data)
     }
@@ -1636,7 +1927,11 @@ impl ProxmoxGateway for PxClient {
         }
         let resp: ApiResponse<String> = self
             .post(
-                &format!("/nodes/{node}/storage/{storage}/download-url"),
+                &format!(
+                    "/nodes/{node}/storage/{storage}/download-url",
+                    node = urlenc_segment(node),
+                    storage = urlenc_segment(storage)
+                ),
                 &params,
             )
             .await?;
@@ -1650,8 +1945,16 @@ impl ProxmoxGateway for PxClient {
         content_filter: Option<&str>,
     ) -> Result<Vec<crate::api::types::StorageContent>> {
         let path = match content_filter {
-            Some(c) => format!("/nodes/{node}/storage/{storage}/content?content={c}"),
-            None => format!("/nodes/{node}/storage/{storage}/content"),
+            Some(c) => format!(
+                "/nodes/{node}/storage/{storage}/content?content={c}",
+                node = urlenc_segment(node),
+                storage = urlenc_segment(storage)
+            ),
+            None => format!(
+                "/nodes/{node}/storage/{storage}/content",
+                node = urlenc_segment(node),
+                storage = urlenc_segment(storage)
+            ),
         };
         let resp: ApiResponse<Vec<crate::api::types::StorageContent>> = self.get(&path).await?;
         Ok(resp.data)
@@ -1667,7 +1970,13 @@ impl ProxmoxGateway for PxClient {
         // even attempt this for an LXC vmid (we'll let Proxmox 4xx if
         // they do, surfacing the right error).
         let resp: ApiResponse<crate::api::types::SpiceConfig> = self
-            .post(&format!("/nodes/{node}/qemu/{vmid}/spiceproxy"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/qemu/{vmid}/spiceproxy",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
@@ -1680,7 +1989,13 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<crate::api::types::TermproxyTicket> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<crate::api::types::TermproxyTicket> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/termproxy"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/termproxy",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
@@ -1693,7 +2008,13 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<crate::api::types::VncTicket> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<crate::api::types::VncTicket> = self
-            .post(&format!("/nodes/{node}/{kind}/{vmid}/vncproxy"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/vncproxy",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
@@ -1734,13 +2055,19 @@ impl ProxmoxGateway for PxClient {
         vmid: u32,
     ) -> Result<Vec<crate::api::types::LxcInterface>> {
         let resp: ApiResponse<Vec<crate::api::types::LxcInterface>> = self
-            .get(&format!("/nodes/{node}/lxc/{vmid}/interfaces"))
+            .get(&format!(
+                "/nodes/{node}/lxc/{vmid}/interfaces",
+                node = urlenc_segment(node)
+            ))
             .await?;
         Ok(resp.data)
     }
 
     async fn dump_qemu_cloudinit(&self, node: &str, vmid: u32, kind: &str) -> Result<String> {
-        let mut path = format!("/nodes/{node}/qemu/{vmid}/cloudinit/dump");
+        let mut path = format!(
+            "/nodes/{node}/qemu/{vmid}/cloudinit/dump",
+            node = urlenc_segment(node)
+        );
         append_query(&mut path, &[("type", kind)]);
         let resp: ApiResponse<String> = self.get(&path).await?;
         Ok(resp.data)
@@ -1762,7 +2089,10 @@ impl ProxmoxGateway for PxClient {
         // makes the static-analysis map gate see `/nodes/.../vncwebsocket`
         // as a real PVE path string. The leading slash is required for
         // `is_pve_path` to fire.
-        let path = format!("/nodes/{node}/{kind}/{vmid}/vncwebsocket");
+        let path = format!(
+            "/nodes/{node}/{kind}/{vmid}/vncwebsocket",
+            node = urlenc_segment(node)
+        );
         let ws_base = if let Some(rest) = self.base_url.strip_prefix("https://") {
             format!("wss://{rest}")
         } else if let Some(rest) = self.base_url.strip_prefix("http://") {
@@ -1783,7 +2113,13 @@ impl ProxmoxGateway for PxClient {
         vmid: u32,
     ) -> Result<crate::api::types::SpiceConfig> {
         let resp: ApiResponse<crate::api::types::SpiceConfig> = self
-            .post(&format!("/nodes/{node}/lxc/{vmid}/spiceproxy"), &[])
+            .post(
+                &format!(
+                    "/nodes/{node}/lxc/{vmid}/spiceproxy",
+                    node = urlenc_segment(node)
+                ),
+                &[],
+            )
             .await?;
         Ok(resp.data)
     }
@@ -1800,7 +2136,7 @@ impl ProxmoxGateway for PxClient {
         // (parity with QEMU's QGA exec polling).
         let resp: ApiResponse<serde_json::Value> = self
             .post(
-                &format!("/nodes/{node}/lxc/{vmid}/exec"),
+                &format!("/nodes/{node}/lxc/{vmid}/exec", node = urlenc_segment(node)),
                 &[("command", command)],
             )
             .await?;
@@ -1808,20 +2144,32 @@ impl ProxmoxGateway for PxClient {
     }
 
     async fn get_node_termproxy(&self, node: &str) -> Result<crate::api::types::TermproxyTicket> {
-        let resp: ApiResponse<crate::api::types::TermproxyTicket> =
-            self.post(&format!("/nodes/{node}/termproxy"), &[]).await?;
+        let resp: ApiResponse<crate::api::types::TermproxyTicket> = self
+            .post(
+                &format!("/nodes/{node}/termproxy", node = urlenc_segment(node)),
+                &[],
+            )
+            .await?;
         Ok(resp.data)
     }
 
     async fn get_node_vncshell(&self, node: &str) -> Result<crate::api::types::VncTicket> {
-        let resp: ApiResponse<crate::api::types::VncTicket> =
-            self.post(&format!("/nodes/{node}/vncshell"), &[]).await?;
+        let resp: ApiResponse<crate::api::types::VncTicket> = self
+            .post(
+                &format!("/nodes/{node}/vncshell", node = urlenc_segment(node)),
+                &[],
+            )
+            .await?;
         Ok(resp.data)
     }
 
     async fn get_node_spiceshell(&self, node: &str) -> Result<crate::api::types::SpiceConfig> {
-        let resp: ApiResponse<crate::api::types::SpiceConfig> =
-            self.post(&format!("/nodes/{node}/spiceshell"), &[]).await?;
+        let resp: ApiResponse<crate::api::types::SpiceConfig> = self
+            .post(
+                &format!("/nodes/{node}/spiceshell", node = urlenc_segment(node)),
+                &[],
+            )
+            .await?;
         Ok(resp.data)
     }
 
@@ -1867,7 +2215,8 @@ impl ProxmoxGateway for PxClient {
     async fn extract_backup_config(&self, node: &str, volume: &str) -> Result<String> {
         let path = format!(
             "/nodes/{node}/vzdump/extractconfig?volume={}",
-            urlenc(volume)
+            urlenc(volume),
+            node = urlenc_segment(node)
         );
         let resp: ApiResponse<String> = self.get(&path).await?;
         Ok(resp.data)
@@ -2124,7 +2473,9 @@ impl ProxmoxGateway for PxClient {
         let encoded = urlenc(volid);
         let resp: ApiResponse<Option<String>> = self
             .delete(&format!(
-                "/nodes/{node}/storage/{storage}/content/{encoded}"
+                "/nodes/{node}/storage/{storage}/content/{encoded}",
+                node = urlenc_segment(node),
+                storage = urlenc_segment(storage)
             ))
             .await?;
         Ok(resp.data)
@@ -2188,7 +2539,11 @@ impl ProxmoxGateway for PxClient {
             .text("content", content_type.to_string())
             .part("filename", part);
 
-        let path = format!("/nodes/{node}/storage/{storage}/upload");
+        let path = format!(
+            "/nodes/{node}/storage/{storage}/upload",
+            node = urlenc_segment(node),
+            storage = urlenc_segment(storage)
+        );
         let url = format!("{}/api2/json{}", self.base_url, path);
         debug!("POST {} (streaming upload, {} bytes)", url, file_size);
 
@@ -2214,8 +2569,12 @@ impl ProxmoxGateway for PxClient {
     }
 
     async fn list_pci(&self, node: &str) -> Result<Vec<crate::api::types::PciDevice>> {
-        let resp: ApiResponse<Vec<crate::api::types::PciDevice>> =
-            self.get(&format!("/nodes/{node}/hardware/pci")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::PciDevice>> = self
+            .get(&format!(
+                "/nodes/{node}/hardware/pci",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -2229,8 +2588,12 @@ impl ProxmoxGateway for PxClient {
         &self,
         node: &str,
     ) -> Result<Vec<crate::api::types::FirewallRule>> {
-        let resp: ApiResponse<Vec<crate::api::types::FirewallRule>> =
-            self.get(&format!("/nodes/{node}/firewall/rules")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::FirewallRule>> = self
+            .get(&format!(
+                "/nodes/{node}/firewall/rules",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -2242,7 +2605,10 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<Vec<crate::api::types::FirewallRule>> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<Vec<crate::api::types::FirewallRule>> = self
-            .get(&format!("/nodes/{node}/{kind}/{vmid}/firewall/rules"))
+            .get(&format!(
+                "/nodes/{node}/{kind}/{vmid}/firewall/rules",
+                node = urlenc_segment(node)
+            ))
             .await?;
         Ok(resp.data)
     }
@@ -2375,7 +2741,10 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<Vec<crate::api::types::FirewallAlias>> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<Vec<crate::api::types::FirewallAlias>> = self
-            .get(&format!("/nodes/{node}/{kind}/{vmid}/firewall/aliases"))
+            .get(&format!(
+                "/nodes/{node}/{kind}/{vmid}/firewall/aliases",
+                node = urlenc_segment(node)
+            ))
             .await?;
         Ok(resp.data)
     }
@@ -2389,7 +2758,10 @@ impl ProxmoxGateway for PxClient {
         let kind = type_path(guest_type);
         let _resp: ApiResponse<Option<String>> = self
             .post(
-                &format!("/nodes/{node}/{kind}/{vmid}/firewall/aliases"),
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/firewall/aliases",
+                    node = urlenc_segment(node)
+                ),
                 params,
             )
             .await?;
@@ -2408,7 +2780,8 @@ impl ProxmoxGateway for PxClient {
             .put(
                 &format!(
                     "/nodes/{node}/{kind}/{vmid}/firewall/aliases/{}",
-                    urlenc(name)
+                    urlenc(name),
+                    node = urlenc_segment(node)
                 ),
                 params,
             )
@@ -2426,7 +2799,8 @@ impl ProxmoxGateway for PxClient {
         let _resp: ApiResponse<Option<String>> = self
             .delete(&format!(
                 "/nodes/{node}/{kind}/{vmid}/firewall/aliases/{}",
-                urlenc(name)
+                urlenc(name),
+                node = urlenc_segment(node)
             ))
             .await?;
         Ok(())
@@ -2439,7 +2813,10 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<crate::api::types::GuestFirewallOptions> {
         let kind = type_path(guest_type);
         let resp: ApiResponse<crate::api::types::GuestFirewallOptions> = self
-            .get(&format!("/nodes/{node}/{kind}/{vmid}/firewall/options"))
+            .get(&format!(
+                "/nodes/{node}/{kind}/{vmid}/firewall/options",
+                node = urlenc_segment(node)
+            ))
             .await?;
         Ok(resp.data)
     }
@@ -2453,7 +2830,10 @@ impl ProxmoxGateway for PxClient {
         let kind = type_path(guest_type);
         let _resp: ApiResponse<Option<String>> = self
             .put(
-                &format!("/nodes/{node}/{kind}/{vmid}/firewall/options"),
+                &format!(
+                    "/nodes/{node}/{kind}/{vmid}/firewall/options",
+                    node = urlenc_segment(node)
+                ),
                 params,
             )
             .await?;
@@ -2510,20 +2890,32 @@ impl ProxmoxGateway for PxClient {
         &self,
         node: &str,
     ) -> Result<Vec<crate::api::types::NetworkInterface>> {
-        let resp: ApiResponse<Vec<crate::api::types::NetworkInterface>> =
-            self.get(&format!("/nodes/{node}/network")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::NetworkInterface>> = self
+            .get(&format!(
+                "/nodes/{node}/network",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
     async fn list_usb(&self, node: &str) -> Result<Vec<crate::api::types::UsbDevice>> {
-        let resp: ApiResponse<Vec<crate::api::types::UsbDevice>> =
-            self.get(&format!("/nodes/{node}/hardware/usb")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::UsbDevice>> = self
+            .get(&format!(
+                "/nodes/{node}/hardware/usb",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
     async fn list_node_disks(&self, node: &str) -> Result<Vec<crate::api::types::Disk>> {
-        let resp: ApiResponse<Vec<crate::api::types::Disk>> =
-            self.get(&format!("/nodes/{node}/disks/list")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::Disk>> = self
+            .get(&format!(
+                "/nodes/{node}/disks/list",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -2531,7 +2923,11 @@ impl ProxmoxGateway for PxClient {
         // PVE expects the disk path as a query parameter, not in the
         // URL path — `?disk=/dev/sda`. The leading `/` survives URL
         // encoding (PVE specifically expects it raw).
-        let path = format!("/nodes/{node}/disks/smart?disk={}", urlenc(disk));
+        let path = format!(
+            "/nodes/{node}/disks/smart?disk={}",
+            urlenc(disk),
+            node = urlenc_segment(node)
+        );
         let resp: ApiResponse<crate::api::types::DiskSmart> = self.get(&path).await?;
         Ok(resp.data)
     }
@@ -2546,7 +2942,12 @@ impl ProxmoxGateway for PxClient {
             #[serde(default)]
             children: Vec<crate::api::types::LvmVolumeGroup>,
         }
-        let resp: ApiResponse<LvmTree> = self.get(&format!("/nodes/{node}/disks/lvm")).await?;
+        let resp: ApiResponse<LvmTree> = self
+            .get(&format!(
+                "/nodes/{node}/disks/lvm",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data.children)
     }
 
@@ -2556,14 +2957,22 @@ impl ProxmoxGateway for PxClient {
         // against PVE 9.1.1). Future-proof: explicit `vg=*` would also
         // work but PVE versions disagree on whether `*` is allowed —
         // omitting is the most compatible.
-        let resp: ApiResponse<Vec<crate::api::types::LvmThinPool>> =
-            self.get(&format!("/nodes/{node}/disks/lvmthin")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::LvmThinPool>> = self
+            .get(&format!(
+                "/nodes/{node}/disks/lvmthin",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
     async fn list_node_zfs(&self, node: &str) -> Result<Vec<crate::api::types::ZfsPool>> {
-        let resp: ApiResponse<Vec<crate::api::types::ZfsPool>> =
-            self.get(&format!("/nodes/{node}/disks/zfs")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::ZfsPool>> = self
+            .get(&format!(
+                "/nodes/{node}/disks/zfs",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -2572,8 +2981,13 @@ impl ProxmoxGateway for PxClient {
         node: &str,
         name: &str,
     ) -> Result<crate::api::types::ZfsPoolDetail> {
-        let resp: ApiResponse<RawZfsDetail> =
-            self.get(&format!("/nodes/{node}/disks/zfs/{name}")).await?;
+        let resp: ApiResponse<RawZfsDetail> = self
+            .get(&format!(
+                "/nodes/{node}/disks/zfs/{name}",
+                node = urlenc_segment(node),
+                name = urlenc_segment(name)
+            ))
+            .await?;
         let raw = resp.data;
         let mut children = Vec::new();
         flatten_zfs_children(&raw.children, &mut children);
@@ -2872,7 +3286,10 @@ impl ProxmoxGateway for PxClient {
         cf: crate::api::types::RrdCf,
     ) -> Result<crate::api::types::RrdImage> {
         let kind = type_path(guest_type);
-        let mut path = format!("/nodes/{node}/{kind}/{vmid}/rrd");
+        let mut path = format!(
+            "/nodes/{node}/{kind}/{vmid}/rrd",
+            node = urlenc_segment(node)
+        );
         append_query(
             &mut path,
             &[
@@ -2922,7 +3339,7 @@ impl ProxmoxGateway for PxClient {
         node: &str,
         limit: Option<u32>,
     ) -> Result<Vec<crate::api::types::TaskInfo>> {
-        let mut path = format!("/nodes/{node}/tasks");
+        let mut path = format!("/nodes/{node}/tasks", node = urlenc_segment(node));
         if let Some(n) = limit {
             let n_str = n.to_string();
             append_query(&mut path, &[("limit", n_str.as_str())]);
@@ -2932,7 +3349,11 @@ impl ProxmoxGateway for PxClient {
     }
     async fn stop_node_task(&self, node: &str, upid: &str) -> Result<()> {
         let _resp: ApiResponse<Option<String>> = self
-            .delete(&format!("/nodes/{node}/tasks/{}", urlenc(upid)))
+            .delete(&format!(
+                "/nodes/{node}/tasks/{}",
+                urlenc(upid),
+                node = urlenc_segment(node)
+            ))
             .await?;
         Ok(())
     }
@@ -2947,7 +3368,8 @@ impl ProxmoxGateway for PxClient {
         let kind = type_path(guest_type);
         let path = format!(
             "/nodes/{node}/{kind}/{vmid}/feature?feature={}",
-            urlenc(feature)
+            urlenc(feature),
+            node = urlenc_segment(node)
         );
         let resp: ApiResponse<crate::api::types::GuestFeatureCheck> = self.get(&path).await?;
         Ok(resp.data)
@@ -2956,7 +3378,10 @@ impl ProxmoxGateway for PxClient {
     async fn send_qemu_key(&self, node: &str, vmid: u32, key: &str) -> Result<()> {
         let _resp: ApiResponse<Option<String>> = self
             .put(
-                &format!("/nodes/{node}/qemu/{vmid}/sendkey"),
+                &format!(
+                    "/nodes/{node}/qemu/{vmid}/sendkey",
+                    node = urlenc_segment(node)
+                ),
                 &[("key", key)],
             )
             .await?;
@@ -2973,7 +3398,10 @@ impl ProxmoxGateway for PxClient {
         let force_str = if force { "1" } else { "0" };
         let _resp: ApiResponse<Option<String>> = self
             .put(
-                &format!("/nodes/{node}/qemu/{vmid}/unlink"),
+                &format!(
+                    "/nodes/{node}/qemu/{vmid}/unlink",
+                    node = urlenc_segment(node)
+                ),
                 &[("idlist", idlist), ("force", force_str)],
             )
             .await?;
@@ -2981,8 +3409,12 @@ impl ProxmoxGateway for PxClient {
     }
 
     async fn list_node_aplinfo(&self, node: &str) -> Result<Vec<crate::api::types::AplTemplate>> {
-        let resp: ApiResponse<Vec<crate::api::types::AplTemplate>> =
-            self.get(&format!("/nodes/{node}/aplinfo")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::AplTemplate>> = self
+            .get(&format!(
+                "/nodes/{node}/aplinfo",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
     async fn download_node_aplinfo(
@@ -2993,7 +3425,7 @@ impl ProxmoxGateway for PxClient {
     ) -> Result<String> {
         let resp: ApiResponse<String> = self
             .post(
-                &format!("/nodes/{node}/aplinfo"),
+                &format!("/nodes/{node}/aplinfo", node = urlenc_segment(node)),
                 &[("storage", storage), ("template", template)],
             )
             .await?;
@@ -3005,7 +3437,10 @@ impl ProxmoxGateway for PxClient {
         node: &str,
         url: &str,
     ) -> Result<crate::api::types::UrlMetadata> {
-        let mut path = format!("/nodes/{node}/query-url-metadata");
+        let mut path = format!(
+            "/nodes/{node}/query-url-metadata",
+            node = urlenc_segment(node)
+        );
         append_query(&mut path, &[("url", url)]);
         let resp: ApiResponse<crate::api::types::UrlMetadata> = self.get(&path).await?;
         Ok(resp.data)
@@ -3207,8 +3642,12 @@ impl ProxmoxGateway for PxClient {
         &self,
         node: &str,
     ) -> Result<Vec<crate::api::types::ReplicationStatus>> {
-        let resp: ApiResponse<Vec<crate::api::types::ReplicationStatus>> =
-            self.get(&format!("/nodes/{node}/replication")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::ReplicationStatus>> = self
+            .get(&format!(
+                "/nodes/{node}/replication",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -3233,7 +3672,13 @@ impl ProxmoxGateway for PxClient {
                     ("delete", delete_str),
                 ];
                 let resp: Result<ApiResponse<String>> = self
-                    .post(&format!("/nodes/{node}/qemu/{vmid}/move_disk"), &params)
+                    .post(
+                        &format!(
+                            "/nodes/{node}/qemu/{vmid}/move_disk",
+                            node = urlenc_segment(node)
+                        ),
+                        &params,
+                    )
                     .await;
                 resp.map(|r| r.data)
             }
@@ -3244,7 +3689,13 @@ impl ProxmoxGateway for PxClient {
                     ("delete", delete_str),
                 ];
                 let resp: Result<ApiResponse<String>> = self
-                    .post(&format!("/nodes/{node}/lxc/{vmid}/move_volume"), &params)
+                    .post(
+                        &format!(
+                            "/nodes/{node}/lxc/{vmid}/move_volume",
+                            node = urlenc_segment(node)
+                        ),
+                        &params,
+                    )
                     .await;
                 resp.map(|r| r.data)
             }
@@ -3311,7 +3762,10 @@ impl ProxmoxGateway for PxClient {
             self.base_url
         );
         let auth = self.auth.read().await;
-        let path = format!("/nodes/{node}/{kind}/{vmid}/resize");
+        let path = format!(
+            "/nodes/{node}/{kind}/{vmid}/resize",
+            node = urlenc_segment(node)
+        );
         let resp = auth
             .apply(self.http.put(&url))
             .form(&params)
@@ -3339,8 +3793,12 @@ impl ProxmoxGateway for PxClient {
     }
 
     async fn apt_update_refresh(&self, node: &str) -> Result<String> {
-        let resp: ApiResponse<String> =
-            self.post(&format!("/nodes/{node}/apt/update"), &[]).await?;
+        let resp: ApiResponse<String> = self
+            .post(
+                &format!("/nodes/{node}/apt/update", node = urlenc_segment(node)),
+                &[],
+            )
+            .await?;
         Ok(resp.data)
     }
 
@@ -3348,14 +3806,22 @@ impl ProxmoxGateway for PxClient {
         &self,
         node: &str,
     ) -> Result<Vec<crate::api::types::AptUpgradable>> {
-        let resp: ApiResponse<Vec<crate::api::types::AptUpgradable>> =
-            self.get(&format!("/nodes/{node}/apt/update")).await?;
+        let resp: ApiResponse<Vec<crate::api::types::AptUpgradable>> = self
+            .get(&format!(
+                "/nodes/{node}/apt/update",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
     async fn node_status_detail(&self, node: &str) -> Result<crate::api::types::NodeStatusDetail> {
-        let resp: ApiResponse<crate::api::types::NodeStatusDetail> =
-            self.get(&format!("/nodes/{node}/status")).await?;
+        let resp: ApiResponse<crate::api::types::NodeStatusDetail> = self
+            .get(&format!(
+                "/nodes/{node}/status",
+                node = urlenc_segment(node)
+            ))
+            .await?;
         Ok(resp.data)
     }
 
@@ -3375,12 +3841,22 @@ impl ProxmoxGateway for PxClient {
     }
 
     async fn create_qemu(&self, node: &str, params: &[(&str, &str)]) -> Result<String> {
-        let resp: ApiResponse<String> = self.post(&format!("/nodes/{node}/qemu"), params).await?;
+        let resp: ApiResponse<String> = self
+            .post(
+                &format!("/nodes/{node}/qemu", node = urlenc_segment(node)),
+                params,
+            )
+            .await?;
         Ok(resp.data)
     }
 
     async fn create_lxc(&self, node: &str, params: &[(&str, &str)]) -> Result<String> {
-        let resp: ApiResponse<String> = self.post(&format!("/nodes/{node}/lxc"), params).await?;
+        let resp: ApiResponse<String> = self
+            .post(
+                &format!("/nodes/{node}/lxc", node = urlenc_segment(node)),
+                params,
+            )
+            .await?;
         Ok(resp.data)
     }
 }
@@ -3439,5 +3915,49 @@ mod tests {
         assert_eq!(out[2].cksum, 3);
         assert_eq!(out[2].state, "DEGRADED");
         assert_eq!(out[2].msg.as_deref(), Some("too many errors"));
+    }
+}
+
+#[cfg(test)]
+mod path_guard_tests {
+    use super::reject_path_traversal;
+
+    /// #253 — a `..` segment reaching the transport must be refused.
+    /// Percent-encoding each caller-supplied segment is what prevents
+    /// this being constructible; the guard is the net for a call site
+    /// that forgets, or a method added later.
+    #[test]
+    fn rejects_relative_segments() {
+        for path in [
+            "/nodes/pve1/tasks/../../../access/users/log",
+            "/nodes/pve1/tasks/..%2f..%2faccess/log",
+            "/nodes/pve1/tasks/%2e%2e/access/log",
+            "/nodes/../access/users",
+            "/nodes/pve1/qemu/100/snapshot/./rollback",
+        ] {
+            assert!(
+                reject_path_traversal(path).is_err(),
+                "must refuse traversal in {path:?}"
+            );
+        }
+    }
+
+    /// Ordinary paths, including legitimately dotted names, still pass —
+    /// a guard that blocks real requests would be reverted within a week.
+    #[test]
+    fn accepts_ordinary_paths() {
+        for path in [
+            "/nodes/pve1/qemu/100/status/current",
+            "/cluster/resources",
+            "/nodes/pve-test-1/storage/local-lvm/content",
+            "/nodes/pve1/tasks/UPID:pve1:0000:0000:test::root@pam:/log?start=0&limit=500",
+            "/nodes/pve1/apt/changelog?name=pve-manager",
+            "/nodes/n1/qemu/1/snapshot/backup.2026-09-09/rollback",
+        ] {
+            assert!(
+                reject_path_traversal(path).is_ok(),
+                "must accept ordinary path {path:?}"
+            );
+        }
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -750,20 +750,59 @@ impl ProxmoxGateway for PxClient {
     }
 
     async fn get_guest_status(&self, node: &str, vmid: u32) -> Result<Guest> {
-        // Try QEMU first, then LXC
+        // Audit 2026-09-09 (#260) — assign `guest_type` and `node` from
+        // the hierarchy that answered, exactly as `get_guests` does.
+        //
+        // `/status/current` does not carry a `type` field, and `Guest`
+        // is `#[serde(default)]` over a `GuestType` whose Default is
+        // `Qemu` — so this used to return every container labelled as a
+        // QEMU VM, on node "". The MCP `get_guest_status` tool serialises
+        // the value straight to its caller, and anything dispatching on
+        // the returned type then builds a `/qemu/{vmid}/...` URL for an
+        // LXC container: bug #1 all over again (see `type_path`).
+        //
+        // The probe also stops swallowing every error. Falling through
+        // on a 403, a transport failure or an exhausted retry budget
+        // meant the operator was shown an LXC 404 for a VM that exists,
+        // naming the wrong hierarchy and the wrong cause. Only "this
+        // vmid is not a QEMU guest" justifies trying the other one.
         let qemu_path = format!(
             "/nodes/{node}/qemu/{vmid}/status/current",
             node = urlenc_segment(node)
         );
-        if let Ok(resp) = self.get::<ApiResponse<Guest>>(&qemu_path).await {
-            return Ok(resp.data);
+        match self.get::<ApiResponse<Guest>>(&qemu_path).await {
+            Ok(resp) => {
+                let mut g = resp.data;
+                g.node = node.to_string();
+                g.guest_type = GuestType::Qemu;
+                return Ok(g);
+            }
+            Err(e) => {
+                let is_wrong_hierarchy = e
+                    .downcast_ref::<super::ApiError>()
+                    .is_some_and(|api| {
+                        matches!(api, super::ApiError::NotFound(_))
+                            // PVE answers 500 for a vmid that exists but
+                            // belongs to the other hierarchy.
+                            || matches!(api, super::ApiError::Other { status, .. } if *status == 500)
+                    });
+                if !is_wrong_hierarchy {
+                    return Err(e).with_context(|| {
+                        format!("querying QEMU status for guest {vmid} on node {node}")
+                    });
+                }
+            }
         }
+
         let lxc_path = format!(
             "/nodes/{node}/lxc/{vmid}/status/current",
             node = urlenc_segment(node)
         );
         let resp: ApiResponse<Guest> = self.get(&lxc_path).await?;
-        Ok(resp.data)
+        let mut g = resp.data;
+        g.node = node.to_string();
+        g.guest_type = GuestType::Lxc;
+        Ok(g)
     }
 
     async fn get_storage_pools(&self, node: &str) -> Result<Vec<StoragePool>> {

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -50,7 +50,7 @@ fn reject_path_traversal(path: &str) -> Result<()> {
         .replace("%2e", ".")
         .replace("%2f", "/");
     let suspicious = normalised
-        .split(|c| c == '/' || c == '?' || c == '&' || c == '=')
+        .split(['/', '?', '&', '='])
         .any(|seg| seg == ".." || seg == ".");
     if suspicious {
         anyhow::bail!(

--- a/src/app.rs
+++ b/src/app.rs
@@ -720,6 +720,7 @@ fn guest_block_reason(state: &AppState, vmid: u32, op_label: &str) -> Option<Str
     None
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub fn update(state: &mut AppState, action: Action) -> Option<SideEffect> {
     match action {
         Action::Quit => return Some(SideEffect::Quit),

--- a/src/app/preflight.rs
+++ b/src/app/preflight.rs
@@ -277,6 +277,7 @@ pub fn parse_listening_ports(output: &str) -> Vec<u16> {
 ///
 /// Skipped entirely for LXC (no agent) and stopped guests (no
 /// listening sockets).
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn assess_deep(
     client: &crate::api::PxClient,
     pbs: Option<&crate::pbs::PbsClient>,

--- a/src/app/queue.rs
+++ b/src/app/queue.rs
@@ -36,6 +36,7 @@ pub enum OpStatus {
 
 impl QueuedOp {
     #[must_use]
+    #[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
     pub fn new(action: Box<Action>, state: &AppState) -> Self {
         let (description, diff) = match &*action {
             Action::StartGuest { vmid } => {

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -59,10 +59,12 @@ impl AuditLogger {
                 params_json TEXT,
                 result     TEXT    NOT NULL DEFAULT '',
                 chain_hmac TEXT    NOT NULL,
-                chain_version INTEGER NOT NULL DEFAULT 1
+                chain_version INTEGER NOT NULL DEFAULT 1,
+                key_id     TEXT    NOT NULL DEFAULT 'primary'
             );",
         )?;
         migrate_chain_version(&conn)?;
+        migrate_key_id(&conn)?;
         Ok(Self { conn, key })
     }
 
@@ -93,8 +95,9 @@ impl AuditLogger {
         );
         self.conn.execute(
             "INSERT INTO audit_log
-                (ts, action, user, vmid, node, params_json, result, chain_hmac, chain_version)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                (ts, action, user, vmid, node, params_json, result, chain_hmac,
+                 chain_version, key_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 ts,
                 action,
@@ -105,6 +108,7 @@ impl AuditLogger {
                 result,
                 chain_hmac,
                 CHAIN_V2,
+                PRIMARY_KEY_ID,
             ],
         )?;
         info!(action, vmid, result, "audit");
@@ -133,7 +137,7 @@ impl AuditLogger {
 
     pub fn verify(&self) -> Result<(usize, usize)> {
         let mut stmt = self.conn.prepare(
-            "SELECT ts,action,user,vmid,node,params_json,result,chain_hmac,chain_version
+            "SELECT ts,action,user,vmid,node,params_json,result,chain_hmac,chain_version,key_id
              FROM audit_log ORDER BY id ASC",
         )?;
         let mut prev = String::new();
@@ -150,17 +154,41 @@ impl AuditLogger {
                 r.get::<_, String>(6)?,         // result
                 r.get::<_, String>(7)?,         // chain_hmac
                 r.get::<_, i64>(8)?,            // chain_version
+                r.get::<_, String>(9)?,         // key_id
             ))
         })?;
+        // #281 — a row is verified with the key it was signed with, so a
+        // rotation does not invalidate everything written before it. The
+        // primary key is already loaded; retired ones are read on first
+        // use and cached for the walk.
+        let mut retired: std::collections::HashMap<String, Option<Vec<u8>>> =
+            std::collections::HashMap::new();
         for row in rows {
-            let (ts, action, user, vmid, node, params, result, stored_hmac, version) = row?;
+            let (ts, action, user, vmid, node, params, result, stored_hmac, version, key_id) = row?;
+            let key: &[u8] = if key_id == PRIMARY_KEY_ID {
+                &self.key
+            } else {
+                let entry = retired
+                    .entry(key_id.clone())
+                    .or_insert_with(|| load_retired_key(&key_id).ok());
+                let Some(k) = entry else {
+                    // The key this row was signed with is gone, so its
+                    // MAC cannot be recomputed. Count it as a failure
+                    // rather than silently skipping: an unverifiable row
+                    // IS a gap in the trail.
+                    fail += 1;
+                    prev = stored_hmac;
+                    continue;
+                };
+                k.as_slice()
+            };
             let vmid_str = vmid.map(|v| v.to_string()).unwrap_or_default();
             // Recompute under each row's OWN chain format, so legacy v1 rows
             // keep verifying after the migration while new v2 rows get the
             // stronger who/what coverage.
             let expected = if version == CHAIN_V2 {
                 compute_hmac_v2(
-                    &self.key,
+                    key,
                     &prev,
                     &ts,
                     &action,
@@ -171,7 +199,7 @@ impl AuditLogger {
                     &result,
                 )
             } else {
-                compute_hmac(&self.key, &prev, &ts, &action, &vmid_str, &result)
+                compute_hmac(key, &prev, &ts, &action, &vmid_str, &result)
             };
             if expected == stored_hmac {
                 ok += 1;
@@ -303,6 +331,34 @@ fn migrate_chain_version(conn: &Connection) -> Result<()> {
     }
     Ok(())
 }
+
+/// Add the `key_id` column to an `audit_log` written before key
+/// rotation existed (audit 2026-09-09, #281). Pre-existing rows are
+/// `primary`, which is the key they were signed with.
+fn migrate_key_id(conn: &Connection) -> Result<()> {
+    let has_col: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('audit_log') WHERE name = 'key_id'",
+        [],
+        |r| r.get(0),
+    )?;
+    if has_col == 0 {
+        conn.execute(
+            "ALTER TABLE audit_log ADD COLUMN key_id TEXT NOT NULL DEFAULT 'primary'",
+            [],
+        )?;
+    }
+    Ok(())
+}
+
+/// Identifier of the key currently being written with.
+///
+/// Retired keys keep their own id and stay on disk as
+/// `audit.key.<id>`, so rows signed with them keep verifying. Before
+/// this existed, rotating meant deleting `audit.key` and starting a new
+/// chain — which destroyed the verifiability of exactly the history an
+/// investigation would need, so in practice the key was permanent for
+/// the life of the log.
+pub const PRIMARY_KEY_ID: &str = "primary";
 
 fn load_or_create_key(path: &PathBuf) -> Result<Vec<u8>> {
     if path.exists() {
@@ -450,6 +506,88 @@ fn audit_key_path() -> Result<PathBuf> {
     ))
 }
 
+/// Path a retired key is archived at: the primary key path with the
+/// key id appended. Keeping them beside the primary means a backup of
+/// the audit directory captures the whole verifiable history, which is
+/// the property #281 is about.
+fn retired_key_path(key_id: &str) -> Result<PathBuf> {
+    let primary = audit_key_path()?;
+    let name = primary
+        .file_name()
+        .map(|n| format!("{}.{key_id}", n.to_string_lossy()))
+        .unwrap_or_else(|| format!("audit.key.{key_id}"));
+    Ok(primary.with_file_name(name))
+}
+
+/// Read a retired key. Same 0600 custody check as the primary — a
+/// retired key still proves every row it signed.
+fn load_retired_key(key_id: &str) -> Result<Vec<u8>> {
+    let path = retired_key_path(key_id)?;
+    anyhow::ensure!(
+        path.exists(),
+        "audit key `{key_id}` is not present at {} — rows signed with it cannot \
+         be verified",
+        path.display()
+    );
+    load_or_create_key(&path)
+}
+
+/// Rotate the audit HMAC key (audit 2026-09-09, #281).
+///
+/// The current key is archived under a fresh id and a new primary is
+/// generated. Rows already written keep their `key_id`, so `verify`
+/// continues to check them against the key that signed them: rotation no
+/// longer destroys the verifiability of the history it is supposed to
+/// protect.
+///
+/// Returns the id the retired key was archived under.
+///
+/// # Errors
+/// When the key directory cannot be read or written.
+pub fn rotate_key() -> Result<String> {
+    let primary = audit_key_path()?;
+    anyhow::ensure!(
+        primary.exists(),
+        "no audit key at {} — nothing to rotate (one is created on first use)",
+        primary.display()
+    );
+    // The id is a timestamp: sortable, and it says when the key stopped
+    // being used, which is what an investigator wants to know.
+    let key_id = format!("retired-{}", now_unix_secs());
+    let dest = retired_key_path(&key_id)?;
+    anyhow::ensure!(
+        !dest.exists(),
+        "a retired key already exists at {} — refusing to overwrite it, since \
+         that would strand every row it signed",
+        dest.display()
+    );
+    std::fs::rename(&primary, &dest)
+        .with_context(|| format!("archiving {} to {}", primary.display(), dest.display()))?;
+    crate::util::durable::sync_parent_dir(&dest)?;
+
+    // Re-point every existing row at the key that actually signed it,
+    // BEFORE creating the new primary — if this fails, the old key is
+    // still the primary and nothing is stranded.
+    let conn = Connection::open(audit_db_path()?)?;
+    migrate_key_id(&conn)?;
+    conn.execute(
+        "UPDATE audit_log SET key_id = ?1 WHERE key_id = ?2",
+        params![key_id, PRIMARY_KEY_ID],
+    )?;
+
+    // Generating the new primary is the last step.
+    let _new = load_or_create_key(&primary)?;
+    info!(key_id = %key_id, "audit key rotated");
+    Ok(key_id)
+}
+
+fn now_unix_secs() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
 fn chrono_now() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let secs = SystemTime::now()
@@ -519,7 +657,8 @@ impl AuditLogger {
                 params_json TEXT,
                 result     TEXT    NOT NULL DEFAULT '',
                 chain_hmac TEXT    NOT NULL,
-                chain_version INTEGER NOT NULL DEFAULT 1
+                chain_version INTEGER NOT NULL DEFAULT 1,
+                key_id     TEXT    NOT NULL DEFAULT 'primary'
             );",
         )
         .expect("create audit_log");
@@ -844,6 +983,114 @@ mod key_tests {
         assert_eq!(
             resolve_audit_key_path(Some("/secure/mnt/proxxx.key".into()), data_dir),
             PathBuf::from("/secure/mnt/proxxx.key")
+        );
+    }
+}
+
+#[cfg(test)]
+mod key_rotation_tests {
+    use super::{compute_hmac_v2, retired_key_path, CHAIN_V2};
+    use rusqlite::{params, Connection};
+
+    /// #281 — the whole point: rotating must NOT invalidate the history
+    /// it exists to protect. Before this, rotation meant deleting the
+    /// key and starting a new chain, so the correct response to a host
+    /// compromise destroyed the evidence.
+    ///
+    /// Driven against an in-memory DB and explicit keys rather than the
+    /// real paths: `PROXXX_AUDIT_DIR` is process-global and cargo runs
+    /// these in parallel, so mutating it races every sibling test — a
+    /// hazard this codebase already documents elsewhere.
+    #[test]
+    fn a_row_verifies_under_the_key_that_signed_it_not_the_current_one() {
+        let old_key = vec![7u8; 32];
+        let new_key = vec![9u8; 32];
+
+        // A row signed with the OLD key.
+        let ts = "2026-09-09T00:00:00Z";
+        let mac_old = compute_hmac_v2(&old_key, "", ts, "test.before", "tester", "", "", "", "OK");
+
+        // Verifying it against the NEW key must fail — this is what
+        // "rotation invalidated the history" looked like.
+        let mac_under_new =
+            compute_hmac_v2(&new_key, "", ts, "test.before", "tester", "", "", "", "OK");
+        assert_ne!(
+            mac_old, mac_under_new,
+            "sanity: the two keys must produce different MACs"
+        );
+
+        // Verifying it against the key it was signed with must pass.
+        // That is exactly what `verify` now does, via the row's key_id.
+        let recomputed =
+            compute_hmac_v2(&old_key, "", ts, "test.before", "tester", "", "", "", "OK");
+        assert_eq!(
+            recomputed, mac_old,
+            "a row must verify under the key that signed it"
+        );
+    }
+
+    /// The schema carries the key id per row, so `verify` can make that
+    /// choice at all. Without the column there is nothing to select on.
+    #[test]
+    fn the_schema_records_which_key_signed_each_row() {
+        let conn = Connection::open_in_memory().expect("sqlite");
+        conn.execute_batch(
+            "CREATE TABLE audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL, action TEXT NOT NULL, user TEXT NOT NULL DEFAULT '',
+                vmid INTEGER, node TEXT, params_json TEXT,
+                result TEXT NOT NULL DEFAULT '', chain_hmac TEXT NOT NULL,
+                chain_version INTEGER NOT NULL DEFAULT 1
+            );",
+        )
+        .expect("create");
+
+        // A pre-rotation database has no key_id column at all.
+        super::migrate_key_id(&conn).expect("migrate");
+        let has: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('audit_log') WHERE name = 'key_id'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("query");
+        assert_eq!(has, 1, "migration must add key_id");
+
+        // Existing rows default to `primary` — the key they were signed
+        // with — rather than to NULL or to the new key.
+        conn.execute(
+            "INSERT INTO audit_log (ts, action, chain_hmac, chain_version)
+             VALUES (?1, ?2, ?3, ?4)",
+            params!["2026-01-01T00:00:00Z", "legacy", "deadbeef", CHAIN_V2],
+        )
+        .expect("insert");
+        let key_id: String = conn
+            .query_row("SELECT key_id FROM audit_log LIMIT 1", [], |r| r.get(0))
+            .expect("read");
+        assert_eq!(key_id, super::PRIMARY_KEY_ID);
+
+        // Migration is idempotent — `open()` runs it on every call.
+        super::migrate_key_id(&conn).expect("second migrate is a no-op");
+    }
+
+    /// Retired keys are archived beside the primary, so a backup of the
+    /// audit directory captures the whole verifiable history.
+    #[test]
+    fn a_retired_key_is_archived_next_to_the_primary() {
+        let path = retired_key_path("retired-1757000000").expect("path");
+        let name = path
+            .file_name()
+            .expect("filename")
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            name.ends_with(".retired-1757000000"),
+            "the id must be in the filename so the pairing is obvious: {name}"
+        );
+        assert_eq!(
+            path.parent(),
+            super::audit_key_path().expect("primary").parent(),
+            "retired keys live beside the primary, so one backup covers both"
         );
     }
 }

--- a/src/cli/access.rs
+++ b/src/cli/access.rs
@@ -184,6 +184,7 @@ pub enum TokenCommand {
 }
 
 /// Feature #10 — read-only access browse.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_access(
     client: &Arc<crate::api::PxClient>,
     action: AccessCommand,

--- a/src/cli/accounting.rs
+++ b/src/cli/accounting.rs
@@ -211,6 +211,7 @@ pub fn integrate_rrd(points: &[RrdPoint]) -> WindowedTotals {
     t
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_accounting(
     client: &Arc<PxClient>,
     args: AccountingReportArgs,

--- a/src/cli/audit_cmd.rs
+++ b/src/cli/audit_cmd.rs
@@ -29,6 +29,20 @@ pub enum AuditAction {
     },
     /// Verify cryptographic integrity of the audit log chain
     Verify,
+    /// Rotate the HMAC key, keeping existing entries verifiable.
+    ///
+    /// The current key is archived beside the primary under a
+    /// timestamped id and every existing row is re-pointed at it, so
+    /// `audit verify` keeps checking those rows against the key that
+    /// actually signed them. Before this existed, rotating meant
+    /// deleting the key and starting a new chain — which destroyed the
+    /// verifiability of exactly the history an investigation needs, so
+    /// in practice the key was permanent (audit #281).
+    ///
+    /// Rotate after a host compromise, or on whatever schedule your
+    /// policy sets. Back up the retired keys: without them the rows they
+    /// signed can no longer be verified.
+    RotateKey,
 }
 
 pub fn execute_log(limit: usize, since: Option<&str>) -> Result<(Value, i32)> {
@@ -69,5 +83,22 @@ pub fn execute_verify() -> Result<(Value, i32)> {
     Ok((
         serde_json::json!({"verified": ok, "failed": fail, "status": status}),
         exit_code,
+    ))
+}
+
+/// `proxxx audit rotate-key` — see [`AuditAction::RotateKey`].
+///
+/// # Errors
+/// When there is no key to rotate, or the archive/write fails.
+pub fn execute_rotate_key() -> Result<(Value, i32)> {
+    let key_id = crate::audit::rotate_key()?;
+    Ok((
+        serde_json::json!({
+            "status": "rotated",
+            "retired_key_id": key_id,
+            "note": "Existing entries remain verifiable under the retired key. \
+                     Back it up: without it those rows cannot be verified.",
+        }),
+        0,
     ))
 }

--- a/src/cli/backup_verify.rs
+++ b/src/cli/backup_verify.rs
@@ -71,6 +71,7 @@ pub enum VerifyStatus {
     Error,
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_verify(client: &Arc<PxClient>, args: VerifyArgs) -> Result<(Value, i32)> {
     use crate::api::ProxmoxGateway;
 

--- a/src/cli/cloudimg.rs
+++ b/src/cli/cloudimg.rs
@@ -361,6 +361,7 @@ pub enum CloudImgOutput {
     Json,
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_cloudimg(
     client: &Arc<PxClient>,
     action: CloudImgCommand,

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -27,43 +27,160 @@ pub(crate) fn require_yes(yes: bool, what: &str) -> Result<()> {
 }
 
 /// Locate which node owns a given VMID and which guest type it is.
-/// Walks `get_nodes()` then `get_guests(node)` per node — O(N nodes)
-/// network calls. Used by every per-vmid command (migrate, exec, config,
-/// disk, …) that the user invokes by VMID alone, without specifying
-/// the node.
+///
+/// ONE request: `GET /cluster/resources?type=vm` returns every guest in
+/// the cluster with its node and type (audit 2026-09-09, #276).
+///
+/// This used to walk `get_nodes()` and then `get_guests(node)` per node.
+/// Because `get_guests` fetches `/qemu` and `/lxc` separately that was
+/// 1 + 2N requests on an N-node cluster, paid by every per-vmid command
+/// (migrate, exec, config, disk, snapshot) and at seventeen call sites in
+/// the MCP dispatcher — before the requested work even started. Against
+/// the default `rate_limit = 10` a ten-node cluster spent roughly two
+/// seconds just locating the guest. It also multiplied the failure
+/// surface: each of those 2N calls could fail, which is what turned one
+/// unreachable node into a false "guest not found".
+///
+/// Falls back to the per-node walk if `/cluster/resources` is
+/// unavailable, so a cluster that does not serve it still works.
 pub async fn find_guest(
     client: &crate::api::PxClient,
     vmid: u32,
 ) -> Result<(String, crate::api::types::GuestType)> {
-    use crate::api::ProxmoxGateway;
-    let nodes = client.get_nodes().await?;
-    let mut node_errors: Vec<String> = Vec::new();
-    for n in nodes {
-        match client.get_guests(&n.node).await {
-            Ok(guests) => {
-                if let Some(g) = guests.iter().find(|g| g.vmid == vmid) {
-                    return Ok((n.node.clone(), g.guest_type));
-                }
-            }
-            Err(e) => {
-                node_errors.push(format!("{}: {}", n.node, e));
-            }
+    // Node and type are both in the `/cluster/resources` row, so this
+    // needs exactly one request — no second fetch from the owning node,
+    // unlike `find_guest_full`, whose caller needs the risk-relevant
+    // fields that endpoint does not carry.
+    match find_guest_via_cluster_resources(client, vmid).await {
+        Ok(Some(g)) => return Ok((g.node, g.guest_type)),
+        Ok(None) => {
+            // The cluster answered and has no such vmid. Fall through:
+            // the walk reaches the same conclusion but produces the
+            // richer message when some nodes are unreachable.
+        }
+        Err(e) => {
+            tracing::debug!("/cluster/resources unavailable ({e:#}) — using per-node walk");
         }
     }
-    if node_errors.is_empty() {
-        anyhow::bail!("Guest {vmid} not found on any node")
-    }
-    anyhow::bail!(
-        "Guest {vmid} not found; {} node(s) returned errors: {}",
-        node_errors.len(),
-        node_errors.join("; ")
-    )
+    let g = find_guest_full_via_walk(client, vmid).await?;
+    Ok((g.node, g.guest_type))
+}
+
+/// Resolve `vmid` through `/cluster/resources`, returning `None` when
+/// the cluster answered but does not have that guest.
+///
+/// Separated so both lookups share the fast path and its fallback
+/// decision, rather than each having its own copy — the duplication
+/// between them was itself a finding (#251 in the audit's code-quality
+/// category).
+async fn find_guest_via_cluster_resources(
+    client: &crate::api::PxClient,
+    vmid: u32,
+) -> Result<Option<crate::api::types::Guest>> {
+    use crate::api::types::{Guest, GuestStatus, GuestType};
+    use crate::api::ProxmoxGateway;
+
+    let resources = client.get_cluster_resources(Some("vm")).await?;
+    let Some(r) = resources.into_iter().find(|r| r.vmid == vmid) else {
+        return Ok(None);
+    };
+    let guest_type = match r.resource_type.as_str() {
+        "lxc" => GuestType::Lxc,
+        "qemu" => GuestType::Qemu,
+        // A resource typed as neither is not a guest we can dispatch on.
+        // Fall back rather than guessing a hierarchy — guessing is the
+        // bug class `type_path` exists to prevent.
+        other => {
+            tracing::debug!("cluster/resources returned vmid {vmid} with type {other:?}");
+            return Ok(None);
+        }
+    };
+    Ok(Some(Guest {
+        vmid: r.vmid,
+        name: r.name,
+        status: match r.status.as_str() {
+            "running" => GuestStatus::Running,
+            "stopped" => GuestStatus::Stopped,
+            "paused" => GuestStatus::Paused,
+            "suspended" => GuestStatus::Suspended,
+            _ => GuestStatus::Unknown,
+        },
+        guest_type,
+        node: r.node,
+        cpu: r.cpu,
+        cpus: r.maxcpu,
+        mem: r.mem,
+        maxmem: r.maxmem,
+        disk: r.disk,
+        maxdisk: r.maxdisk,
+        uptime: r.uptime,
+        tags: r.tags,
+        template: r.template != 0,
+        // `/cluster/resources` does not carry `lock`, `hastate` or the
+        // network counters. The pre-flight gate reads all three, so
+        // `find_guest_full` re-fetches from the owning node rather than
+        // handing back a Guest whose risk-relevant fields are silently
+        // empty — which would weaken the gate instead of speeding it up.
+        ..Guest::default()
+    }))
 }
 
 /// Same scan as `find_guest`, but returns the full `Guest` so the
 /// caller can run pre-flight risk assessment (lock, HA state, uptime,
 /// tags, traffic) without a second round-trip.
 pub async fn find_guest_full(
+    client: &crate::api::PxClient,
+    vmid: u32,
+) -> Result<crate::api::types::Guest> {
+    use crate::api::ProxmoxGateway;
+
+    // #276 — one request to locate the guest, then one to the owning
+    // node for the fields `/cluster/resources` does not carry (`lock`,
+    // `hastate`, netin/netout). Two requests regardless of cluster size,
+    // against 1 + 2N before.
+    //
+    // The second fetch is not optional: the pre-flight risk gate reads
+    // exactly those fields, and handing it a Guest with them silently
+    // empty would turn a speed-up into a weakened safety check.
+    match find_guest_via_cluster_resources(client, vmid).await {
+        Ok(Some(located)) => {
+            let node = located.node.clone();
+            match client.get_guests(&node).await {
+                Ok(guests) => {
+                    if let Some(g) = guests.into_iter().find(|g| g.vmid == vmid) {
+                        return Ok(g);
+                    }
+                    // Raced with a migration between the two calls: fall
+                    // through to the full walk rather than return the
+                    // partial record.
+                    tracing::debug!(
+                        "guest {vmid} was on {node} per /cluster/resources but is not \
+                         there now — falling back to the per-node walk"
+                    );
+                }
+                Err(e) => {
+                    tracing::debug!("get_guests({node}) failed after fast lookup: {e:#}");
+                }
+            }
+        }
+        Ok(None) => {
+            // The cluster answered and does not have this vmid. The walk
+            // below would reach the same conclusion 2N requests later,
+            // but it also produces the richer per-node error message when
+            // some nodes are unreachable, so let it run.
+        }
+        Err(e) => {
+            tracing::debug!("/cluster/resources unavailable ({e:#}) — using per-node walk");
+        }
+    }
+
+    find_guest_full_via_walk(client, vmid).await
+}
+
+/// The original per-node walk, kept as the fallback for a cluster that
+/// does not serve `/cluster/resources` and as the path that produces the
+/// detailed per-node error message.
+async fn find_guest_full_via_walk(
     client: &crate::api::PxClient,
     vmid: u32,
 ) -> Result<crate::api::types::Guest> {
@@ -490,6 +607,7 @@ impl IntoArray for serde_json::Value {
     }
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 async fn execute_batch_op_full(
     client: &std::sync::Arc<crate::api::PxClient>,
     op: BatchOp,

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -608,7 +608,13 @@ async fn execute_batch_op_full(
                 if let Some(ref tg) = tg_gateway {
                     let reason = format!("CLI requested batch op: {action_str}");
                     if let Err(e) = tg
-                        .request_approval(action_str, &vmid.to_string(), &reason, &txn_id)
+                        .request_approval(
+                            action_str,
+                            &vmid.to_string(),
+                            &reason,
+                            &txn_id,
+                            policy.require,
+                        )
                         .await
                     {
                         error!("Failed to send Telegram approval request: {}", e);

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -513,6 +513,15 @@ async fn execute_batch_op_full(
         });
     }
 
+    // Audit 2026-09-09 (#266) — remember which nodes we could NOT read.
+    //
+    // A node whose listing fails contributes no guests, so every guest on
+    // it is missing from the map. Reporting those as "Guest not found" is
+    // a false statement — the guest exists and was not acted on — and an
+    // operator or CI job reading it concludes the VMID is wrong. This
+    // reintroduced at the batch layer exactly the partial-list behaviour
+    // `get_guests` was changed to stop doing (see api/client.rs).
+    let mut unreachable_nodes: Vec<String> = Vec::new();
     while let Some(res) = join_set.join_next().await {
         match res {
             Ok((_node_name, Ok(guests))) => {
@@ -522,12 +531,16 @@ async fn execute_batch_op_full(
             }
             Ok((node_name, Err(e))) => {
                 tracing::warn!("get_guests({node_name}) failed during batch scan: {e:#}");
+                unreachable_nodes.push(format!("{node_name}: {e}"));
             }
             Err(join_err) => {
                 tracing::warn!("get_guests task panicked during batch scan: {join_err}");
+                unreachable_nodes.push(format!("<panicked task>: {join_err}"));
             }
         }
     }
+    let scan_incomplete = !unreachable_nodes.is_empty();
+    let unreachable_detail = unreachable_nodes.join("; ");
 
     let mut results = Vec::new();
     let mut has_failure = false;
@@ -560,6 +573,17 @@ async fn execute_batch_op_full(
     };
 
     if strict {
+        // #266 — in strict mode an incomplete scan is itself the failure.
+        // Claiming the guests are missing would be a diagnostic lie when
+        // the truth is that we could not look.
+        if scan_incomplete {
+            anyhow::bail!(
+                "Strict mode: cannot determine guest placement — {} node(s) could \
+                 not be listed ({unreachable_detail}). Refusing rather than \
+                 reporting guests on those nodes as missing.",
+                unreachable_nodes.len()
+            );
+        }
         let mut missing = Vec::new();
         for vmid in vmids {
             if !guest_map.contains_key(vmid) {
@@ -705,6 +729,24 @@ async fn execute_batch_op_full(
                     (v, res)
                 });
             }
+        } else if scan_incomplete {
+            // #266 — indeterminate, not absent. The distinction matters:
+            // "not found" invites the operator to recreate or renumber a
+            // guest that is running.
+            warn!(
+                "Guest {vmid} not located, but the scan was incomplete \
+                 ({unreachable_detail})"
+            );
+            results.push(serde_json::json!({
+                "vmid": vmid,
+                "status": "error",
+                "message": format!(
+                    "cannot determine: guest not seen, and {} node(s) could not be \
+                     listed ({unreachable_detail}). It may exist on an unreachable node.",
+                    unreachable_nodes.len()
+                )
+            }));
+            has_failure = true;
         } else {
             warn!("Guest {} not found across any node", vmid);
             results.push(serde_json::json!({
@@ -1159,5 +1201,55 @@ mod require_yes_tests {
     #[test]
     fn allows_with_yes() {
         assert!(require_yes(true, "pool delete").is_ok());
+    }
+}
+
+#[cfg(test)]
+mod incomplete_scan_tests {
+    /// #266 — the shape of the fix, asserted against the source.
+    ///
+    /// A behavioural test needs a multi-node wiremock cluster where one
+    /// node's `/qemu` and `/lxc` both fail while another succeeds, plus a
+    /// full batch dispatch; the live harness covers that. What regresses
+    /// here is someone restoring the unconditional "Guest not found",
+    /// which is a text-level property of this function.
+    #[test]
+    fn a_failed_node_listing_is_not_reported_as_a_missing_guest() {
+        let src = include_str!("common.rs");
+        let body = src
+            .split_once("async fn execute_batch_op_full")
+            .expect("the batch entry point must exist")
+            .1;
+
+        assert!(
+            body.contains("let mut unreachable_nodes"),
+            "the scan must remember which nodes it could not read"
+        );
+        assert!(
+            body.contains("} else if scan_incomplete {"),
+            "a guest missing from an incomplete scan must take a distinct branch \
+             from one missing from a complete scan"
+        );
+        assert!(
+            body.contains("cannot determine"),
+            "the indeterminate case must say so rather than assert absence"
+        );
+        assert!(
+            body.contains("Strict mode: cannot determine guest placement"),
+            "strict mode must fail on the incomplete scan itself, not report the \
+             guests on the unreachable node as missing"
+        );
+    }
+
+    /// The complete-scan case must keep its plain, correct message —
+    /// widening "not found" into "cannot determine" everywhere would
+    /// make the common case vaguer for no reason.
+    #[test]
+    fn a_complete_scan_still_says_not_found() {
+        let src = include_str!("common.rs");
+        assert!(
+            src.contains(r#""message": "Guest not found""#),
+            "a guest genuinely absent from a complete scan is still not found"
+        );
     }
 }

--- a/src/cli/ct.rs
+++ b/src/cli/ct.rs
@@ -81,6 +81,7 @@ pub enum CtCommand {
     },
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute(
     client: &Arc<crate::api::PxClient>,
     action: CtCommand,

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -41,6 +41,12 @@
 //!
 //! - SIGTERM/SIGINT cancels the outer `await`. We then `.abort()`
 //!   every spawned task and `.await` it to allow Drop cleanup.
+//! - A component that exits on its own — panic, or a loop that returns —
+//!   is a fault, not a no-op (#264). The supervisor selects the shutdown
+//!   signal against the component watchers, stops the rest, and exits
+//!   non-zero so `Restart=on-failure` can act. Before v0.13.4 nothing
+//!   polled the handles: the process stayed up and exited zero with a
+//!   dead pillar, so systemd never noticed.
 //! - Per-task panics propagate as `JoinError`. We log + continue —
 //!   the remaining daemons keep running. A panicking alerts loop
 //!   shouldn't kill the HITL receiver.
@@ -260,25 +266,78 @@ async fn run_unified(
             .join(" + "),
     );
 
-    // Race the global shutdown signal against any spawned task
-    // crashing. A crashing daemon doesn't kill the others (we
-    // log + continue), but a clean signal stops everything.
-    crate::util::shutdown::wait_for_shutdown_signal().await;
-    eprintln!("\nproxxx daemon: shutdown signal received, stopping components...");
-
+    // Audit 2026-09-09 (#264) — actually supervise the components.
+    //
+    // This used to be a bare `wait_for_shutdown_signal().await`, with a
+    // comment claiming it raced the spawned tasks. It did not: nothing
+    // polled the handles, so a component that panicked or returned an
+    // error was neither detected nor restarted. The process stayed alive
+    // and exited zero, which meant the `Restart=on-failure` unit in the
+    // production checklist never fired — systemd saw a running process
+    // while the HITL loop was dead and every approval parked forever.
+    //
+    // Each handle is now watched by a small task that reports the exit
+    // down a channel; the supervisor selects that against the shutdown
+    // signal. A component exiting on its own is a fault: we stop the
+    // rest and exit non-zero so the supervisor above us (systemd) can do
+    // its job. Restarting the component in-process was the alternative,
+    // and is worse here — a HITL loop that dies because its Telegram
+    // credentials were revoked would spin forever instead of surfacing.
+    let (exit_tx, mut exit_rx) =
+        tokio::sync::mpsc::channel::<(&'static str, String)>(components.len().max(1));
+    let mut aborts: Vec<(&'static str, tokio::task::AbortHandle)> =
+        Vec::with_capacity(components.len());
     for c in components {
-        c.handle.abort();
-        // Best-effort join. Aborted tasks return JoinError::Cancelled
-        // which we treat as success. Real panics get logged.
-        match c.handle.await {
-            Ok(Ok(())) => eprintln!("  - {} stopped cleanly", c.name),
-            Ok(Err(e)) => eprintln!("  - {} returned error: {e:#}", c.name),
-            Err(e) if e.is_cancelled() => eprintln!("  - {} stopped (cancelled)", c.name),
-            Err(e) => eprintln!("  - {} JOIN ERROR: {e}", c.name),
+        aborts.push((c.name, c.handle.abort_handle()));
+        let tx = exit_tx.clone();
+        let name = c.name;
+        crate::util::spawn_traced::spawn_traced("daemon_component_watch", async move {
+            let outcome = match c.handle.await {
+                Ok(Ok(())) => "returned Ok — a daemon loop should never finish".to_string(),
+                Ok(Err(e)) => format!("returned error: {e:#}"),
+                Err(e) if e.is_cancelled() => return, // our own abort; not a fault
+                Err(e) if e.is_panic() => format!("PANICKED: {e}"),
+                Err(e) => format!("join error: {e}"),
+            };
+            let _ = tx.send((name, outcome)).await;
+        });
+    }
+    // Drop our sender so `recv()` resolves to None if every watcher ends.
+    drop(exit_tx);
+
+    let exit_code = tokio::select! {
+        () = crate::util::shutdown::wait_for_shutdown_signal() => {
+            eprintln!("\nproxxx daemon: shutdown signal received, stopping components...");
+            0
         }
+        Some((name, outcome)) = exit_rx.recv() => {
+            eprintln!(
+                "\nproxxx daemon: component `{name}` stopped on its own ({outcome}). \
+                 Stopping the remaining components and exiting non-zero so the \
+                 process supervisor can restart the daemon."
+            );
+            tracing::error!("daemon component `{name}` exited unexpectedly: {outcome}");
+            1
+        }
+    };
+
+    for (name, abort) in &aborts {
+        abort.abort();
+        eprintln!("  - {name} stopped");
     }
 
-    Ok((serde_json::json!({"status": "daemon stopped"}), 0))
+    // Drain whatever the watchers reported while we were stopping, so a
+    // second failing component is not lost from the record.
+    while let Ok((name, outcome)) = exit_rx.try_recv() {
+        eprintln!("  - {name}: {outcome}");
+    }
+
+    Ok((
+        serde_json::json!({
+            "status": if exit_code == 0 { "daemon stopped" } else { "daemon component failed" }
+        }),
+        exit_code,
+    ))
 }
 
 /// Schedule tick loop. Every `interval_secs`, fires
@@ -990,6 +1049,53 @@ mod tests {
         assert!(
             c.lines().await.is_empty(),
             "prune-without-cap must not delete a single resource"
+        );
+    }
+}
+
+#[cfg(test)]
+mod supervision_tests {
+    /// #264 — the supervisor must watch its components, not just the
+    /// shutdown signal.
+    ///
+    /// Asserted against the source because the behaviour needs a real
+    /// runtime with spawned pillars to exercise end to end, and what
+    /// actually regresses is someone restoring the bare
+    /// `wait_for_shutdown_signal().await`. The comment that used to sit
+    /// above it claimed the race existed while the code did not do it,
+    /// so a structural assertion is the honest guard here.
+    #[test]
+    fn the_supervisor_selects_component_exits_against_the_shutdown_signal() {
+        let src = include_str!("daemon.rs");
+        let body = src
+            .split_once("let exit_code = tokio::select!")
+            .expect("the supervisor must select, not bare-await the signal")
+            .1;
+        let (select_block, _) = body.split_once("};").expect("select block");
+
+        assert!(
+            select_block.contains("wait_for_shutdown_signal()"),
+            "a clean signal must still stop everything"
+        );
+        assert!(
+            select_block.contains("exit_rx.recv()"),
+            "a component exiting on its own must wake the supervisor"
+        );
+        assert!(
+            select_block.contains('1'),
+            "an unexpected component exit must produce a non-zero exit code so \
+             Restart=on-failure can act"
+        );
+    }
+
+    /// Aborting our own components is not a fault — only an exit the
+    /// component chose counts.
+    #[test]
+    fn our_own_abort_is_not_reported_as_a_failure() {
+        let src = include_str!("daemon.rs");
+        assert!(
+            src.contains("Err(e) if e.is_cancelled() => return"),
+            "a cancelled component is our own abort during shutdown, not a fault"
         );
     }
 }

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -289,16 +289,25 @@ async fn run_unified(
         Vec::with_capacity(components.len());
     for c in components {
         aborts.push((c.name, c.handle.abort_handle()));
+        // #271 — publish liveness so a pillar that stops is visible to
+        // monitoring, not just to whoever happens to read stderr.
+        crate::metrics::daemon_health::register(c.name);
         let tx = exit_tx.clone();
         let name = c.name;
         crate::util::spawn_traced::spawn_traced("daemon_component_watch", async move {
             let outcome = match c.handle.await {
                 Ok(Ok(())) => "returned Ok — a daemon loop should never finish".to_string(),
                 Ok(Err(e)) => format!("returned error: {e:#}"),
-                Err(e) if e.is_cancelled() => return, // our own abort; not a fault
+                Err(e) if e.is_cancelled() => {
+                    // Our own abort during shutdown: not a fault, but the
+                    // component IS down and the gauge must say so.
+                    crate::metrics::daemon_health::mark_down(name);
+                    return;
+                }
                 Err(e) if e.is_panic() => format!("PANICKED: {e}"),
                 Err(e) => format!("join error: {e}"),
             };
+            crate::metrics::daemon_health::mark_down(name);
             let _ = tx.send((name, outcome)).await;
         });
     }
@@ -358,6 +367,9 @@ async fn schedule_loop(interval_secs: u64) -> Result<()> {
                 let result = tokio::task::spawn_blocking(|| {
                     crate::cli::schedule::run_due(None)
                 }).await;
+                // #271 — a completed tick, so "wedged" is distinguishable
+                // from "idle" in the metrics.
+                crate::metrics::daemon_health::tick("schedule");
                 match result {
                     Ok(Ok(_)) => {} // happy path, swallow the Value/exit
                     Ok(Err(e)) => tracing::warn!("daemon schedule tick: {e:#}"),
@@ -421,6 +433,11 @@ async fn reconcile_loop(
             biased;
             () = crate::util::shutdown::wait_for_shutdown_signal() => break,
             () = tokio::time::sleep(Duration::from_secs(interval)) => {
+                // #271 — the reconcile pillar already had a staleness
+                // signal via proxxx_reconcile_last_check_timestamp; this
+                // adds the same for the component itself so all four
+                // pillars answer the same question the same way.
+                crate::metrics::daemon_health::tick("reconcile");
                 match super::reconcile::compute_drift(&client, &profile_label, &rec.source, &path).await {
                     Ok(changes) => {
                         let in_sync = changes.is_empty();

--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -172,6 +172,7 @@ struct Component {
 }
 
 #[allow(clippy::fn_params_excessive_bools)]
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 async fn run_unified(
     client: &Arc<PxClient>,
     config_handle: ConfigHandle,
@@ -614,6 +615,7 @@ fn is_frozen(profile: Option<&str>) -> bool {
 /// human review" alert and mutates nothing) and fail-fast
 /// (`continue_on_error = false`). Never returns an error: a failed tick must not
 /// kill the watch loop.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 async fn run_auto_converge(
     client: &Arc<PxClient>,
     profile_label: &str,

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -77,6 +77,16 @@ pub struct ClusterDigest {
     pub recent_failures: Option<Vec<TaskSummary>>,
     /// Only populated when `--include rbac` or `--include all`.
     pub rbac: Option<RbacSummary>,
+    /// Sections that were requested but could not be read, each with
+    /// the reason (audit 2026-09-09, #278).
+    ///
+    /// Present and non-empty means the digest is INCOMPLETE: the empty
+    /// collections above may be empty because there is nothing there, or
+    /// because we were not allowed to look. Absent from the JSON when
+    /// everything was readable, so the common case is unchanged for
+    /// existing consumers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unavailable: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -229,8 +239,24 @@ async fn collect(
     }
     let storages: Vec<StorageSummary> = storage_map.into_values().collect();
 
+    // Audit 2026-09-09 (#278) — an API failure must not read as "there
+    // is nothing here". This output is documented as designed to paste
+    // at the top of an LLM chat, and the recent-failure and RBAC
+    // sections are exactly what a reader uses to judge blast radius. A
+    // 403 on /access/users — the common case for the scoped token this
+    // project recommends — rendered as "this cluster has no users".
+    //
+    // Silence is only acceptable when the reader can tell it apart from
+    // zero, so each section that could not be read says so instead.
+    let mut unavailable: Vec<String> = Vec::new();
     let recent_failures = if include_events {
-        let tasks = client.get_cluster_tasks().await.unwrap_or_default();
+        let tasks = match client.get_cluster_tasks().await {
+            Ok(t) => t,
+            Err(e) => {
+                unavailable.push(format!("recent_failures: {e}"));
+                Vec::new()
+            }
+        };
         // Filter to failures (status != "OK" and endtime set).
         // Take the 5 most recent.
         let mut failures: Vec<TaskSummary> = tasks
@@ -259,8 +285,20 @@ async fn collect(
     };
 
     let rbac = if include_rbac {
-        let pools = client.list_pools().await.unwrap_or_default();
-        let users = client.list_users().await.unwrap_or_default();
+        let pools = match client.list_pools().await {
+            Ok(p) => p,
+            Err(e) => {
+                unavailable.push(format!("rbac.pools: {e}"));
+                Vec::new()
+            }
+        };
+        let users = match client.list_users().await {
+            Ok(u) => u,
+            Err(e) => {
+                unavailable.push(format!("rbac.users: {e}"));
+                Vec::new()
+            }
+        };
         Some(RbacSummary {
             pool_count: pools.len(),
             user_count: users.len(),
@@ -282,6 +320,11 @@ async fn collect(
         storages,
         recent_failures,
         rbac,
+        unavailable: if unavailable.is_empty() {
+            None
+        } else {
+            Some(unavailable)
+        },
     })
 }
 
@@ -307,6 +350,17 @@ fn print_text(d: &ClusterDigest) {
         "  {} nodes  /  {} guests  /  {} storages\n",
         d.cluster.node_count, d.cluster.guest_count, d.cluster.storage_count
     );
+    // #278 — say it where the reader is, not only in the JSON. A digest
+    // that silently omits a section it could not read is worse than one
+    // that says so, because the reader has no way to tell.
+    if let Some(missing) = &d.unavailable {
+        println!("## INCOMPLETE — some sections could not be read");
+        for m in missing {
+            println!("  ! {m}");
+        }
+        println!("  (empty sections below may be empty, or unreadable — do not");
+        println!("   infer absence from them)\n");
+    }
     println!("## Nodes");
     for n in &d.nodes {
         let mem_used = format_bytes_gib(n.mem_used_bytes);
@@ -515,7 +569,7 @@ fn print_llm_context(d: &ClusterDigest) {
 mod tests {
     use super::*;
 
-    fn sample_digest() -> ClusterDigest {
+    pub(super) fn sample_digest() -> ClusterDigest {
         ClusterDigest {
             cluster: ClusterInfo {
                 pve_version: "9.1.1".into(),
@@ -550,6 +604,7 @@ mod tests {
             }],
             recent_failures: None,
             rbac: None,
+            unavailable: None,
         }
     }
 
@@ -577,5 +632,39 @@ mod tests {
         assert_eq!(fmt_uptime(3600), "1h");
         assert_eq!(fmt_uptime(86400), "1d0h");
         assert_eq!(fmt_uptime(86400 * 2 + 3600 * 5), "2d5h");
+    }
+}
+
+#[cfg(test)]
+mod unavailable_section_tests {
+    /// #278 — a section that could not be read must be distinguishable
+    /// from one that is genuinely empty. A 403 on `/access/users` is the
+    /// common case for the scoped token this project recommends, and it
+    /// used to render as "this cluster has no users".
+    #[test]
+    fn the_digest_can_say_a_section_was_unreadable() {
+        let mut d = super::tests::sample_digest();
+        assert!(
+            d.unavailable.is_none(),
+            "a complete digest must not carry the marker"
+        );
+        let complete = serde_json::to_value(&d).expect("serialises");
+        assert!(
+            complete.get("unavailable").is_none(),
+            "the field must be absent from JSON when everything was readable, so \
+             existing consumers see an unchanged shape"
+        );
+
+        d.unavailable = Some(vec!["rbac.users: Proxmox refused (403)".into()]);
+        let incomplete = serde_json::to_value(&d).expect("serialises");
+        let listed = incomplete
+            .get("unavailable")
+            .and_then(|v| v.as_array())
+            .expect("the marker must appear once something was unreadable");
+        assert_eq!(listed.len(), 1);
+        assert!(
+            listed[0].as_str().unwrap_or_default().contains("403"),
+            "the reason must travel with the marker, not just the fact"
+        );
     }
 }

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -155,6 +155,7 @@ pub async fn execute_describe(client: &Arc<PxClient>, args: DescribeArgs) -> Res
     Ok((Value::Null, 0))
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 async fn collect(
     client: &PxClient,
     include_events: bool,

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -27,6 +27,7 @@ impl CheckStatus {
     }
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn run() -> Result<(Value, i32)> {
     let mut checks: Vec<Check> = Vec::new();
     let mut overall_ok = true;

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -223,14 +223,41 @@ pub async fn run() -> Result<(Value, i32)> {
         }
     }
 
+    // Audit 2026-09-09 (#281) — actually verify the chain.
+    //
+    // This used to report OK on the strength of the database opening,
+    // while the README credited doctor with validating "audit log
+    // integrity". A chain broken by an interrupted write, a partial
+    // restore or tampering reported OK here — and since nothing else
+    // runs `verify()` automatically, doctor was the most likely place
+    // for that damage to go unnoticed.
     match crate::audit::AuditLogger::open() {
-        Ok(_) => {
-            checks.push(Check {
-                name: "audit_log",
-                status: CheckStatus::Ok,
-                message: "audit log DB accessible".into(),
-            });
-        }
+        Ok(logger) => match logger.verify() {
+            Ok((ok, 0)) => {
+                checks.push(Check {
+                    name: "audit_log",
+                    status: CheckStatus::Ok,
+                    message: format!("audit chain verified — {ok} entries, chain intact"),
+                });
+            }
+            Ok((ok, broken)) => {
+                checks.push(Check {
+                    name: "audit_log",
+                    status: CheckStatus::Fail,
+                    message: format!(
+                        "audit chain BROKEN — {broken} of {} entries failed verification.                          Run `proxxx audit verify` for the first bad link. Entries after a                          break chain onto the damaged prefix, so the trail cannot be                          trusted from that point on.",
+                        ok + broken
+                    ),
+                });
+            }
+            Err(e) => {
+                checks.push(Check {
+                    name: "audit_log",
+                    status: CheckStatus::Warn,
+                    message: format!("audit chain could not be verified: {e}"),
+                });
+            }
+        },
         Err(e) => {
             checks.push(Check {
                 name: "audit_log",

--- a/src/cli/incident.rs
+++ b/src/cli/incident.rs
@@ -147,9 +147,13 @@ fn audit_thaw(reason: &str, profile: Option<&str>, prior: Option<&incident::Free
     }
 }
 
+/// Fallback operator label when no prior freeze state names one.
+///
+/// #256 — delegates to the same uid-anchored identity the freeze writer
+/// uses, rather than reading `$USER` (which the caller controls) a
+/// second time with different formatting.
 fn default_operator() -> String {
-    let user = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
-    format!("{user}@unknown")
+    crate::incident::operator_label()
 }
 
 /// Open the audit logger, call `f`, then drop it. Encapsulates the

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -66,6 +66,12 @@ token_id = "proxxx"
 # [telegram]
 # bot_token = "0000000000:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 # chat_id = "-1001234567890"
+# REQUIRED for the HITL daemon to act on any approval. Telegram numeric
+# user ids allowed to approve/deny. The callback signature proves proxxx
+# minted the keyboard, not who pressed it — without this list every
+# member of chat_id could approve a destructive op. Get an id from
+# @userinfobot. Absent or empty => every callback is refused.
+# allowed_approvers = [123456789]
 
 # Per-action policies. `action` matches the dispatch identifier used
 # internally (start, stop, restart, delete, migrate, exec, move_disk,
@@ -74,7 +80,8 @@ token_id = "proxxx"
 # action = "delete"
 # target = "tag:prod"
 # channel = "telegram"
-# require = 1                    # Number of approvals needed
+# require = 2                    # DISTINCT approvers needed before the
+#                                # operation runs (1 = single approver)
 
 # ── Optional: SSH layer (SSH layer) ───────────────────────────
 # Enables features that can't go through the Proxmox REST API:

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -179,7 +179,10 @@ fn atomic_write(
         std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
             .with_context(|| format!("setting 0600 on {}", tmp_path.display()))?;
     }
-    std::fs::rename(&tmp_path, config_path).with_context(|| {
+    // #268 — fsync the directory too, so the rename itself survives a
+    // power loss rather than leaving the pre-rename state on disk after
+    // we already told the operator the config was written.
+    crate::util::durable::rename_durable(&tmp_path, config_path).with_context(|| {
         format!(
             "renaming temp config into place at {}",
             config_path.display()

--- a/src/cli/init_wizard.rs
+++ b/src/cli/init_wizard.rs
@@ -27,6 +27,7 @@ const VERIFY_TLS_DEFAULT: bool = true;
 /// Run the interactive wizard. Returns the same shape as the
 /// non-interactive `execute_init` so the calling dispatcher doesn't
 /// have to special-case it.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn run(profile_name: Option<&str>) -> Result<(serde_json::Value, i32)> {
     // The interactive wizard writes the flat top-level config. Appending a
     // *named* profile interactively is a larger flow (it would have to read

--- a/src/cli/init_wizard.rs
+++ b/src/cli/init_wizard.rs
@@ -1004,7 +1004,8 @@ fn write_config(config_dir: &Path, config_path: &Path, body: &str) -> Result<()>
         use std::os::unix::fs::PermissionsExt as _;
         std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))?;
     }
-    std::fs::rename(&tmp, config_path)
+    // #268 — see util::durable.
+    crate::util::durable::rename_durable(&tmp, config_path)
         .with_context(|| format!("renaming into {}", config_path.display()))?;
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1111,6 +1111,7 @@ pub async fn execute(
                 since,
             } => audit_cmd::execute_export(format, *limit, since.as_deref()),
             AuditAction::Verify => audit_cmd::execute_verify(),
+            AuditAction::RotateKey => audit_cmd::execute_rotate_key(),
         };
     }
 
@@ -1304,7 +1305,10 @@ pub async fn execute(
                 // (the streamer's output otherwise starts directly
                 // with the first log line and feels disconnected
                 // from the invocation).
-                let json_mode = matches!(format, util::format::OutputFormat::Json);
+                let json_mode = matches!(
+                    format,
+                    util::format::OutputFormat::Json | util::format::OutputFormat::JsonEnvelope
+                );
                 if !json_mode {
                     eprintln!(
                         "migrating vmid={vmid} {from} → {to} (task {upid})",
@@ -1387,7 +1391,10 @@ pub async fn execute(
         }
         Command::Events { action } => events::execute_events(&client, action).await,
         Command::Logs { action } => {
-            let render = if matches!(format, util::format::OutputFormat::Json) {
+            let render = if matches!(
+                format,
+                util::format::OutputFormat::Json | util::format::OutputFormat::JsonEnvelope
+            ) {
                 logs::LogsRenderMode::Json
             } else {
                 logs::LogsRenderMode::Text

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1002,6 +1002,7 @@ pub enum McpCommand {
 ///
 /// `_secure` is reserved for future per-command HITL gating in pipelines;
 /// it's currently honoured by the TUI only (see `state.secure_mode`).
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute(
     cmd: Command,
     profile: Option<&str>,

--- a/src/cli/monitoring.rs
+++ b/src/cli/monitoring.rs
@@ -461,6 +461,7 @@ pub enum ReplicationCommand {
 }
 
 /// Feature #8 — alerts CLI dispatch.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_alerts(
     client: &Arc<crate::api::PxClient>,
     config: crate::config::ConfigHandle,
@@ -723,6 +724,7 @@ pub async fn execute_alerts(
 /// sparkline + min/max/avg over the chosen field; `--format json`
 /// short-circuits and returns the raw rrddata. Auto-discovers the
 /// owning node when the user omits `--node` for vm/ct.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_metrics(
     client: &Arc<crate::api::PxClient>,
     action: MetricsCommand,
@@ -1231,6 +1233,7 @@ pub async fn execute_disks(
 }
 
 /// Feature #5 — HA console CLI.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_ha(
     client: &Arc<crate::api::PxClient>,
     action: HaCommand,

--- a/src/cli/reconcile.rs
+++ b/src/cli/reconcile.rs
@@ -282,7 +282,7 @@ pub(crate) async fn compute_drift_with_live(
     path: &Path,
 ) -> Result<(Vec<Change>, state::model::ClusterState)> {
     let toml_str = load_desired_toml(source, path).await?;
-    let declared: state::model::ClusterState = toml::from_str(&toml_str).with_context(|| {
+    let declared = state::model::ClusterState::from_toml_str(&toml_str).with_context(|| {
         format!(
             "parsing desired state from `{source}` — is it the output of `proxxx state export`?"
         )

--- a/src/cli/schedule.rs
+++ b/src/cli/schedule.rs
@@ -144,7 +144,9 @@ pub fn save_store_at(path: &std::path::Path, store: &ScheduleStore) -> Result<()
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))?;
     }
-    std::fs::rename(&tmp, path)
+    // #268 — durable rename, so a scheduled job written before a crash
+    // is still there afterwards.
+    crate::util::durable::rename_durable(&tmp, path)
         .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
     Ok(())
 }

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -252,7 +252,7 @@ pub async fn execute_state(
             // Read the declared file.
             let toml_str = std::fs::read_to_string(&declared)
                 .with_context(|| format!("reading declared state from {}", declared.display()))?;
-            let declared_state: state::model::ClusterState = toml::from_str(&toml_str)
+            let declared_state = state::model::ClusterState::from_toml_str(&toml_str)
                 .with_context(|| {
                     format!(
                         "parsing TOML at {} — is it the output of `proxxx state export`?",
@@ -311,7 +311,7 @@ pub async fn execute_state(
         } => {
             let toml_str = std::fs::read_to_string(&declared)
                 .with_context(|| format!("reading declared state from {}", declared.display()))?;
-            let declared_state: state::model::ClusterState = toml::from_str(&toml_str)
+            let declared_state = state::model::ClusterState::from_toml_str(&toml_str)
                 .with_context(|| {
                     format!(
                         "parsing TOML at {} — is it the output of `proxxx state export`?",

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -220,6 +220,7 @@ pub enum DiffFormat {
 /// pipeline — the document IS the output, re-serialising it through
 /// `format::print` would either escape the TOML's newlines or wrap
 /// the JSON in an additional outer layer.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_state(
     client: &Arc<PxClient>,
     profile: Option<&str>,

--- a/src/cli/storage.rs
+++ b/src/cli/storage.rs
@@ -554,6 +554,7 @@ pub async fn execute_storage(
 /// Backup-jobs CRUD CLI. proxxx already has `proxxx backup` for
 /// one-shot vzdump; this surface manages the RECURRING jobs PVE
 /// stores cluster-wide at `/cluster/backup`.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_backup_jobs(
     client: &Arc<crate::api::PxClient>,
     action: BackupJobsCommand,
@@ -1135,6 +1136,7 @@ pub async fn execute_pbs(
 }
 
 /// Feature #2 CLI dispatch.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_iso(
     client: &Arc<crate::api::PxClient>,
     action: IsoCommand,

--- a/src/cli/upgrade_check.rs
+++ b/src/cli/upgrade_check.rs
@@ -167,6 +167,7 @@ pub enum UpgradeOutput {
     Json,
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_upgrade_check(
     client: &Arc<PxClient>,
     config: &crate::config::ProfileConfig,

--- a/src/cli/vm.rs
+++ b/src/cli/vm.rs
@@ -373,6 +373,7 @@ pub enum SnapshotCommand {
     },
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn execute_vm(
     client: &Arc<crate::api::PxClient>,
     action: VmCommand,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -794,6 +794,92 @@ impl ProfileConfig {
         }
     }
 
+    /// Reject values for enum-like string keys that are neither of the
+    /// documented options (audit 2026-09-09, #255).
+    ///
+    /// `auth_method()` above maps anything that is not exactly
+    /// `"password"` to token auth, so `auth = "Password"` or a typo
+    /// silently switched authentication mode: the operator supplied a
+    /// password, got token auth, and the secret chain then either failed
+    /// with a message that never mentioned `auth`, or picked up a
+    /// `PROXXX_TOKEN_SECRET` left over from another profile and
+    /// authenticated as a different identity.
+    ///
+    /// Validated at load rather than in `auth_method` so the failure
+    /// names the key and its accepted values, once, before anything
+    /// tries to connect.
+    ///
+    /// # Errors
+    /// When a key holds a value outside its documented set.
+    /// Warn when a lower-precedence secret source is shadowed by a
+    /// higher one (audit 2026-09-09, #257).
+    ///
+    /// The resolution order is inline-then-file, and both the README and
+    /// the configuration reference stated the opposite until v0.13.4. An
+    /// operator following the production checklist's advice to move a
+    /// secret into a `0600` file, without deleting the inline value,
+    /// therefore kept using the inline one: the file was never read, and
+    /// rotating it had no effect.
+    ///
+    /// The order itself is left alone — changing it would silently swap
+    /// which credential a live deployment authenticates with, which is a
+    /// worse failure than the one being fixed. Instead the shadowing is
+    /// made visible at load.
+    pub fn warn_on_shadowed_secret_sources(&self) {
+        let inline_set = |s: &Option<crate::util::secret::SecretString>| {
+            s.as_ref().is_some_and(|v| !v.expose().trim().is_empty())
+        };
+        if inline_set(&self.token_secret) && self.token_secret_file.is_some() {
+            tracing::warn!(
+                "config: both `token_secret` (inline) and `token_secret_file` are set. \
+                 Inline wins — the file is NOT read, and rotating it will have no \
+                 effect. Delete the inline value to use the file."
+            );
+        }
+        if let Some(pbs) = &self.pbs {
+            if inline_set(&pbs.token_secret) && pbs.token_secret_file.is_some() {
+                tracing::warn!(
+                    "config: both `pbs.token_secret` (inline) and \
+                     `pbs.token_secret_file` are set. Inline wins — the file is NOT \
+                     read. Delete the inline value to use the file."
+                );
+            }
+        }
+        if let Some(tg) = &self.telegram {
+            if inline_set(&tg.bot_token) && tg.bot_token_file.is_some() {
+                tracing::warn!(
+                    "config: both `telegram.bot_token` (inline) and \
+                     `telegram.bot_token_file` are set. Inline wins — the file is \
+                     NOT read. Delete the inline value to use the file."
+                );
+            }
+        }
+    }
+
+    pub fn validate_enum_like_fields(&self) -> Result<()> {
+        const AUTH_VALUES: &[&str] = &["token", "password"];
+        if !AUTH_VALUES.contains(&self.auth.as_str()) {
+            anyhow::bail!(
+                "config key `auth` is {:?}, which is not a recognised value. \
+                 Accepted: {}. Note the comparison is case-sensitive.",
+                self.auth,
+                AUTH_VALUES.join(" | ")
+            );
+        }
+        if let Some(mode) = self.tls_pin_mode.as_deref() {
+            if !mode.trim().is_empty() && !mode.eq_ignore_ascii_case("tofu") {
+                anyhow::bail!(
+                    "config key `tls_pin_mode` is {mode:?}, which is not a recognised \
+                     value. Accepted: \"tofu\" (case-insensitive), or omit the key \
+                     entirely for no pinning. Refusing rather than silently running \
+                     unpinned — you set this key because the default trust posture \
+                     was not enough."
+                );
+            }
+        }
+        Ok(())
+    }
+
     pub async fn resolve_token_secret(&self, cli_secret: Option<&str>) -> Result<SecretString> {
         // 1. CLI Flag
         if let Some(secret) = cli_secret {
@@ -1145,6 +1231,8 @@ pub fn load_config(profile_name: Option<&str>) -> Result<ProfileConfig> {
     // only the global lock. Note this is `effective`, not the raw CLI arg,
     // so a `default = "x"` key or single-profile auto-default is attributed.
     cfg.profile_name = effective;
+    cfg.validate_enum_like_fields()?;
+    cfg.warn_on_shadowed_secret_sources();
     Ok(cfg)
 }
 
@@ -1496,5 +1584,76 @@ verify_tls = false
 "#;
         let cfg: ProfileConfig = toml::from_str(toml).expect("parses");
         assert!(!cfg.verify_tls);
+    }
+}
+
+#[cfg(test)]
+mod enum_like_validation_tests {
+    use super::ProfileConfig;
+
+    fn parse(toml_src: &str) -> ProfileConfig {
+        toml::from_str(toml_src).expect("parses")
+    }
+
+    const BASE: &str = r#"
+url = "https://pve.example:8006"
+user = "root@pam"
+"#;
+
+    /// #255 — `auth_method()` maps anything that is not exactly
+    /// "password" to token auth, so a typo silently switched mode. The
+    /// value is now rejected at load, naming the key.
+    #[test]
+    fn unrecognised_auth_value_is_refused() {
+        for bad in ["Password", "pasword", "tokne", "PAM", ""] {
+            let cfg = parse(&format!("{BASE}auth = \"{bad}\"\n"));
+            let err = cfg
+                .validate_enum_like_fields()
+                .expect_err("must refuse {bad:?}");
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("auth") && msg.contains("token | password"),
+                "the error must name the key and its accepted values, got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn documented_auth_values_are_accepted() {
+        for good in ["token", "password"] {
+            let cfg = parse(&format!("{BASE}auth = \"{good}\"\n"));
+            cfg.validate_enum_like_fields()
+                .unwrap_or_else(|e| panic!("{good} must be accepted: {e}"));
+        }
+        // Omitted entirely -> serde default, which must also be valid.
+        parse(BASE)
+            .validate_enum_like_fields()
+            .expect("the default auth value must itself be valid");
+    }
+
+    /// #255 — a misspelled `tls_pin_mode` used to warn (to a log file
+    /// nobody reads) and run unpinned. The operator set the key because
+    /// the default trust posture was not enough.
+    #[test]
+    fn unrecognised_tls_pin_mode_is_refused() {
+        for bad in ["TOFU ", "pin", "tofu2", "on"] {
+            let cfg = parse(&format!("{BASE}tls_pin_mode = \"{bad}\"\n"));
+            assert!(
+                cfg.validate_enum_like_fields().is_err(),
+                "must refuse tls_pin_mode = {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn tofu_is_accepted_case_insensitively_and_absence_is_fine() {
+        for good in ["tofu", "TOFU", "ToFu"] {
+            let cfg = parse(&format!("{BASE}tls_pin_mode = \"{good}\"\n"));
+            cfg.validate_enum_like_fields()
+                .unwrap_or_else(|e| panic!("{good} must be accepted: {e}"));
+        }
+        parse(BASE)
+            .validate_enum_like_fields()
+            .expect("omitting tls_pin_mode means no pinning, which is valid");
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,7 +17,20 @@ pub struct ProfileConfig {
     pub token_secret: Option<SecretString>,
     pub token_secret_file: Option<String>,
     pub password: Option<SecretString>,
-    #[serde(default)]
+    /// Validate the cluster's TLS certificate. **Defaults to `true`**
+    /// since v0.13.4 (audit 2026-09-09, #251): omitting the key used to
+    /// mean `false`, so a minimal config silently accepted any
+    /// certificate — including one presented by whoever sat between
+    /// proxxx and the cluster, who then received the API token.
+    ///
+    /// Proxmox ships a self-signed certificate, so a fresh cluster needs
+    /// either `verify_tls = false` (deliberate, and what `proxxx doctor`
+    /// will flag as "ok for homelab, not for production") or
+    /// `tls_pin_mode = "tofu"` to pin the leaf on first connect.
+    ///
+    /// The PBS block has defaulted to `true` all along; this aligns the
+    /// two.
+    #[serde(default = "default_verify_tls")]
     pub verify_tls: bool,
     /// Phase 13 audit fix: opt-in TLS pinning. Set to `"tofu"` (case
     /// insensitive) to snapshot the cluster's leaf cert on first connect
@@ -252,6 +265,12 @@ const fn default_verify_tls_pbs() -> bool {
     true
 }
 
+/// See [`ProfileConfig::verify_tls`]. Separate from the PBS default only
+/// because serde needs a path per field.
+const fn default_verify_tls() -> bool {
+    true
+}
+
 /// (Gemini wave-3 audit) — keychain access wrapper.
 ///
 /// `keyring::Entry::get_password()` is **synchronous** and can block
@@ -421,6 +440,23 @@ pub struct TelegramConfig {
     /// Destination chat / channel id. Negative for groups & channels,
     /// positive for direct chats with the bot user.
     pub chat_id: String,
+    /// Telegram numeric user ids allowed to approve or deny a HITL
+    /// request. **Required for the HITL daemon to act on any callback.**
+    ///
+    /// The callback HMAC proves proxxx minted the keyboard; it does not
+    /// establish who pressed the button. Without this list every member
+    /// of `chat_id` — including anyone added to the group later — could
+    /// approve a destructive operation, which then executes with the
+    /// daemon's full PVE credentials (audit 2026-09-09, #249).
+    ///
+    /// Numeric ids only: a Telegram `username` is mutable and can be
+    /// reassigned after release, so an allowlist keyed on handles is
+    /// forgeable. Get yours by messaging `@userinfobot`.
+    ///
+    /// Absent or empty ⇒ the daemon refuses every callback and tells the
+    /// operator to configure it. This is fail-closed by design.
+    #[serde(default)]
+    pub allowed_approvers: Option<Vec<i64>>,
 }
 
 impl TelegramConfig {
@@ -1425,5 +1461,40 @@ mod env_secret_cap_tests {
         let got = env_var_secret(name).expect("a normal-sized value resolves");
         assert_eq!(got.expose(), "a-normal-token-value");
         std::env::remove_var(name);
+    }
+}
+
+#[cfg(test)]
+mod tls_default_tests {
+    use super::ProfileConfig;
+
+    /// #251 — a profile that omits `verify_tls` must validate the
+    /// cluster certificate. Before v0.13.4 the bare `#[serde(default)]`
+    /// on a bool made omission mean "accept any certificate", so a
+    /// minimal config silently trusted whatever cert it was handed.
+    #[test]
+    fn verify_tls_defaults_to_true_when_omitted() {
+        let toml = r#"
+url = "https://pve.example:8006"
+user = "root@pam"
+token_id = "proxxx"
+"#;
+        let cfg: ProfileConfig = toml::from_str(toml).expect("parses");
+        assert!(
+            cfg.verify_tls,
+            "omitting verify_tls must not disable certificate validation"
+        );
+    }
+
+    /// The opt-out still works — it just has to be stated.
+    #[test]
+    fn verify_tls_false_is_still_honoured() {
+        let toml = r#"
+url = "https://pve.example:8006"
+user = "root@pam"
+verify_tls = false
+"#;
+        let cfg: ProfileConfig = toml::from_str(toml).expect("parses");
+        assert!(!cfg.verify_tls);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1113,7 +1113,8 @@ fn write_secret_file(path: &std::path::Path, secret: &str) -> Result<std::path::
         std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))
             .with_context(|| format!("setting 0600 on {}", tmp.display()))?;
     }
-    std::fs::rename(&tmp, path)
+    // #268 — see util::durable.
+    crate::util::durable::rename_durable(&tmp, path)
         .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
     Ok(path.to_path_buf())
 }

--- a/src/hitl/daemon.rs
+++ b/src/hitl/daemon.rs
@@ -55,6 +55,18 @@ pub enum CallbackOutcome {
     InvalidFormat { data: String },
     /// Unknown action token (not start/stop/restart). Ignored.
     UnknownAction { action: String, vmid: u32 },
+    /// The callback was well-formed and correctly signed, but the
+    /// Telegram account that pressed the button is not on the configured
+    /// approver allowlist — or no allowlist is configured at all, which
+    /// is treated the same way. The daemon did NOT execute.
+    UnauthorizedApprover { user_id: i64 },
+    /// The callback originated in a chat other than the configured
+    /// `chat_id` — a forwarded keyboard. The daemon did NOT execute.
+    WrongChat { chat_id: i64 },
+    /// The vote was recorded but the policy's `require` quorum is not
+    /// yet met. The daemon did NOT execute; it is waiting for more
+    /// distinct approvers.
+    AwaitingApprovals { have: usize, need: usize },
 }
 
 /// Process exactly one Telegram update.
@@ -134,6 +146,67 @@ pub async fn handle_callback_update(
         head_payload.to_string()
     };
 
+    // Audit 2026-09-09 (#249) — WHO pressed the button.
+    //
+    // The HMAC above proves this daemon minted the keyboard. It proves
+    // nothing about the person acting on it: Telegram delivers the
+    // buttons to everyone who can see the message, so without this gate
+    // any member of the chat could approve a destructive operation,
+    // which then executes with the daemon's full PVE credentials.
+    //
+    // Two checks, both fail-closed:
+    //   1. The originating chat must be the configured one, so a
+    //      forwarded keyboard cannot drive the daemon.
+    //   2. The sender must be on `allowed_approvers`. An unconfigured
+    //      (empty) allowlist refuses everything rather than accepting
+    //      anyone — same posture as v0.13.0's "destructive MCP tool with
+    //      no policy is REFUSED".
+    if let Some(chat) = cb.message.as_ref().and_then(|m| m.chat.as_ref()) {
+        if tg_gateway.chat_id() != chat.id.to_string() {
+            warn!(
+                "HITL callback from chat {} but configured chat is {} — refused",
+                chat.id,
+                tg_gateway.chat_id()
+            );
+            let _ = tg_gateway
+                .answer_callback(&cb.id, "❌ Wrong chat — refused")
+                .await;
+            return Ok(CallbackOutcome::WrongChat { chat_id: chat.id });
+        }
+    }
+    let approvers = tg_gateway.allowed_approvers();
+    if approvers.is_empty() {
+        warn!(
+            "HITL callback from user {} refused: no `allowed_approvers` configured. \
+             Add the approving Telegram user ids to the profile's [telegram] section \
+             (numeric ids, e.g. from @userinfobot) — proxxx will not act on an \
+             unauthenticated approval.",
+            cb.from.id
+        );
+        let _ = tg_gateway
+            .answer_callback(
+                &cb.id,
+                "❌ No approver allowlist configured — refused. See `allowed_approvers`.",
+            )
+            .await;
+        return Ok(CallbackOutcome::UnauthorizedApprover {
+            user_id: cb.from.id,
+        });
+    }
+    if !approvers.contains(&cb.from.id) {
+        warn!(
+            "HITL callback from unauthorised user {} (@{}) — refused",
+            cb.from.id,
+            cb.from.username.as_deref().unwrap_or("?")
+        );
+        let _ = tg_gateway
+            .answer_callback(&cb.id, "❌ Not an authorised approver — refused")
+            .await;
+        return Ok(CallbackOutcome::UnauthorizedApprover {
+            user_id: cb.from.id,
+        });
+    }
+
     let parts: Vec<&str> = payload_for_parse.split(':').collect();
     if parts.len() < 3 {
         let _ = tg_gateway
@@ -174,6 +247,43 @@ pub async fn handle_callback_update(
             action: action.to_string(),
             vmid,
         });
+    }
+
+    // #250 — quorum. `require` rides in the signed payload as a 4th
+    // segment (`r<N>`); a keyboard minted before v0.13.4 has no such
+    // segment and means "one approver", which is the historic behaviour.
+    let require: u8 = parts
+        .get(3)
+        .and_then(|seg| seg.strip_prefix('r'))
+        .and_then(|n| n.parse().ok())
+        .unwrap_or(1);
+
+    // Vote BEFORE the replay gate: every approver presses the same
+    // keyboard, so their callback data is identical by construction and
+    // the replay gate would reject the second signature as a duplicate.
+    // Only the callback that completes the quorum falls through to
+    // `consume`, which then makes the whole transaction single-use.
+    match pending.record_vote(data, cb.from.id, require) {
+        crate::hitl::pending::VoteProgress::Satisfied => {}
+        crate::hitl::pending::VoteProgress::Waiting {
+            have,
+            need,
+            duplicate,
+        } => {
+            let note = if duplicate {
+                format!("You already approved — {have}/{need}")
+            } else {
+                format!("Recorded — {have}/{need} approvals")
+            };
+            info!("HITL quorum not yet met for {data}: {have}/{need}");
+            let _ = tg_gateway.answer_callback(&cb.id, &note).await;
+            edit_status(
+                &format!("\u{23f3} Awaiting approval ({have}/{need})"),
+                cb.from.username.as_deref().unwrap_or(&cb.from.first_name),
+            )
+            .await;
+            return Ok(CallbackOutcome::AwaitingApprovals { have, need });
+        }
     }
 
     // Replay gate. The full callback data string IS the txn_id from the

--- a/src/hitl/daemon.rs
+++ b/src/hitl/daemon.rs
@@ -84,6 +84,7 @@ pub enum CallbackOutcome {
 /// Never returns `Err` — all failure modes surface through
 /// `CallbackOutcome`. The `Result` return is reserved for future
 /// expansion (e.g. propagating shutdown signals).
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn handle_callback_update(
     update: &Update,
     pending: &PendingApprovals,

--- a/src/hitl/hmac_key.rs
+++ b/src/hitl/hmac_key.rs
@@ -129,7 +129,10 @@ pub fn load_or_generate_hmac_key() -> Result<Vec<u8>> {
             f.set_permissions(perms)?;
         }
     }
-    std::fs::rename(&tmp, &path).with_context(|| format!("renaming tmp to {}", path.display()))?;
+    // #268 — durable: losing a newly generated key to a power loss makes
+    // every callback signed with it unverifiable.
+    crate::util::durable::rename_durable(&tmp, &path)
+        .with_context(|| format!("renaming tmp to {}", path.display()))?;
     Ok(key.to_vec())
 }
 

--- a/src/hitl/pending.rs
+++ b/src/hitl/pending.rs
@@ -28,7 +28,7 @@
 //! The Telegram offset advancement (`offset = max(offset, id+1)`) is
 //! the cross-restart line of defense.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
 /// Reason a callback was rejected by the dedup gate.
@@ -52,6 +52,24 @@ pub enum ReplayError {
 /// below any reasonable concern.
 pub struct PendingApprovals {
     consumed: Mutex<HashSet<String>>,
+    /// Per-transaction set of distinct approver ids, for the `require`
+    /// quorum. Session-local, exactly like `consumed` — see the scope
+    /// note in the module header.
+    votes: Mutex<HashMap<String, HashSet<i64>>>,
+}
+
+/// Outcome of recording one approver's vote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoteProgress {
+    /// The quorum is met; the caller may proceed to execute.
+    Satisfied,
+    /// Still short of the quorum. `duplicate` is true when this approver
+    /// had already voted, so the count did not move.
+    Waiting {
+        have: usize,
+        need: usize,
+        duplicate: bool,
+    },
 }
 
 impl Default for PendingApprovals {
@@ -65,6 +83,38 @@ impl PendingApprovals {
     pub fn new() -> Self {
         Self {
             consumed: Mutex::new(HashSet::new()),
+            votes: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Record one approver's vote for `txn_id` and report whether the
+    /// configured quorum is now satisfied (audit 2026-09-09, #250).
+    ///
+    /// Votes are a SET of approver ids, so the same person pressing
+    /// Approve twice counts once — an N-of-M control that one enthusiastic
+    /// operator can satisfy alone is not a control. `require <= 1` is the
+    /// ordinary single-approver case and is satisfied immediately.
+    ///
+    /// The lock is held across the read-modify-write so two callbacks
+    /// arriving concurrently cannot both observe `have == require - 1`
+    /// and both conclude they completed the quorum.
+    pub fn record_vote(&self, txn_id: &str, approver: i64, require: u8) -> VoteProgress {
+        let mut guard = self
+            .votes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let voters = guard.entry(txn_id.to_string()).or_default();
+        let fresh = voters.insert(approver);
+        let have = voters.len();
+        let need = require.max(1) as usize;
+        if have >= need {
+            VoteProgress::Satisfied
+        } else {
+            VoteProgress::Waiting {
+                have,
+                need,
+                duplicate: !fresh,
+            }
         }
     }
 

--- a/src/hitl/telegram.rs
+++ b/src/hitl/telegram.rs
@@ -94,7 +94,19 @@ struct TgResponse<T> {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Chat {
+    pub id: i64,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Message {
+    /// Chat the keyboard message lives in. Compared against the
+    /// configured `chat_id` before a callback is honoured, so a keyboard
+    /// forwarded into another chat cannot drive the daemon. `Option`
+    /// because Telegram omits `message` on callbacks from inline mode,
+    /// which proxxx never sends.
+    #[serde(default)]
+    pub chat: Option<Chat>,
     /// Telegram-assigned id for THIS message. Required for the
     /// lifecycle-edit flow: when a callback arrives, the daemon
     /// reads `cb.message.message_id` and calls `edit_message_text`
@@ -120,6 +132,12 @@ pub struct CallbackQuery {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct User {
+    /// Telegram numeric user id. This is the ONLY stable identifier for
+    /// a Telegram account: `username` is mutable and reassignable, so an
+    /// allowlist keyed on it would be forgeable by whoever claims a
+    /// released handle. Approver authorisation compares this field.
+    #[serde(default)]
+    pub id: i64,
     pub username: Option<String>,
     pub first_name: String,
 }
@@ -152,6 +170,11 @@ pub struct TelegramGateway {
     /// `from_config()` call. Tests inject a deterministic key via
     /// `with_base_url_and_key`.
     hmac_key: Vec<u8>,
+    /// Telegram user ids permitted to act on an approval keyboard.
+    /// Empty means "no allowlist configured" — the daemon refuses every
+    /// callback in that state rather than accepting anyone who can see
+    /// the message (audit 2026-09-09, #249).
+    allowed_approvers: Vec<i64>,
 }
 
 impl TelegramGateway {
@@ -173,6 +196,7 @@ impl TelegramGateway {
             chat_id,
             base_url: DEFAULT_TG_API.to_string(),
             hmac_key,
+            allowed_approvers: Vec::new(),
         })
     }
 
@@ -208,6 +232,7 @@ impl TelegramGateway {
             chat_id,
             base_url,
             hmac_key,
+            allowed_approvers: Vec::new(),
         }
     }
 
@@ -219,13 +244,38 @@ impl TelegramGateway {
         &self.hmac_key
     }
 
+    /// Telegram user ids permitted to act on an approval keyboard.
+    /// Empty means no allowlist is configured, which the daemon treats
+    /// as "refuse every callback" rather than "accept anyone".
+    #[must_use]
+    pub fn allowed_approvers(&self) -> &[i64] {
+        &self.allowed_approvers
+    }
+
+    /// The configured destination chat. A callback whose originating
+    /// chat differs is refused, so a keyboard forwarded elsewhere cannot
+    /// drive the daemon.
+    #[must_use]
+    pub fn chat_id(&self) -> &str {
+        &self.chat_id
+    }
+
+    /// Builder used by `from_config` and by tests to install the
+    /// approver allowlist.
+    #[must_use]
+    pub fn with_allowed_approvers(mut self, ids: Vec<i64>) -> Self {
+        self.allowed_approvers = ids;
+        self
+    }
+
     /// High-level convenience: resolve the bot token via the configured
     /// hierarchy (env / file / inline / keychain) and build the gateway.
     /// Use this from production call sites; tests should prefer
     /// `with_base_url()` and pass an explicit fake token.
     pub async fn from_config(config: &crate::config::TelegramConfig) -> Result<Self> {
         let token = config.resolve_bot_token().await?;
-        Self::new(token, config.chat_id.clone())
+        let gw = Self::new(token, config.chat_id.clone())?;
+        Ok(gw.with_allowed_approvers(config.allowed_approvers.clone().unwrap_or_default()))
     }
 
     /// Sends a request for approval to the Telegram chat.
@@ -236,6 +286,7 @@ impl TelegramGateway {
         target: &str,
         reason: &str,
         txn_id: &str,
+        require: u8,
     ) -> Result<i64> {
         // Phase 5.13 — escape user-controlled values inserted into the
         // MarkdownV2 message body. Without this, any reason / txn_id /
@@ -256,7 +307,16 @@ impl TelegramGateway {
         // token but not the HMAC key. Tag is appended as `:<hex>` to
         // the existing `decision:txn_id` shape; the daemon parser
         // peels it off and re-verifies before consuming the txn.
-        let approve_payload = format!("approve:{txn_id}");
+        // #250 — the quorum travels in the signed payload. The sender
+        // knows which policy fired; the daemon does not (it is a separate
+        // process and cannot re-derive tag-scoped matches without a
+        // cluster round trip). The HMAC below covers this segment, so it
+        // cannot be edited by whoever holds the keyboard.
+        //
+        // Appended as a 4th `:`-segment. The daemon's parser reads
+        // segments 0..3 and ignores extras, so a keyboard minted by an
+        // older proxxx (3 segments) still parses and means "require 1".
+        let approve_payload = format!("approve:{txn_id}:r{require}");
         let approve_tag = crate::hitl::hmac_key::sign(&self.hmac_key, &approve_payload);
         let deny_payload = format!("deny:{txn_id}");
         let deny_tag = crate::hitl::hmac_key::sign(&self.hmac_key, &deny_payload);

--- a/src/incident/mod.rs
+++ b/src/incident/mod.rs
@@ -202,10 +202,88 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
+/// Identify the operator for the audit trail.
+///
+/// Audit 2026-09-09 (#256): this used to read `$USER`, which the calling
+/// process controls — `USER=someone-else proxxx incident freeze` wrote
+/// and then cryptographically sealed an entry attributing the action to
+/// whoever was named. The v2 chain format binds the actor into the MAC
+/// specifically so a local tamperer cannot rewrite it afterwards; that
+/// is worth nothing if the field was never true to begin with.
+///
+/// The real uid cannot be set by the environment, so it is the anchor.
+/// The resolved login name is a convenience on top: if `$USER` disagrees
+/// with the uid's passwd entry, the uid wins and the claimed name is
+/// recorded separately as unverified, rather than being silently
+/// believed or silently dropped.
+/// Public wrapper so the CLI's audit hooks label the operator exactly
+/// the way the freeze writer does.
+#[must_use]
+pub fn operator_label() -> String {
+    operator_id()
+}
+
 fn operator_id() -> String {
-    let user = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
     let host = hostname_or_unknown();
-    format!("{user}@{host}")
+    let uid = real_uid();
+    let resolved = login_name_for_uid(uid);
+    let claimed = std::env::var("USER").ok();
+
+    let who = match (resolved.as_deref(), claimed.as_deref()) {
+        // Resolved name and the environment agree — the ordinary case.
+        (Some(r), Some(c)) if r == c => r.to_string(),
+        // Disagreement, or no passwd entry: keep the uid, which is
+        // authoritative, and mark the claim as unverified.
+        (Some(r), Some(c)) => format!("{r}(uid:{uid};claimed:{c})"),
+        (Some(r), None) => r.to_string(),
+        (None, Some(c)) => format!("uid:{uid}(claimed:{c})"),
+        (None, None) => format!("uid:{uid}"),
+    };
+    format!("{who}@{host}")
+}
+
+/// The real (not effective) uid of this process. Unlike `$USER` this is
+/// kernel state and cannot be set by whoever launched us.
+#[cfg(unix)]
+fn real_uid() -> u32 {
+    // SAFETY: `getuid` is always successful, takes no arguments and
+    // touches no memory we own. It is one of the few genuinely
+    // infallible syscalls.
+    unsafe { libc::getuid() }
+}
+
+#[cfg(not(unix))]
+fn real_uid() -> u32 {
+    0
+}
+
+/// Resolve a uid to its login name via the passwd database.
+#[cfg(unix)]
+fn login_name_for_uid(uid: u32) -> Option<String> {
+    // SAFETY: `getpwuid` returns a pointer into a static buffer owned by
+    // libc, or NULL when the uid has no passwd entry. We copy the name
+    // out immediately and never retain the pointer, and the buffer is
+    // not mutated between the call and the copy on any single-threaded
+    // path through here.
+    unsafe {
+        let pw = libc::getpwuid(uid as libc::uid_t);
+        if pw.is_null() {
+            return None;
+        }
+        let name = (*pw).pw_name;
+        if name.is_null() {
+            return None;
+        }
+        std::ffi::CStr::from_ptr(name)
+            .to_str()
+            .ok()
+            .map(str::to_owned)
+    }
+}
+
+#[cfg(not(unix))]
+fn login_name_for_uid(_uid: u32) -> Option<String> {
+    std::env::var("USERNAME").ok()
 }
 
 fn hostname_or_unknown() -> String {
@@ -260,11 +338,11 @@ pub fn current_state_at(path: &std::path::Path) -> Result<Option<FreezeState>> {
 /// future MCP dispatch, future scheduler tick) calls this at the
 /// top before any side-effect.
 ///
-/// I/O errors reading the lock are treated as "no freeze" — we
-/// prefer to over-permit than to silently lock the cluster out due
-/// to a transient I/O failure. The error is logged but not
-/// propagated. This is a deliberate trade-off documented in #64
-/// discussion.
+/// A lock file that exists but cannot be read or parsed is treated as
+/// an ACTIVE freeze, not as an absent one (#252). Only a missing file
+/// means "not frozen". The earlier posture — over-permit on any I/O
+/// error, per the #64 discussion — did not distinguish the two, so a
+/// corrupt lock silently disarmed the kill-switch.
 pub fn check_not_frozen() -> Result<()> {
     check_not_frozen_at(&freeze_path())
 }
@@ -306,9 +384,38 @@ pub fn check_not_frozen_at(path: &std::path::Path) -> Result<()> {
             frozen_at: state.frozen_at,
         })),
         Ok(None) => Ok(()),
+        // Audit 2026-09-09 (#252) — an unreadable lock is UNKNOWN state,
+        // not absent state, and for a kill-switch unknown must mean
+        // stopped.
+        //
+        // This branch used to return `Ok(())` on the reasoning that a
+        // transient I/O error should not lock the cluster out. But the
+        // two cases were conflated: `current_state_at` already returns
+        // `Ok(None)` when the file does not exist, which is the only
+        // case that legitimately means "not frozen". Reaching here means
+        // the file IS there and could not be read or parsed — a torn
+        // write after power loss, a truncated copy, a full disk, or
+        // tampering — and proceeding then silently disarms the control
+        // at exactly the moment it is being relied on.
+        //
+        // `proxxx incident thaw` rewrites the file, so the operator
+        // still has a deliberate way out that does not involve the
+        // process guessing.
         Err(e) => {
-            tracing::warn!("freeze: lock unreadable, allowing operation through: {e:#}");
-            Ok(())
+            tracing::warn!(
+                "freeze: lock at {} exists but is unreadable — refusing the operation: {e:#}",
+                path.display()
+            );
+            Err(anyhow::Error::from(FreezeRefusal {
+                scope: "the fleet (lock unreadable)".to_string(),
+                reason: format!(
+                    "the freeze lock at {} could not be read or parsed, so proxxx cannot \
+                     tell whether a freeze is active. Run `proxxx incident thaw` to clear \
+                     it deliberately, or repair the file. Underlying error: {e}",
+                    path.display()
+                ),
+                frozen_at: 0,
+            }))
         }
     }
 }
@@ -456,6 +563,35 @@ fn write_atomic(path: &std::path::Path, content: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    /// #252 — a lock file that exists but cannot be parsed is UNKNOWN
+    /// state, and a kill-switch must treat unknown as stopped. Before
+    /// v0.13.4 this returned `Ok(())`, so a torn or truncated lock
+    /// silently disarmed the control.
+    #[test]
+    fn unreadable_lock_refuses_the_operation() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let path = dir.path().join("freeze.lock");
+        std::fs::write(&path, b"\xff\xfe not toml at all \x00").expect("write garbage");
+        let err = super::check_not_frozen_at(&path)
+            .expect_err("a corrupt lock must refuse, not pass through");
+        let refusal = err
+            .downcast_ref::<super::FreezeRefusal>()
+            .expect("must surface as a typed FreezeRefusal (exit code 8)");
+        assert!(
+            refusal.reason.contains("could not be read or parsed"),
+            "the refusal must tell the operator why: {}",
+            refusal.reason
+        );
+    }
+
+    /// The distinction that matters: absent still means not frozen.
+    #[test]
+    fn absent_lock_still_passes() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let path = dir.path().join("does-not-exist.lock");
+        super::check_not_frozen_at(&path).expect("an absent lock means not frozen");
+    }
+
     use super::*;
 
     /// Each test gets its own private temp directory + lock file
@@ -704,5 +840,54 @@ mod tests {
             scopes,
             vec![None, Some("alpha".into()), Some("beta".into())]
         );
+    }
+}
+
+#[cfg(test)]
+mod operator_identity_tests {
+    /// #256 — the audit actor must be anchored on the real uid, which
+    /// the caller cannot set, rather than on `$USER`, which it can.
+    ///
+    /// This test does not mutate the environment (it is process-global
+    /// and other tests in this binary run in parallel); it asserts the
+    /// structural property instead: whatever `$USER` says, the label
+    /// resolves from the passwd entry for our real uid, and a
+    /// disagreement is marked rather than believed.
+    #[test]
+    fn operator_label_is_anchored_on_the_real_uid() {
+        let label = super::operator_label();
+        assert!(
+            label.contains('@'),
+            "the label must carry a host component: {label}"
+        );
+        let who = label.split('@').next().unwrap_or_default();
+        assert!(!who.is_empty(), "the actor part must not be empty: {label}");
+
+        // Either the resolved passwd name (agreeing with $USER), or an
+        // explicit marker that the two disagreed / could not be resolved.
+        let resolved = super::login_name_for_uid(super::real_uid());
+        let claimed = std::env::var("USER").ok();
+        match (resolved.as_deref(), claimed.as_deref()) {
+            (Some(r), Some(c)) if r == c => assert_eq!(who, r),
+            (Some(_), Some(_)) => assert!(
+                who.contains("uid:") && who.contains("claimed:"),
+                "a disagreement must be recorded, not silently resolved: {label}"
+            ),
+            _ => assert!(
+                who.contains("uid:") || Some(who) == resolved.as_deref(),
+                "unexpected label shape: {label}"
+            ),
+        }
+    }
+
+    /// The uid is real kernel state — it must not be affected by the
+    /// environment variable the old implementation trusted.
+    #[test]
+    fn real_uid_is_not_influenced_by_env() {
+        let before = super::real_uid();
+        // Reading is enough: we assert stability across a call that would
+        // have changed the old `$USER`-derived answer.
+        let after = super::real_uid();
+        assert_eq!(before, after, "getuid() must be stable");
     }
 }

--- a/src/incident/mod.rs
+++ b/src/incident/mod.rs
@@ -856,29 +856,41 @@ mod operator_identity_tests {
     /// structural property instead: whatever `$USER` says, the label
     /// resolves from the passwd entry for our real uid, and a
     /// disagreement is marked rather than believed.
+    /// Assertion messages here deliberately describe the SHAPE of the
+    /// label rather than interpolating it. A uid is not a credential,
+    /// but it is account-identifying, and `CodeQL`'s `rust/cleartext-logging`
+    /// is right that a test failure should not be the thing that prints
+    /// it into CI output. The structural description is what a reader
+    /// debugging a failure actually needs.
     #[test]
     fn operator_label_is_anchored_on_the_real_uid() {
         let label = super::operator_label();
         assert!(
             label.contains('@'),
-            "the label must carry a host component: {label}"
+            "the label must carry a host component (got {} chars, no '@')",
+            label.len()
         );
         let who = label.split('@').next().unwrap_or_default();
-        assert!(!who.is_empty(), "the actor part must not be empty: {label}");
+        assert!(!who.is_empty(), "the actor part must not be empty");
 
         // Either the resolved passwd name (agreeing with $USER), or an
         // explicit marker that the two disagreed / could not be resolved.
         let resolved = super::login_name_for_uid(super::real_uid());
         let claimed = std::env::var("USER").ok();
         match (resolved.as_deref(), claimed.as_deref()) {
-            (Some(r), Some(c)) if r == c => assert_eq!(who, r),
+            (Some(r), Some(c)) if r == c => assert_eq!(
+                who, r,
+                "when passwd and $USER agree the label must be that name verbatim"
+            ),
             (Some(_), Some(_)) => assert!(
                 who.contains("uid:") && who.contains("claimed:"),
-                "a disagreement must be recorded, not silently resolved: {label}"
+                "passwd and $USER disagree, so the label must carry both the uid \
+                 and the unverified claim — it carried neither marker"
             ),
             _ => assert!(
                 who.contains("uid:") || Some(who) == resolved.as_deref(),
-                "unexpected label shape: {label}"
+                "with no passwd entry or no $USER, the label must fall back to the \
+                 uid form or to the resolved name"
             ),
         }
     }

--- a/src/incident/mod.rs
+++ b/src/incident/mod.rs
@@ -556,7 +556,10 @@ fn write_atomic(path: &std::path::Path, content: &str) -> Result<()> {
         std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))
             .with_context(|| format!("chmod 0600 {}", tmp.display()))?;
     }
-    std::fs::rename(&tmp, path)
+    // #268 — the freeze lock above all: a rename that does not survive a
+    // power loss means the kill-switch is off after the reboot, while the
+    // operator was told the fleet was frozen.
+    crate::util::durable::rename_durable(&tmp, path)
         .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,32 @@
-// Library root — exposes modules for integration tests
-// The binary entry point is main.rs
+//! proxxx as a library.
+//!
+//! # Compatibility (audit 2026-09-09, #284)
+//!
+//! This crate is consumed by the proxxx binary, by the integration tests
+//! and — since v0.9.2 — by the **proxima** desktop UI, which links it
+//! directly. The per-surface `SemVer` contract at the top of `CHANGELOG.md`
+//! enumerated the CLI, exit codes, `--format json`, the config schema
+//! and the MCP registry, and said nothing about this one; the header
+//! here still described the crate as existing "for integration tests"
+//! long after that stopped being the whole truth.
+//!
+//! The supported surface is:
+//!
+//! * [`api`] — `ProxmoxGateway`, `PxClient`, `ApiError` and the types in
+//!   `api::types`. Additive within a minor; signature changes are major.
+//! * [`config`] — `ProfileConfig` and its nested structs.
+//! * [`app::preflight`] — the risk gate, so a consumer can run the same
+//!   assessment before mutating.
+//! * [`state::model`] — the declarative schema, versioned by
+//!   `StateMeta::schema_version`.
+//!
+//! Everything else is an implementation detail and may change in any
+//! release, including `tui`, `cli`, `state::test_support`, and the
+//! internals of `app` outside `preflight`. If you depend on one of those,
+//! open an issue and say why — it is easier to widen the contract than
+//! to guess who is relying on what.
+//
+// The binary entry point is main.rs.
 
 // Production code obeys the strict deny lints in Cargo.toml.
 // Tests use `unwrap`/`expect`/`panic`/indexing for assertion ergonomics

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,8 +229,11 @@ fn main() -> Result<()> {
                     if !result.is_null() {
                         // Ensure the output is a JSON array if Json
                         // format is requested.
-                        let result_array = if matches!(cli.format, util::format::OutputFormat::Json)
-                            && !result.is_array()
+                        let result_array = if matches!(
+                            cli.format,
+                            util::format::OutputFormat::Json
+                                | util::format::OutputFormat::JsonEnvelope
+                        ) && !result.is_array()
                         {
                             serde_json::json!([result])
                         } else {
@@ -301,7 +304,10 @@ fn main() -> Result<()> {
                         }
                         None
                     });
-                    if matches!(cli.format, util::format::OutputFormat::Json) {
+                    if matches!(
+                        cli.format,
+                        util::format::OutputFormat::Json | util::format::OutputFormat::JsonEnvelope
+                    ) {
                         let mut err_obj = serde_json::json!({
                             "error": e.to_string(),
                             "status": "fatal_error",

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,9 +24,23 @@ struct Cli {
     #[arg(long, global = true, default_value = "table")]
     format: util::format::OutputFormat,
 
-    /// API Token Secret (Overrides env var and config file)
+    /// API token secret. **Visible in the process listing** (`ps`,
+    /// `/proc/<pid>/cmdline`) for as long as the command runs, and in
+    /// shell history and CI logs. Prefer `--token-secret-file`,
+    /// `PROXXX_TOKEN_SECRET`, or the OS keychain — especially for
+    /// `daemon serve`, which is long-running.
     #[arg(long, global = true)]
     token_secret: Option<String>,
+
+    /// Read the API token secret from a file (audit #283).
+    ///
+    /// Unlike `--token-secret` this leaves nothing in the process
+    /// listing. The file must be readable by this process; trailing
+    /// whitespace is trimmed. Takes precedence over `--token-secret`
+    /// when both are given, because it is the safer of the two and a
+    /// caller passing both most likely means the file.
+    #[arg(long, global = true, value_name = "PATH")]
+    token_secret_file: Option<std::path::PathBuf>,
 
     /// Require Telegram 2FA for all destructive operations (Self-HITL)
     #[arg(long, global = true)]
@@ -36,6 +50,25 @@ struct Cli {
 #[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // #283 — resolve the file form once, here, so every downstream call
+    // site sees one value and neither has to know which flag supplied
+    // it. `--token-secret-file` wins when both are given: it is the
+    // safer of the two, and a caller passing both most likely means the
+    // file.
+    let cli_secret: Option<String> = match &cli.token_secret_file {
+        Some(path) => {
+            let raw = std::fs::read_to_string(path).map_err(|e| {
+                anyhow::anyhow!("reading --token-secret-file {}: {e}", path.display())
+            })?;
+            let trimmed = raw.trim().to_string();
+            if trimmed.is_empty() {
+                anyhow::bail!("--token-secret-file {} is empty", path.display());
+            }
+            Some(trimmed)
+        }
+        None => cli.token_secret.clone(),
+    };
 
     // Tracing → rotating file always; stderr as well outside the TUI
     // (see the block below and #270).
@@ -167,14 +200,11 @@ fn main() -> Result<()> {
             // TUI, then re-enter the fleet view when the user quits it.
             if matches!(cmd, cli::Command::Fleet) {
                 rt.block_on(async {
-                    while let Some(profile) =
-                        tui::fleet::run_fleet(cli.token_secret.as_deref()).await?
-                    {
+                    while let Some(profile) = tui::fleet::run_fleet(cli_secret.as_deref()).await? {
                         // Open the selected cluster's full TUI. Its own
                         // profile-switch return value is ignored — on exit
                         // we always come back to the fleet overview.
-                        let _ = tui::run(Some(&profile), cli.token_secret.as_deref(), cli.secure)
-                            .await?;
+                        let _ = tui::run(Some(&profile), cli_secret.as_deref(), cli.secure).await?;
                     }
                     Ok::<(), anyhow::Error>(())
                 })?;
@@ -184,7 +214,7 @@ fn main() -> Result<()> {
             match rt.block_on(cli::execute(
                 cmd,
                 cli.profile.as_deref(),
-                cli.token_secret.as_deref(),
+                cli_secret.as_deref(),
                 cli.secure,
                 cli.format,
             )) {
@@ -312,7 +342,7 @@ fn main() -> Result<()> {
             loop {
                 let next = rt.block_on(tui::run(
                     active_profile.as_deref(),
-                    cli.token_secret.as_deref(),
+                    cli_secret.as_deref(),
                     cli.secure,
                 ))?;
                 match next {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ struct Cli {
     secure: bool,
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn main() -> Result<()> {
     let cli = Cli::parse();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,8 @@ struct Cli {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Tracing → file only (TUI owns stdout).
+    // Tracing → rotating file always; stderr as well outside the TUI
+    // (see the block below and #270).
     //
     // (macro audit) — capped log rotation. Without
     // `max_log_files` a daemon left running for months on a flapping
@@ -74,12 +75,63 @@ fn main() -> Result<()> {
         .build(&log_dir)
         .map_err(|e| anyhow::anyhow!("log appender init failed: {e}"))?;
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-    tracing_subscriber::fmt()
-        .with_writer(non_blocking)
-        .with_env_filter("proxxx=debug")
-        .init();
 
-    info!("proxxx v{} starting", env!("CARGO_PKG_VERSION"));
+    // Audit 2026-09-09 (#270) — two fixes here.
+    //
+    // 1. STDERR AS WELL AS THE FILE, outside the TUI. "The TUI owns
+    //    stdout" is right for the TUI and wrong for everything else: a
+    //    daemon under the systemd unit this project recommends produced
+    //    a journald stream containing its start and stop lines and
+    //    nothing else, forever. Every diagnostic that matters was
+    //    diverted to a file the operator had not been told about and no
+    //    log shipper was watching — including "freeze: lock unreadable"
+    //    (the write kill-switch has disengaged) and "tls_pin_mode is not
+    //    recognised" (certificate pinning is off).
+    //
+    //    stderr, not stdout: `--format json` and `state export` write
+    //    machine-readable output to stdout, and log lines interleaved
+    //    with it would corrupt every pipeline.
+    //
+    // 2. `RUST_LOG` IS HONOURED. The filter was the compile-time literal
+    //    "proxxx=debug", so every request URL was written to disk on
+    //    every run and retained for 14 days, while an operator debugging
+    //    a TLS or russh problem could not raise those crates above their
+    //    defaults. Worse, setting `RUST_LOG` silently did nothing, which
+    //    is more misleading than not supporting it.
+    //
+    //    The default drops to `info` for the file too: `debug` was
+    //    logging a line per HTTP request, which is a lot of disk for a
+    //    long-running daemon and is one `RUST_LOG=proxxx=debug` away
+    //    when someone actually needs it.
+    let filter = || {
+        tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("proxxx=info"))
+    };
+    let is_tui = cli.command.is_none();
+    if is_tui {
+        tracing_subscriber::fmt()
+            .with_writer(non_blocking)
+            .with_env_filter(filter())
+            .init();
+    } else {
+        use tracing_subscriber::layer::SubscriberExt as _;
+        use tracing_subscriber::util::SubscriberInitExt as _;
+        tracing_subscriber::registry()
+            .with(filter())
+            .with(tracing_subscriber::fmt::layer().with_writer(non_blocking))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(std::io::stderr)
+                    .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stderr())),
+            )
+            .init();
+    }
+
+    info!(
+        "proxxx v{} starting (log file: {})",
+        env!("CARGO_PKG_VERSION"),
+        log_dir.join("proxxx.log.<date>").display()
+    );
 
     // flight recorder: install the flight-recorder panic hook BEFORE the
     // tokio runtime / TUI / CLI runs. This way a panic anywhere — in

--- a/src/mcp/dispatch.rs
+++ b/src/mcp/dispatch.rs
@@ -45,8 +45,15 @@ pub async fn handle_tool_call(
                     }
                 }
                 ParamType::Str => {
-                    if !val.is_string() {
+                    let Some(text) = val.as_str() else {
                         anyhow::bail!("Parameter '{}': expected string, got {}", p.name, val);
+                    };
+                    // #254 — enforce the registry's declared shape. Until
+                    // v0.13.4 a string parameter was only checked for
+                    // being a string, so values that become PVE path
+                    // segments arrived unconstrained.
+                    if let Err(why) = p.shape.check(text) {
+                        anyhow::bail!("Parameter '{}': {}", p.name, why);
                     }
                 }
             }

--- a/src/mcp/dispatch.rs
+++ b/src/mcp/dispatch.rs
@@ -127,7 +127,7 @@ pub async fn handle_tool_call(
                     Ok(tg_gateway) => {
                         let reason = format!("MCP requested action: {name}");
                         let _ = tg_gateway
-                            .request_approval(name, &target, &reason, &txn_id)
+                            .request_approval(name, &target, &reason, &txn_id, policy.require)
                             .await;
                     }
                     Err(e) => {

--- a/src/mcp/dispatch.rs
+++ b/src/mcp/dispatch.rs
@@ -16,6 +16,7 @@ use crate::mcp::tools::{ToolAction, TOOLS};
 ///
 /// Returns `Ok(json!({"content": [{"type":"text","text":...}]}))` on success.
 /// The caller wraps this in a JSON-RPC result or HTTP response body.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn handle_tool_call(
     client: &PxClient,
     config: &ProfileConfig,

--- a/src/mcp/http_server.rs
+++ b/src/mcp/http_server.rs
@@ -16,8 +16,9 @@
 
 use anyhow::Result;
 use axum::{
-    extract::State,
+    extract::{Request, State},
     http::{HeaderMap, StatusCode},
+    middleware::{self, Next},
     response::{
         sse::{Event, Sse},
         IntoResponse, Response,
@@ -123,6 +124,28 @@ fn sha256_bytes(s: &str) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(s.as_bytes());
     hasher.finalize().into()
+}
+
+/// Router-level authorization gate.
+///
+/// Runs before any protected handler. Handlers keep their own
+/// `auth_ok` call as defence in depth — belt and braces cost one hash
+/// comparison, and a future refactor that drops the layer should not
+/// silently open the surface.
+async fn require_authorized(
+    State(state): State<McpState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if state.auth_ok(request.headers()).await {
+        return next.run(request).await;
+    }
+    (
+        StatusCode::UNAUTHORIZED,
+        [("WWW-Authenticate", "Bearer realm=\"proxxx-mcp\"")],
+        Json(json!({"error": "Unauthorized"})),
+    )
+        .into_response()
 }
 
 /// `POST /mcp` — JSON-RPC 2.0 request handler.
@@ -318,9 +341,33 @@ pub async fn run_http_server(
     let state = McpState::new(client, config, notifications, require_token);
     let addr = format!("{bind}:{port}");
 
-    let app = Router::new()
+    // #253/#258 — authorization is a LAYER, not a per-handler call.
+    //
+    // It was previously the first statement of each handler, and two of
+    // the three routes made that call: `/health` did not. The leak was
+    // minor (a status object), but the shape was the problem — on a
+    // network-exposed surface a route added by someone who copies
+    // `health` rather than `post_mcp` ships open, and neither the build
+    // nor the tests would notice.
+    //
+    // Applying the gate to the whole router inverts the default from
+    // open to closed. `/health` is then exempted explicitly below, so
+    // the exemption is a visible decision instead of an omission. This
+    // is the same reasoning that puts `guard_read_only` and the incident
+    // freeze check inside the three write helpers in api::client rather
+    // than at their call sites.
+    let protected = Router::new()
         .route("/mcp", post(post_mcp))
         .route("/mcp", get(get_mcp_sse))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_authorized,
+        ));
+
+    let app = protected
+        // Deliberately unauthenticated: a liveness probe must answer
+        // before credentials are configured, and it reveals nothing
+        // beyond "a proxxx MCP server is listening here".
         .route("/health", get(health))
         .with_state(state);
 
@@ -444,5 +491,45 @@ mod tests {
         // Hostnames and junk — fail-closed: treated as exposed.
         assert!(!is_loopback_bind("mcp.example.com"));
         assert!(!is_loopback_bind(""));
+    }
+}
+
+#[cfg(test)]
+mod router_gate_tests {
+    /// #258 — authorization must be a router layer, not a per-handler
+    /// convention, so a route added later cannot ship open by omission.
+    ///
+    /// Asserted structurally against the source: the protected router
+    /// carries a `route_layer`, and `/health` is registered outside it.
+    /// A behavioural test would need a live listener and a bound port;
+    /// what actually regresses here is someone adding `.route(...)` to
+    /// the wrong builder, which this catches.
+    #[test]
+    fn protected_routes_carry_a_layer_and_health_is_explicitly_outside() {
+        let src = include_str!("http_server.rs");
+        let protected = src
+            .split_once("let protected = Router::new()")
+            .expect("the protected router must exist")
+            .1;
+        let (protected_block, rest) = protected
+            .split_once("let app = protected")
+            .expect("the protected router must be consumed by `app`");
+
+        assert!(
+            protected_block.contains("route_layer(middleware::from_fn_with_state"),
+            "the protected router must apply the auth layer"
+        );
+        assert!(
+            protected_block.contains("\"/mcp\""),
+            "the MCP routes belong behind the layer"
+        );
+        assert!(
+            !protected_block.contains("\"/health\""),
+            "/health must not sit behind the auth layer — it is the liveness probe"
+        );
+        assert!(
+            rest.contains("\"/health\""),
+            "/health must be registered outside the layer, deliberately"
+        );
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -87,6 +87,86 @@ pub struct ParamDef {
     pub description: &'static str,
     pub param_type: ParamType,
     pub required: bool,
+    /// Character-class constraint for `ParamType::Str` (audit
+    /// 2026-09-09, #254).
+    ///
+    /// The registry could previously express only "this is a string",
+    /// so every string argument reached the dispatcher unconstrained and
+    /// was used to build PVE request paths. `ParamType::Int` gave real
+    /// protection to the vmid-bearing tools, which is why those were
+    /// never the problem; the string ones had nothing.
+    ///
+    /// `Shape::Any` keeps the old behaviour for free-form values
+    /// (descriptions, comments) where a constraint would be wrong.
+    pub shape: Shape,
+}
+
+/// What a string parameter is allowed to contain.
+///
+/// Deliberately coarse: the goal is to keep separators and control
+/// characters out of values that become path segments, not to duplicate
+/// PVE's own validation. Anything rejected here would have been rejected
+/// or misinterpreted by PVE anyway — the difference is that it now fails
+/// at our boundary with the parameter named.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shape {
+    /// No constraint. For prose: descriptions, comments, notes.
+    Any,
+    /// A PVE node or object name: letters, digits, `-`, `_`, `.`.
+    /// No slashes, no relative segments, 1..=64 bytes.
+    Name,
+    /// A PVE task id: `UPID:node:hex:...:user@realm:`. Allows the `:`
+    /// and `@` a UPID needs, still no slashes.
+    Upid,
+}
+
+impl Shape {
+    /// JSON Schema `pattern` describing this shape, for the `tools/list`
+    /// response. `None` for [`Shape::Any`], which has no constraint.
+    #[must_use]
+    pub const fn json_schema_pattern(self) -> Option<&'static str> {
+        match self {
+            Self::Any => None,
+            Self::Name => Some("^[A-Za-z0-9._-]{1,256}$"),
+            Self::Upid => Some("^[A-Za-z0-9._:@!-]{1,256}$"),
+        }
+    }
+
+    /// Validate `value`, returning a reason on rejection.
+    ///
+    /// # Errors
+    /// Returns the human-readable reason the value is not acceptable.
+    pub fn check(self, value: &str) -> Result<(), String> {
+        let ok_char = |c: char| match self {
+            Self::Any => true,
+            Self::Name => c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'),
+            Self::Upid => {
+                c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':' | '@' | '!')
+            }
+        };
+        if matches!(self, Self::Any) {
+            return Ok(());
+        }
+        if value.is_empty() {
+            return Err("must not be empty".to_string());
+        }
+        if value.len() > 256 {
+            return Err(format!("must be at most 256 bytes, got {}", value.len()));
+        }
+        if let Some(bad) = value.chars().find(|c| !ok_char(*c)) {
+            return Err(format!(
+                "contains {bad:?}, which is not allowed here (letters, digits and \
+                 a small punctuation set only — a value that can carry a path \
+                 separator or a relative segment is refused at the boundary)"
+            ));
+        }
+        // Belt and braces: a value made entirely of dots is a relative
+        // segment even though every character passed the class check.
+        if value.chars().all(|c| c == '.') {
+            return Err("must not be a relative path segment".to_string());
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -106,6 +186,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Connection profile name",
             param_type: ParamType::Str,
             required: false,
+            shape: Shape::Any,
         }],
         action: ToolAction::ListNodes,
         destructive: false,
@@ -120,12 +201,14 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Connection profile",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "node",
                 description: "Filter by node name",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Name,
             },
         ],
         action: ToolAction::ListGuests,
@@ -140,6 +223,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Guest VMID (100-999999)",
             param_type: ParamType::Int,
             required: true,
+            shape: Shape::Any,
         }],
         action: ToolAction::GetGuestStatus,
         destructive: false,
@@ -153,6 +237,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Guest VMID (100-999999)",
             param_type: ParamType::Int,
             required: true,
+            shape: Shape::Any,
         }],
         action: ToolAction::StartGuest,
         destructive: false,
@@ -167,12 +252,14 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Guest VMID (100-999999)",
                 param_type: ParamType::Int,
                 required: true,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "force",
                 description: "Force stop without graceful shutdown",
                 param_type: ParamType::Bool,
                 required: false,
+                shape: Shape::Any,
             },
         ],
         action: ToolAction::StopGuest,
@@ -187,6 +274,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Guest VMID (100-999999)",
             param_type: ParamType::Int,
             required: true,
+            shape: Shape::Any,
         }],
         action: ToolAction::RestartGuest,
         destructive: true,
@@ -200,6 +288,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Guest VMID (100-999999)",
             param_type: ParamType::Int,
             required: true,
+            shape: Shape::Any,
         }],
         action: ToolAction::DeleteGuest,
         destructive: true, // ALWAYS triggers HITL gate
@@ -217,12 +306,14 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Guest VMID",
                 param_type: ParamType::Int,
                 required: true,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "name",
                 description: "Snapshot name",
                 param_type: ParamType::Str,
                 required: true,
+                shape: Shape::Name,
             },
         ],
         action: ToolAction::CreateSnapshot,
@@ -243,12 +334,14 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Guest VMID",
                 param_type: ParamType::Int,
                 required: true,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "name",
                 description: "Snapshot name",
                 param_type: ParamType::Str,
                 required: true,
+                shape: Shape::Name,
             },
         ],
         action: ToolAction::DeleteSnapshot,
@@ -263,6 +356,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Node name",
             param_type: ParamType::Str,
             required: true,
+            shape: Shape::Name,
         }],
         action: ToolAction::GetStoragePools,
         destructive: false,
@@ -277,6 +371,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Guest VMID",
             param_type: ParamType::Int,
             required: true,
+            shape: Shape::Any,
         }],
         action: ToolAction::ListSnapshots,
         destructive: false,
@@ -291,12 +386,14 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Node name where the task ran",
                 param_type: ParamType::Str,
                 required: true,
+                shape: Shape::Name,
             },
             ParamDef {
                 name: "upid",
                 description: "Task UPID string",
                 param_type: ParamType::Str,
                 required: true,
+                shape: Shape::Upid,
             },
         ],
         action: ToolAction::GetTaskLog,
@@ -311,6 +408,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Node name",
             param_type: ParamType::Str,
             required: true,
+            shape: Shape::Name,
         }],
         action: ToolAction::GetNodeResources,
         destructive: false,
@@ -325,6 +423,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Guest VMID",
             param_type: ParamType::Int,
             required: true,
+            shape: Shape::Any,
         }],
         action: ToolAction::SuspendGuest,
         // Availability-affecting: pausing a running VM freezes it (unresponsive
@@ -343,6 +442,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Guest VMID",
             param_type: ParamType::Int,
             required: true,
+            shape: Shape::Any,
         }],
         action: ToolAction::ResumeGuest,
         destructive: false,
@@ -357,24 +457,28 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Source VMID to clone",
                 param_type: ParamType::Int,
                 required: true,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "newid",
                 description: "New VMID (0 = auto-assign next free)",
                 param_type: ParamType::Int,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "name",
                 description: "Name for the new guest",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Name,
             },
             ParamDef {
                 name: "full",
                 description: "Full clone (true) vs linked clone (false, default)",
                 param_type: ParamType::Bool,
                 required: false,
+                shape: Shape::Any,
             },
         ],
         action: ToolAction::CloneGuest,
@@ -390,18 +494,21 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Guest VMID",
                 param_type: ParamType::Int,
                 required: true,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "target_node",
                 description: "Destination node name",
                 param_type: ParamType::Str,
                 required: true,
+                shape: Shape::Name,
             },
             ParamDef {
                 name: "online",
                 description: "Live migration while guest is running (default true)",
                 param_type: ParamType::Bool,
                 required: false,
+                shape: Shape::Any,
             },
         ],
         action: ToolAction::MigrateGuest,
@@ -424,6 +531,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Filter by node (optional, omit for cluster-wide)",
             param_type: ParamType::Str,
             required: false,
+            shape: Shape::Name,
         }],
         action: ToolAction::ListTasks,
         destructive: false,
@@ -437,6 +545,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Node name",
             param_type: ParamType::Str,
             required: true,
+            shape: Shape::Name,
         }],
         action: ToolAction::GetNodeStatus,
         destructive: false,
@@ -458,6 +567,7 @@ pub const TOOLS: &[ToolDef] = &[
             description: "Node name",
             param_type: ParamType::Str,
             required: true,
+            shape: Shape::Name,
         }],
         action: ToolAction::GetReplicationStatus,
         destructive: false,
@@ -472,66 +582,77 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Target Proxmox node name",
                 param_type: ParamType::Str,
                 required: true,
+                shape: Shape::Name,
             },
             ParamDef {
                 name: "type",
                 description: "Guest type: qemu or lxc",
                 param_type: ParamType::Str,
                 required: true,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "vmid",
                 description: "VMID to assign (auto-assigned from cluster nextid if omitted)",
                 param_type: ParamType::Int,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "name",
                 description: "VM name (QEMU) or hostname (LXC)",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Name,
             },
             ParamDef {
                 name: "memory",
                 description: "Memory in MiB (default: 1024 for QEMU, 512 for LXC)",
                 param_type: ParamType::Int,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "cores",
                 description: "CPU cores (default: 1)",
                 param_type: ParamType::Int,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "storage",
                 description: "Storage id for boot disk (e.g. local-lvm). If omitted, no disk is created.",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Name,
             },
             ParamDef {
                 name: "disk_size",
                 description: "Disk size in GiB (default: 32 QEMU, 8 LXC)",
                 param_type: ParamType::Int,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "template",
                 description: "LXC only: ostemplate volid (e.g. local:vztmpl/debian-12-standard_12.0-1_amd64.tar.zst)",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "iso",
                 description: "QEMU only: ISO image volid for CD-ROM (e.g. local:iso/ubuntu-24.04.iso)",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "bridge",
                 description: "Network bridge (default: vmbr0)",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Any,
             },
         ],
         action: ToolAction::CreateGuest,
@@ -548,12 +669,14 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Maximum number of events to return (default 50, max 200)",
                 param_type: ParamType::Int,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "running_only",
                 description: "When true, return only tasks that are currently running",
                 param_type: ParamType::Bool,
                 required: false,
+                shape: Shape::Any,
             },
         ],
         action: ToolAction::ListClusterEvents,
@@ -570,54 +693,63 @@ pub const TOOLS: &[ToolDef] = &[
                 description: "Source VMID (template) to clone",
                 param_type: ParamType::Int,
                 required: true,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "newid",
                 description: "New VMID (0 = auto-assign next free)",
                 param_type: ParamType::Int,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "name",
                 description: "Display name for the new VM",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Name,
             },
             ParamDef {
                 name: "full",
                 description: "Full clone (true) vs linked clone (false, default)",
                 param_type: ParamType::Bool,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "ciuser",
                 description: "Cloud-init default user account",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "sshkey",
                 description: "SSH public key (single line, ssh-ed25519/ssh-rsa form)",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "ipconfig0",
                 description: "First-NIC IP config, e.g. `ip=10.0.0.5/24,gw=10.0.0.1` or `ip=dhcp`",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "searchdomain",
                 description: "DNS search domain",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Any,
             },
             ParamDef {
                 name: "nameserver",
                 description: "DNS resolver IP",
                 param_type: ParamType::Str,
                 required: false,
+                shape: Shape::Any,
             },
         ],
         action: ToolAction::CloneWithCloudinit,
@@ -688,13 +820,23 @@ pub fn tools_list_schema() -> serde_json::Value {
                     ParamType::Int => "integer",
                     ParamType::Bool => "boolean",
                 };
-                properties.insert(
-                    p.name.to_string(),
-                    serde_json::json!({
-                        "type": json_type,
-                        "description": p.description,
-                    }),
-                );
+                let mut prop = serde_json::json!({
+                    "type": json_type,
+                    "description": p.description,
+                });
+                // #254 — publish the constraint the dispatcher enforces,
+                // as a JSON Schema `pattern`, so the model is told what
+                // is acceptable instead of discovering it by rejection.
+                //
+                // Deliberately NOT added to `registry_json`, which is
+                // what `registry_checksum` hashes: this is a validation
+                // tightening, not a change to the advertised tool
+                // surface, and the checksum is a contract fingerprint
+                // callers pin.
+                if let Some(pattern) = p.shape.json_schema_pattern() {
+                    prop["pattern"] = serde_json::Value::String(pattern.to_string());
+                }
+                properties.insert(p.name.to_string(), prop);
                 if p.required {
                     required.push(serde_json::Value::String(p.name.to_string()));
                 }
@@ -734,4 +876,67 @@ pub fn registry_checksum() -> String {
     // `AsRef<[u8]>` which Array does implement, so it's the portable
     // way to get a lowercase hex digest across sha2 0.10 and 0.11.
     hex::encode(digest)
+}
+
+#[cfg(test)]
+mod shape_tests {
+    use super::{Shape, TOOLS};
+
+    /// #254 — every string parameter that becomes a PVE path segment
+    /// must declare a constraint. A registry that can only say "string"
+    /// is why `node` and `upid` reached URL construction unvalidated.
+    #[test]
+    fn path_bearing_string_params_are_constrained() {
+        const PATH_BEARING: &[&str] = &["node", "target_node", "storage", "snapshot", "upid"];
+        for tool in TOOLS {
+            for p in tool.params {
+                if PATH_BEARING.contains(&p.name) {
+                    assert_ne!(
+                        p.shape,
+                        Shape::Any,
+                        "tool `{}` parameter `{}` becomes a path segment and must \
+                         declare a shape",
+                        tool.name,
+                        p.name
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn name_shape_refuses_separators_and_relative_segments() {
+        for bad in [
+            "../../access",
+            "a/b",
+            "..",
+            ".",
+            "pve1?x=1",
+            "pve 1",
+            "pve\u{0}1",
+        ] {
+            assert!(
+                Shape::Name.check(bad).is_err(),
+                "Shape::Name must refuse {bad:?}"
+            );
+        }
+        for good in ["pve1", "pve-test-1", "local-lvm", "backup.2026-09-09"] {
+            assert!(
+                Shape::Name.check(good).is_ok(),
+                "Shape::Name must accept {good:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn upid_shape_keeps_the_characters_a_upid_needs() {
+        let upid = "UPID:pve1:0000ABCD:0000EF01:66E0:qmigrate:100:root@pam:";
+        assert!(Shape::Upid.check(upid).is_ok(), "a real UPID must pass");
+        assert!(Shape::Upid.check("UPID:pve1/../x").is_err());
+    }
+
+    #[test]
+    fn any_shape_still_allows_prose() {
+        assert!(Shape::Any.check("a comment, with punctuation!").is_ok());
+    }
 }

--- a/src/metrics/daemon_health.rs
+++ b/src/metrics/daemon_health.rs
@@ -1,0 +1,140 @@
+//! Liveness of proxxx's own daemon components (audit 2026-09-09, #271).
+//!
+//! The exporter reports thoroughly on the cluster and said nothing about
+//! proxxx itself, so a daemon pillar that had stopped running was
+//! indistinguishable from one that was running with nothing to report.
+//! From outside, a panicked alerts loop or HITL loop looked exactly like
+//! a quiet one: alerts stopped arriving, approvals stopped being
+//! answered, and the natural check — "is the process up?" — was true and
+//! useless.
+//!
+//! The reconcile pillar was the accidental exception, because
+//! `proxxx_reconcile_last_check_timestamp` goes stale if it dies. That is
+//! the shape the other pillars needed, so this generalises it:
+//!
+//! * `proxxx_daemon_component_up{component}` — 1 while the component's
+//!   task is alive, 0 once it has exited.
+//! * `proxxx_daemon_component_last_tick_timestamp{component}` — unix
+//!   seconds of that component's last completed loop iteration, so
+//!   "running but wedged" is distinguishable from "running and idle".
+//!
+//! In-process state rather than a persisted store: these describe THIS
+//! process, and a scrape served by a different process would be lying.
+//! `proxxx daemon serve` runs the metrics exporter alongside the pillars,
+//! which is the deployment this is for.
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Copy)]
+struct ComponentHealth {
+    up: bool,
+    last_tick: u64,
+}
+
+fn registry() -> &'static Mutex<BTreeMap<&'static str, ComponentHealth>> {
+    static REG: OnceLock<Mutex<BTreeMap<&'static str, ComponentHealth>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+/// Record that `component` has started. Called once per pillar at spawn.
+pub fn register(component: &'static str) {
+    let mut g = registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    g.insert(
+        component,
+        ComponentHealth {
+            up: true,
+            last_tick: now_secs(),
+        },
+    );
+}
+
+/// Record that `component` completed a loop iteration.
+///
+/// Call at the END of each tick, so the timestamp means "last time this
+/// pillar finished useful work" rather than "last time it woke up".
+pub fn tick(component: &'static str) {
+    let mut g = registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    g.entry(component)
+        .and_modify(|h| h.last_tick = now_secs())
+        .or_insert(ComponentHealth {
+            up: true,
+            last_tick: now_secs(),
+        });
+}
+
+/// Record that `component` has stopped. The series stays published with
+/// value 0 — a disappearing series looks the same as a scrape failure,
+/// and the whole point is to make the difference visible.
+pub fn mark_down(component: &'static str) {
+    let mut g = registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    g.entry(component).and_modify(|h| h.up = false);
+}
+
+/// Snapshot for the exporter: `(component, up, last_tick_unix_secs)`.
+#[must_use]
+pub fn snapshot() -> Vec<(&'static str, bool, u64)> {
+    registry()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+        .map(|(name, h)| (*name, h.up, h.last_tick))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mark_down, register, snapshot, tick};
+
+    fn find(name: &str) -> Option<(bool, u64)> {
+        snapshot()
+            .into_iter()
+            .find(|(n, _, _)| *n == name)
+            .map(|(_, up, ts)| (up, ts))
+    }
+
+    #[test]
+    fn a_registered_component_reports_up() {
+        register("test_pillar_up");
+        let (up, ts) = find("test_pillar_up").expect("registered");
+        assert!(up);
+        assert!(ts > 0, "registration must stamp a timestamp");
+    }
+
+    /// The point of the finding: a stopped pillar must be visibly down,
+    /// not merely absent. An absent series is indistinguishable from a
+    /// failed scrape.
+    #[test]
+    fn a_stopped_component_reports_down_rather_than_vanishing() {
+        register("test_pillar_down");
+        mark_down("test_pillar_down");
+        let (up, _) = find("test_pillar_down").expect("the series must remain published");
+        assert!(!up, "a stopped component must report 0, not disappear");
+    }
+
+    #[test]
+    fn ticking_advances_the_timestamp() {
+        register("test_pillar_tick");
+        let (_, first) = find("test_pillar_tick").expect("registered");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        tick("test_pillar_tick");
+        let (_, second) = find("test_pillar_tick").expect("still there");
+        assert!(
+            second > first,
+            "a tick must advance the last-tick timestamp ({first} → {second})"
+        );
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -89,6 +89,7 @@ impl MetricWriter {
 
 // ── Scrape ─────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn scrape(client: &PxClient) -> String {
     let mut w = MetricWriter::new();
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -27,6 +27,12 @@
 //!   `proxxx_storage_total_bytes{node,storage,type}`
 //!   `proxxx_storage_avail_bytes{node,storage,type}`
 //!   `proxxx_storage_active{node,storage,type}`  — 1=active 0=inactive
+//!
+//! proxxx's own health (only while `daemon serve` is running):
+//!   `proxxx_daemon_component_up{component}`     — 1=running 0=exited
+//!   `proxxx_daemon_component_last_tick_timestamp{component}`
+
+pub mod daemon_health;
 
 use std::sync::Arc;
 
@@ -211,6 +217,39 @@ pub async fn scrape(client: &PxClient) -> String {
         "1 if the scrape gathered all data; 0 if any fetch failed",
     );
     w.gauge("proxxx_up", &[], scrape_ok);
+
+    // #271 — proxxx's own pillars. Without these a daemon component that
+    // has stopped is indistinguishable from one that is running with
+    // nothing to report: alerts simply stop arriving, approvals stop
+    // being answered, and "the process is up" is true and useless.
+    //
+    // The series stays published with value 0 once a component exits — a
+    // disappearing series looks the same as a failed scrape, which is
+    // the ambiguity being removed.
+    let components = crate::metrics::daemon_health::snapshot();
+    if !components.is_empty() {
+        w.help(
+            "proxxx_daemon_component_up",
+            "1 while the named daemon component is running, 0 once it has exited",
+        );
+        w.help(
+            "proxxx_daemon_component_last_tick_timestamp",
+            "unix seconds of the component's last completed loop iteration",
+        );
+        for (name, up, last_tick) in components {
+            let labels = [("component", name)];
+            w.gauge(
+                "proxxx_daemon_component_up",
+                &labels,
+                if up { 1.0 } else { 0.0 },
+            );
+            w.gauge(
+                "proxxx_daemon_component_last_tick_timestamp",
+                &labels,
+                last_tick as f64,
+            );
+        }
+    }
 
     // Reconcile drift-state, written by the `reconcile watch` daemon pillar
     // to a shared per-profile SQLite store. Absent (no watch / never run) →

--- a/src/ssh/pty.rs
+++ b/src/ssh/pty.rs
@@ -54,6 +54,7 @@ enum PtyInput {
 impl PtySession {
     /// Open a fresh PTY session against a guest. Creates a new SSH connection
     /// (we don't pool guest connections — they're interactive and few).
+    #[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
     pub async fn open(
         vmid: u32,
         target: ResolvedGuestSsh,

--- a/src/state/converge.rs
+++ b/src/state/converge.rs
@@ -182,9 +182,37 @@ pub async fn apply_and_audit<C: StateWriteView + ?Sized>(
 
     // Capture the summary before `apply` consumes `changes` (for the audit entry).
     let summary = crate::cli::reconcile::drift_summary(&changes);
+    let total = changes.len();
+
+    // Audit 2026-09-09 (#265) — leave a record even if we never come back.
+    //
+    // The completion entry below is written after `apply` returns. When
+    // the daemon aborts a component mid-converge, this future is dropped
+    // at whatever await it was sitting on: changes already dispatched
+    // have been applied by PVE and stand, and the entry that would have
+    // described them never runs. An operator restarting the daemon found
+    // a partially converged cluster with nothing in the log.
+    //
+    // A Drop guard is the fix rather than a cancellation token, because
+    // Drop runs on abort too — a token only helps at points we
+    // explicitly check, and the abort lands wherever it lands.
+    //
+    // On the normal path the guard is disarmed and the usual completion
+    // entry is written instead, so the log gains nothing in the case
+    // that already worked.
+    let mut guard = InterruptedRunGuard {
+        armed: !opts.dry_run,
+        action: action.to_string(),
+        user: audit_user.to_string(),
+        profile: profile.to_string(),
+        source: source.to_string(),
+        summary: summary.clone(),
+        total,
+    };
 
     let outcomes = apply(client, changes, opts).await;
     let report = ConvergeReport::from_outcomes(outcomes);
+    guard.armed = false;
 
     // One audit entry per run that actually dispatched (not a dry-run, and
     // something hit PVE). Best-effort — a logging failure never fails the apply.
@@ -193,6 +221,57 @@ pub async fn apply_and_audit<C: StateWriteView + ?Sized>(
     }
 
     report
+}
+
+/// Writes an `<action>_interrupted` audit entry if the run it guards
+/// never reached its completion write (audit 2026-09-09, #265).
+///
+/// Disarmed as soon as `apply` returns, so it fires only when the future
+/// was dropped mid-flight — in practice, a daemon component abort during
+/// shutdown. The entry records what the run intended to do; the changes
+/// that actually landed are recoverable from PVE's own task log, and the
+/// point here is that an investigator learns the run happened at all.
+struct InterruptedRunGuard {
+    armed: bool,
+    action: String,
+    user: String,
+    profile: String,
+    source: String,
+    summary: String,
+    total: usize,
+}
+
+impl Drop for InterruptedRunGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let action = format!("{}_interrupted", self.action);
+        let params = converge_audit_params(&self.profile, &self.source, &self.summary, self.total);
+        let write = (|| -> Result<()> {
+            let mut logger = crate::audit::AuditLogger::open()?;
+            logger.log(
+                &action,
+                &self.user,
+                None,
+                None,
+                Some(&params),
+                "INTERRUPTED",
+            )
+        })();
+        match write {
+            Ok(()) => tracing::error!(
+                "{action}: converge was interrupted mid-apply — changes already \
+                 dispatched to PVE stand. Recorded in the audit log; reconcile \
+                 again to establish the current state."
+            ),
+            Err(e) => tracing::error!(
+                "{action}: converge was interrupted mid-apply AND the audit write \
+                 failed ({e:#}) — the cluster may have been partially changed with \
+                 no record. Reconcile to establish the current state."
+            ),
+        }
+    }
 }
 
 /// Build the `params_json` payload for the converge audit entry. Split out so
@@ -401,5 +480,57 @@ mod tests {
         assert_eq!(report.skipped, 1); // held by prune policy, not the gate
         assert!(!report.dispatched());
         assert!(c.lines().await.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod interrupted_run_tests {
+    use super::{ApplyOptions, InterruptedRunGuard};
+
+    fn guard(armed: bool) -> InterruptedRunGuard {
+        InterruptedRunGuard {
+            armed,
+            action: "reconcile_converge".to_string(),
+            user: "tester@host".to_string(),
+            profile: "prod".to_string(),
+            source: "/tmp/state.toml".to_string(),
+            summary: "3 changes".to_string(),
+            total: 3,
+        }
+    }
+
+    /// #265 — the guard must be disarmed on the normal path, so a run
+    /// that completes writes only its completion entry.
+    #[test]
+    fn a_completed_run_does_not_leave_an_interrupted_entry() {
+        let mut g = guard(true);
+        g.armed = false; // what `apply_and_audit` does when apply returns
+        drop(g); // must not attempt an audit write
+    }
+
+    /// A dry run never dispatches, so there is nothing to record even if
+    /// it is interrupted.
+    #[test]
+    fn a_dry_run_arms_nothing() {
+        let opts = ApplyOptions {
+            dry_run: true,
+            ..Default::default()
+        };
+        assert!(opts.dry_run, "sanity: this is the dry-run case");
+        let g = guard(!opts.dry_run);
+        assert!(!g.armed, "a dry run must not arm the interrupted-run guard");
+        drop(g);
+    }
+
+    /// The guard is armed for a real run — this is the state in which a
+    /// mid-flight drop produces the record.
+    #[test]
+    fn a_real_run_arms_the_guard() {
+        let opts = ApplyOptions::default();
+        let g = guard(!opts.dry_run);
+        assert!(g.armed);
+        // Deliberately not dropped while armed here: Drop opens the real
+        // audit DB, which belongs to the live e2e rather than a unit test.
+        std::mem::forget(g);
     }
 }

--- a/src/state/diff.rs
+++ b/src/state/diff.rs
@@ -94,32 +94,65 @@ pub struct Change {
 #[must_use]
 pub fn diff(declared: &ClusterState, live: &ClusterState) -> Vec<Change> {
     let mut out = Vec::new();
-    diff_pools(&declared.pools, &live.pools, &mut out);
-    diff_acl(&declared.acl, &live.acl, &mut out);
-    diff_storage(&declared.storage, &live.storage, &mut out);
-    diff_backup_jobs(&declared.backup_jobs, &live.backup_jobs, &mut out);
+    // #259 — a family the source document never mentioned is left
+    // alone, not treated as "declared empty". Without this an omitted
+    // or mistyped section header (`[[pool]]` for `[[pools]]`, a family
+    // lost in a merge) deserializes to an empty Vec, and the delete rule
+    // below reads that as "delete every live member".
+    //
+    // `manages()` answers true when the state carries no provenance —
+    // an export, or a state built in memory — so nothing changes for
+    // the export → diff → apply round trip.
+    if declared.manages("pools") {
+        diff_pools(&declared.pools, &live.pools, &mut out);
+    }
+    if declared.manages("acl") {
+        diff_acl(&declared.acl, &live.acl, &mut out);
+    }
+    if declared.manages("storage") {
+        diff_storage(&declared.storage, &live.storage, &mut out);
+    }
+    if declared.manages("backup_jobs") {
+        diff_backup_jobs(&declared.backup_jobs, &live.backup_jobs, &mut out);
+    }
     diff_firewall_options(
         declared.firewall_options.as_ref(),
         live.firewall_options.as_ref(),
         &mut out,
     );
-    diff_firewall_aliases(&declared.firewall_aliases, &live.firewall_aliases, &mut out);
-    diff_firewall_ipsets(&declared.firewall_ipsets, &live.firewall_ipsets, &mut out);
-    diff_firewall_groups(&declared.firewall_groups, &live.firewall_groups, &mut out);
-    diff_notification_matchers(
-        &declared.notification_matchers,
-        &live.notification_matchers,
-        &mut out,
-    );
+    if declared.manages("firewall_aliases") {
+        diff_firewall_aliases(&declared.firewall_aliases, &live.firewall_aliases, &mut out);
+    }
+    if declared.manages("firewall_ipsets") {
+        diff_firewall_ipsets(&declared.firewall_ipsets, &live.firewall_ipsets, &mut out);
+    }
+    if declared.manages("firewall_groups") {
+        diff_firewall_groups(&declared.firewall_groups, &live.firewall_groups, &mut out);
+    }
+    if declared.manages("notification_matchers") {
+        diff_notification_matchers(
+            &declared.notification_matchers,
+            &live.notification_matchers,
+            &mut out,
+        );
+    }
     // HA resources MUST be diffed BEFORE HA rules so create-order flows
     // resources-then-rules at apply time (rules reference resource SIDs).
     // On the delete side, PVE's `purge=1` default on resource DELETE
     // auto-removes the SID from referencing rules — apply_ha_rule_delete
     // tolerates 404 to keep the cleanup idempotent.
-    diff_ha_resources(&declared.ha_resources, &live.ha_resources, &mut out);
-    diff_ha_rules(&declared.ha_rules, &live.ha_rules, &mut out);
-    diff_mappings_pci(&declared.mappings_pci, &live.mappings_pci, &mut out);
-    diff_mappings_usb(&declared.mappings_usb, &live.mappings_usb, &mut out);
+    if declared.manages("ha_resources") {
+        diff_ha_resources(&declared.ha_resources, &live.ha_resources, &mut out);
+    }
+    if declared.manages("ha_rules") {
+        diff_ha_rules(&declared.ha_rules, &live.ha_rules, &mut out);
+    }
+    if declared.manages("mappings_pci") {
+        diff_mappings_pci(&declared.mappings_pci, &live.mappings_pci, &mut out);
+    }
+    if declared.manages("mappings_usb") {
+        diff_mappings_usb(&declared.mappings_usb, &live.mappings_usb, &mut out);
+    }
     out
 }
 
@@ -1686,5 +1719,98 @@ mod tests {
         assert!(kinds_ab.contains(&ChangeKind::Delete));
         assert!(kinds_ba.contains(&ChangeKind::Create));
         assert!(kinds_ba.contains(&ChangeKind::Delete));
+    }
+}
+
+#[cfg(test)]
+mod declared_family_tests {
+    use super::{diff, ChangeKind};
+    use crate::state::model::{ClusterState, PoolDecl};
+
+    fn live_with_two_pools() -> ClusterState {
+        ClusterState {
+            pools: vec![
+                PoolDecl {
+                    poolid: "tenant-a".into(),
+                    ..Default::default()
+                },
+                PoolDecl {
+                    poolid: "tenant-b".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    /// #259 — the failure this guards against: a document that meant to
+    /// declare pools but mistyped the section header. It parses cleanly,
+    /// `pools` is empty, and before v0.13.4 the diff read that as
+    /// "delete every live pool" — destruction from a typo under
+    /// `--prune`.
+    #[test]
+    fn a_family_the_document_never_mentions_is_left_alone() {
+        // A document that manages storage and says nothing about pools —
+        // the shape you get when a family is dropped in a branch merge,
+        // or when an operator exports one family deliberately.
+        let declared = ClusterState::from_toml_str(
+            r#"
+[[storage]]
+storage = "local-lvm"
+"#,
+        )
+        .expect("parses");
+
+        assert!(!declared.manages("pools"));
+        let changes = diff(&declared, &live_with_two_pools());
+        let pool_changes: Vec<_> = changes.iter().filter(|c| c.resource == "pool").collect();
+        assert!(
+            pool_changes.is_empty(),
+            "an unmentioned family must produce no changes for itself, got {pool_changes:?}"
+        );
+        // The family it DOES declare is still reconciled — the guard is
+        // per-family, not a blanket opt-out.
+        assert!(changes.iter().any(|c| c.resource == "storage"));
+    }
+
+    /// #262 — the sibling defence. A mistyped section header is now a
+    /// parse error rather than a silently-empty family, so it never
+    /// reaches the diff at all.
+    #[test]
+    fn a_mistyped_section_header_is_a_parse_error() {
+        let err = ClusterState::from_toml_str(
+            r#"
+[[pool]]
+poolid = "tenant-a"
+"#,
+        )
+        .expect_err("`[[pool]]` is not `[[pools]]` and must not be ignored");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("pool"),
+            "the error must name the offending key: {msg}"
+        );
+    }
+
+    /// The other half of the distinction: a document that DOES mention
+    /// the family, with nothing in it, still means "make it empty".
+    /// Declaring emptiness has to remain expressible.
+    #[test]
+    fn a_family_declared_empty_still_deletes() {
+        let declared = ClusterState::from_toml_str("pools = []\n").expect("parses");
+        let changes = diff(&declared, &live_with_two_pools());
+        assert_eq!(changes.len(), 2, "explicit emptiness must still prune");
+        assert!(changes.iter().all(|c| c.kind == ChangeKind::Delete));
+    }
+
+    /// A state with no provenance — an export, or one built in memory —
+    /// manages everything, so the export → diff → apply round trip is
+    /// unaffected.
+    #[test]
+    fn a_state_without_provenance_manages_every_family() {
+        let declared = ClusterState::default();
+        assert!(declared.manages("pools"));
+        let changes = diff(&declared, &live_with_two_pools());
+        assert_eq!(changes.len(), 2);
     }
 }

--- a/src/state/export.rs
+++ b/src/state/export.rs
@@ -252,7 +252,11 @@ pub async fn export_state<C: StateReadView + ?Sized>(
         .unwrap_or_default();
 
     let mut state = ClusterState {
+        // A fresh export mentions every family it produced, so there is
+        // no provenance to record and `manages()` answers true for all.
+        declared_families: None,
         meta: Some(StateMeta {
+            schema_version: crate::state::model::CURRENT_STATE_SCHEMA,
             profile: profile.to_string(),
             exported_at: rfc3339_now(),
             exported_from_proxxx: env!("CARGO_PKG_VERSION").to_string(),

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -27,13 +27,37 @@ use serde::{Deserialize, Serialize};
 /// exports are valid documents. `meta` is emitted on export but
 /// optional on import; a hand-written declared state can omit it.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ClusterState {
     /// Provenance: where this state came from and when. Skipped on
     /// serialisation when absent so hand-authored declared states
     /// don't need it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<StateMeta>,
+
+    /// Which resource families the source document actually mentioned
+    /// (audit 2026-09-09, #259).
+    ///
+    /// Every family below is a `Vec` with `#[serde(default)]`, so "not
+    /// managed by this file" and "should be empty" deserialize to the
+    /// same value — and `diff` reads an empty declared family as
+    /// "delete every live member of it". A mistyped or dropped section
+    /// header (`[[pool]]` for `[[pools]]`, a family lost in a merge)
+    /// therefore parses cleanly and, under `--prune`, destroys that
+    /// family. `firewall_options` is the one family that escaped this,
+    /// because being a singleton it is an `Option` and `None` already
+    /// meant "leave it alone".
+    ///
+    /// Rather than change ten field types (and every construction site
+    /// with them), the loader records the top-level keys it saw. `None`
+    /// means "no provenance available" — a state built in memory, as
+    /// `export` does — and is treated as "all families declared", which
+    /// is correct for a fresh export.
+    ///
+    /// `#[serde(skip)]`: this is provenance about the document, not
+    /// content of it, and must never round-trip into an exported file.
+    #[serde(skip)]
+    pub declared_families: Option<std::collections::BTreeSet<String>>,
 
     /// Pools — `GET /pools` + `GET /pools/{poolid}` for membership.
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -158,13 +182,141 @@ pub struct ClusterState {
     pub mappings_usb: Vec<MappingUsbDecl>,
 }
 
+impl ClusterState {
+    /// Whether `family` (a top-level TOML key such as `pools`) should be
+    /// reconciled for this document.
+    ///
+    /// True when the document mentioned it, or when no provenance is
+    /// recorded at all. A family the document never mentions is left
+    /// alone entirely — it is not "declared empty".
+    #[must_use]
+    pub fn manages(&self, family: &str) -> bool {
+        self.declared_families
+            .as_ref()
+            .is_none_or(|d| d.contains(family))
+    }
+
+    /// Reject a document that declares the same identity twice within a
+    /// family (audit 2026-09-09, #261).
+    ///
+    /// Every family documents an identity — `poolid`, `name`, `storage`,
+    /// the ACL 4-tuple — and `diff` keys a `HashMap` on it, so a
+    /// duplicate silently kept whichever entry the iteration inserted
+    /// last. An operator merging two branches that both add
+    /// `[[pools]] poolid = "tenant-a"` got a clean parse, a clean diff,
+    /// and a converge that applied one of the two with no warning that
+    /// the other was discarded. In `acl`, the discarded entry may be the
+    /// more restrictive grant.
+    ///
+    /// # Errors
+    /// Names the family and the duplicated identity.
+    pub fn validate_unique_identities(&self) -> Result<(), String> {
+        fn check<T, K, F>(family: &str, items: &[T], key: F) -> Result<(), String>
+        where
+            K: Ord + std::fmt::Display,
+            F: Fn(&T) -> K,
+        {
+            let mut seen = std::collections::BTreeSet::new();
+            for item in items {
+                let k = key(item);
+                if !seen.insert(k.to_string()) {
+                    return Err(format!(
+                        "`{family}` declares `{k}` more than once. Each entry in a \
+                         family must have a distinct identity — a duplicate is \
+                         silently discarded at diff time, so this is refused instead."
+                    ));
+                }
+            }
+            Ok(())
+        }
+
+        check("pools", &self.pools, |p| p.poolid.clone())?;
+        check("acl", &self.acl, |a| {
+            // Identity is the 4-tuple; `propagate` is part of the value.
+            format!("{}|{}|{}|{}", a.path, a.kind, a.ugid, a.roleid)
+        })?;
+        check("storage", &self.storage, |x| x.storage.clone())?;
+        check("backup_jobs", &self.backup_jobs, |x| x.id.clone())?;
+        check("firewall_aliases", &self.firewall_aliases, |x| {
+            x.name.clone()
+        })?;
+        check("firewall_ipsets", &self.firewall_ipsets, |x| x.name.clone())?;
+        check("firewall_groups", &self.firewall_groups, |x| {
+            x.group.clone()
+        })?;
+        check("notification_matchers", &self.notification_matchers, |x| {
+            x.name.clone()
+        })?;
+        check("ha_resources", &self.ha_resources, |x| x.sid.clone())?;
+        check("ha_rules", &self.ha_rules, |x| x.rule.clone())?;
+        check("mappings_pci", &self.mappings_pci, |x| x.id.clone())?;
+        check("mappings_usb", &self.mappings_usb, |x| x.id.clone())?;
+        Ok(())
+    }
+
+    /// Parse a state document, recording which families it mentions.
+    ///
+    /// Prefer this over a bare `toml::from_str` for anything an operator
+    /// authored: without the provenance, an omitted family is
+    /// indistinguishable from one declared empty, and `diff` reads the
+    /// latter as "delete everything in it" (#259).
+    ///
+    /// # Errors
+    /// When the text is not valid TOML, does not match the schema, or
+    /// declares the same identity twice within a family (#261).
+    pub fn from_toml_str(text: &str) -> anyhow::Result<Self> {
+        let mut state: Self = toml::from_str(text)?;
+        let raw: toml::Value = toml::from_str(text)?;
+        state.record_declared_families(&raw);
+        state
+            .validate_unique_identities()
+            .map_err(|e| anyhow::anyhow!(e))?;
+        if let Some(meta) = &state.meta {
+            anyhow::ensure!(
+                meta.schema_version <= CURRENT_STATE_SCHEMA,
+                "state document declares schema_version {} but this proxxx \
+                 understands at most {}. Upgrade proxxx rather than letting an \
+                 older binary reinterpret a newer document.",
+                meta.schema_version,
+                CURRENT_STATE_SCHEMA
+            );
+        }
+        Ok(state)
+    }
+
+    /// Record which top-level keys the source document contained.
+    ///
+    /// Called by the loaders right after deserialization; `raw` is the
+    /// same text parsed as a generic TOML table.
+    pub fn record_declared_families(&mut self, raw: &toml::Value) {
+        if let Some(table) = raw.as_table() {
+            self.declared_families = Some(table.keys().cloned().collect());
+        }
+    }
+}
+
 /// Metadata header emitted by the export layer. Captures *which*
 /// cluster the state was read from, *when*, and *with what proxxx
 /// version*. Useful for audit trail and forensic comparison; ignored
 /// by the apply layer (apply consults live state, not metadata).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct StateMeta {
+    /// Shape of this document (audit 2026-09-09, #263).
+    ///
+    /// The cache DB and the audit chain both version their shapes and
+    /// can therefore step old data forward or refuse it. This document —
+    /// the artefact operators commit to git and keep for years — could
+    /// not: every field defaults, so an old file parses into new structs
+    /// successfully and converge computes a diff against a misread
+    /// desired state, with no place to hang a migration or a refusal.
+    ///
+    /// Defaults to [`CURRENT_STATE_SCHEMA`] when absent so documents
+    /// written before v0.13.4 keep loading; a version NEWER than this
+    /// binary understands is refused, the same posture
+    /// `app::cache::migrate_schema` takes for the cache DB.
+    #[serde(default = "default_state_schema")]
+    pub schema_version: u32,
     /// proxxx profile name the state was exported from.
     pub profile: String,
     /// RFC 3339 timestamp at export.
@@ -175,6 +327,20 @@ pub struct StateMeta {
     pub pve_version: String,
 }
 
+/// Schema version this binary writes and understands.
+///
+/// Bump when a family's identity or field set changes in a way that
+/// would make an older document parse into something it did not mean.
+/// A purely additive family does not need a bump — absent fields already
+/// default, and `manages()` keeps an unmentioned family out of the diff.
+pub const CURRENT_STATE_SCHEMA: u32 = 1;
+
+/// Documents written before the field existed are schema 1 by
+/// definition: that is the shape they were written against.
+const fn default_state_schema() -> u32 {
+    CURRENT_STATE_SCHEMA
+}
+
 /// One pool declaration — poolid + comment + members.
 ///
 /// Members are emitted as `kind/id` strings (`qemu/<vmid>`,
@@ -182,7 +348,7 @@ pub struct StateMeta {
 /// PVE API returns a richer object per member, but only the kind + id
 /// is identity-bearing — every other field is recomputable.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct PoolDecl {
     pub poolid: String,
     /// Free-form description. Empty by default; suppressed in the
@@ -203,7 +369,7 @@ pub struct PoolDecl {
 /// shows up as a separate entry. We mirror that 1:1: the on-disk
 /// state is a flat array of `AclDecl`, identity-keyed at apply time.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AclDecl {
     /// ACL path — e.g. `/`, `/vms/100`, `/pool/team-platform`,
     /// `/storage/ceph-rbd`.
@@ -273,7 +439,7 @@ const fn is_zero_u32(n: &u32) -> bool {
 /// or an explicit `vmid` CSV. The two are mutually exclusive in PVE;
 /// the apply layer sends whichever is set.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct BackupJobDecl {
     /// Job id — the identity. Stable across re-apply. Operators pick a
     /// readable one (`nightly-all`, `weekly-prod`); PVE accepts it on
@@ -326,7 +492,7 @@ pub struct BackupJobDecl {
 /// the whole point); the policy / ratelimit strings are skipped when
 /// empty so a minimal block can set just `enable`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct FirewallOptionsDecl {
     /// Master switch. `false` disables the entire cluster firewall.
     pub enable: bool,
@@ -349,7 +515,7 @@ pub struct FirewallOptionsDecl {
 /// `comment` are the value. PVE infers `ipversion` from the CIDR, so
 /// it's not modelled (a derived field would round-trip-drift).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct FirewallAliasDecl {
     /// Alias name — referenced from rules as `+name`. The identity.
     pub name: String,
@@ -366,7 +532,7 @@ pub struct FirewallAliasDecl {
 /// a map entry is host-DERIVED — a diff there means the hardware moved, not
 /// config drift. `mdev` is the only PCI-specific top-level field.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct MappingPciDecl {
     /// Mapping id — referenced from a guest as `hostpciN: mapping=<id>`. Identity.
     pub id: String,
@@ -385,7 +551,7 @@ pub struct MappingPciDecl {
 /// identity; `map` is the per-node device list (`node=…,path=…,id=…`). No `mdev`
 /// (USB has no mediated-device concept).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct MappingUsbDecl {
     /// Mapping id — referenced from a guest as `usbN: mapping=<id>`. Identity.
     pub id: String,
@@ -401,7 +567,7 @@ pub struct MappingUsbDecl {
 /// `name` is the identity; `comment` + the `cidrs` membership are the
 /// value. CIDRs are sorted by `cidr` on export for diff-stability.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct FirewallIpsetDecl {
     /// IP set name — referenced from rules as `+name`. The identity.
     pub name: String,
@@ -417,7 +583,7 @@ pub struct FirewallIpsetDecl {
 /// set; `comment` + `nomatch` are the value. `nomatch` inverts
 /// membership for this entry (carve an exception out of a range).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct FirewallIpsetCidrDecl {
     /// The CIDR or address (e.g. `10.0.0.0/24`, `1.2.3.4`).
     pub cidr: String,
@@ -434,7 +600,7 @@ pub struct FirewallIpsetCidrDecl {
 /// rules endpoint is read-only here), so only create/delete are
 /// applied — see [`ClusterState::firewall_groups`].
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct FirewallGroupDecl {
     /// Group name — referenced from `group`-direction rules. Identity.
     pub group: String,
@@ -451,7 +617,7 @@ pub struct FirewallGroupDecl {
 /// The three list fields are sorted on export for diff-stability;
 /// order is not semantically meaningful for `all`/`any` matching.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct NotificationMatcherDecl {
     /// Matcher name. The identity. Operators pick a readable one
     /// (`vzdump-failures`, `oncall`); PVE accepts it on create.
@@ -508,7 +674,7 @@ pub struct NotificationMatcherDecl {
 /// `digest` is deliberately NOT modelled — server-generated, would
 /// churn the TOML on every export.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct HaRuleDecl {
     /// Rule identifier — the URL last-segment. Operator-chosen on
     /// create (`keep-db-on-pve1`, `web-spread`).
@@ -580,7 +746,7 @@ pub struct HaRuleDecl {
 /// `digest` is deliberately NOT modelled — server-generated, would
 /// churn the TOML on every export.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct HaResourceDecl {
     /// HA SID. Identity. `vm:<vmid>` or `ct:<vmid>`.
     pub sid: String,
@@ -643,7 +809,7 @@ impl Default for HaResourceDecl {
 ///   Including it would make the TOML churn on every API call even
 ///   when nothing's changed.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct StorageDecl {
     /// Storage id (operator-chosen name, unique across the cluster).
     pub storage: String,
@@ -763,6 +929,7 @@ mod tests {
         // issues, missing #[serde(default)], etc.
         let s = ClusterState {
             meta: Some(StateMeta {
+                schema_version: crate::state::model::CURRENT_STATE_SCHEMA,
                 profile: "prod".into(),
                 exported_at: "2026-05-19T22:00:00Z".into(),
                 exported_from_proxxx: "0.2.1".into(),
@@ -1068,5 +1235,154 @@ members = ["qemu/100", "storage/ceph-rbd"]
         assert!(!toml_str.contains("mode"));
         assert!(!toml_str.contains("invert_match"));
         assert!(!toml_str.contains("disable"));
+    }
+}
+
+#[cfg(test)]
+mod identity_uniqueness_tests {
+    use super::ClusterState;
+
+    /// #261 — `diff` keys a HashMap on the identity, so a duplicate was
+    /// silently discarded. The realistic shape is a branch merge where
+    /// both sides added the same pool with different members.
+    #[test]
+    fn duplicate_pool_identity_is_refused() {
+        let err = ClusterState::from_toml_str(
+            r#"
+[[pools]]
+poolid = "tenant-a"
+members = ["qemu/100"]
+
+[[pools]]
+poolid = "tenant-a"
+members = ["qemu/200"]
+"#,
+        )
+        .expect_err("a duplicated poolid must not parse");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("pools") && msg.contains("tenant-a"),
+            "the error must name the family and the identity: {msg}"
+        );
+    }
+
+    /// ACL identity is the 4-tuple, not the path alone — two grants on
+    /// the same path with different roles are legitimate.
+    #[test]
+    fn acl_identity_is_the_full_tuple() {
+        ClusterState::from_toml_str(
+            r#"
+[[acl]]
+path = "/vms/100"
+kind = "user"
+ugid = "alice@pve"
+roleid = "PVEVMAdmin"
+
+[[acl]]
+path = "/vms/100"
+kind = "user"
+ugid = "alice@pve"
+roleid = "PVEAuditor"
+"#,
+        )
+        .expect("distinct roles on the same path are two distinct grants");
+
+        ClusterState::from_toml_str(
+            r#"
+[[acl]]
+path = "/vms/100"
+kind = "user"
+ugid = "alice@pve"
+roleid = "PVEVMAdmin"
+
+[[acl]]
+path = "/vms/100"
+kind = "user"
+ugid = "alice@pve"
+roleid = "PVEVMAdmin"
+propagate = false
+"#,
+        )
+        .expect_err("the same 4-tuple twice is a duplicate, whatever the value differs by");
+    }
+
+    #[test]
+    fn distinct_identities_still_parse() {
+        ClusterState::from_toml_str(
+            r#"
+[[pools]]
+poolid = "tenant-a"
+
+[[pools]]
+poolid = "tenant-b"
+"#,
+        )
+        .expect("distinct identities are fine");
+    }
+}
+
+#[cfg(test)]
+mod schema_version_tests {
+    use super::{ClusterState, CURRENT_STATE_SCHEMA};
+
+    /// #263 — a document written by a NEWER proxxx must be refused, not
+    /// reinterpreted. Same posture the cache DB takes when its
+    /// `user_version` exceeds the binary's.
+    #[test]
+    fn a_newer_schema_is_refused() {
+        let toml = format!(
+            r#"
+[meta]
+schema_version = {}
+profile = "prod"
+exported_at = "2026-09-09T00:00:00Z"
+exported_from_proxxx = "9.9.9"
+pve_version = "9.1.9"
+"#,
+            CURRENT_STATE_SCHEMA + 1
+        );
+        let err = ClusterState::from_toml_str(&toml).expect_err("a newer document must be refused");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("schema_version") && msg.contains("Upgrade proxxx"),
+            "the refusal must say what to do: {msg}"
+        );
+    }
+
+    /// Documents written before the field existed keep loading — they
+    /// are schema 1 by definition, being the shape it was introduced to
+    /// describe.
+    #[test]
+    fn a_document_without_the_field_still_loads() {
+        let s = ClusterState::from_toml_str(
+            r#"
+[meta]
+profile = "prod"
+exported_at = "2026-07-01T00:00:00Z"
+exported_from_proxxx = "0.13.3"
+pve_version = "9.1.9"
+"#,
+        )
+        .expect("pre-v0.13.4 documents must keep loading");
+        assert_eq!(
+            s.meta.expect("meta").schema_version,
+            CURRENT_STATE_SCHEMA,
+            "an absent version means the shape the field was introduced for"
+        );
+    }
+
+    #[test]
+    fn the_current_schema_loads() {
+        let toml = format!(
+            r#"
+[meta]
+schema_version = {CURRENT_STATE_SCHEMA}
+profile = "prod"
+exported_at = "2026-09-09T00:00:00Z"
+exported_from_proxxx = "0.13.4"
+pve_version = "9.1.9"
+"#
+        );
+        ClusterState::from_toml_str(&toml).expect("the current schema must load");
     }
 }

--- a/src/state/model.rs
+++ b/src/state/model.rs
@@ -1242,7 +1242,7 @@ members = ["qemu/100", "storage/ceph-rbd"]
 mod identity_uniqueness_tests {
     use super::ClusterState;
 
-    /// #261 — `diff` keys a HashMap on the identity, so a duplicate was
+    /// #261 — `diff` keys a `HashMap` on the identity, so a duplicate was
     /// silently discarded. The realistic shape is a branch merge where
     /// both sides added the same pool with different members.
     #[test]

--- a/src/state/preflight.rs
+++ b/src/state/preflight.rs
@@ -343,6 +343,7 @@ pub fn assess(changes: &[Change], live: &ClusterState) -> Vec<StateRisk> {
 }
 
 /// Per-change risk surface. Pure function; no I/O.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn assess_one(change: &Change, live: &ClusterState) -> Vec<StateRisk> {
     let mut out = Vec::new();
     match (change.kind, change.resource) {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -74,6 +74,7 @@ pub fn spawn_event_loop(tick_rate: Duration) -> mpsc::Receiver<AppEvent> {
 
 /// Map a key event to an app Action
 #[must_use]
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub fn map_key(key: KeyEvent, state: &crate::app::AppState) -> Option<crate::app::Action> {
     use crate::app::{Action, AppMode, View};
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -49,6 +49,11 @@ enum DataMsg {
     /// from this point may be stale.
     ClusterQuorate(bool),
     Error(String),
+    /// The cluster refresh cycle took longer than its target interval,
+    /// so what is on screen is at least this old (#277). Surfaced so the
+    /// operator sees staleness rather than inferring it from numbers
+    /// that stopped moving.
+    RefreshLagging(Duration),
     HitlRequested(String, String),               // txn_id, description
     HitlApproved(String, bool, Box<SideEffect>), // txn_id, approved, action
     TaskStarted(String),                         // upid
@@ -410,9 +415,36 @@ pub async fn run(
     let worker_client = Arc::clone(&client);
     let worker_tx = data_tx.clone();
     let api_worker_handle: tokio::task::JoinHandle<()> = tokio::spawn(async move {
+        // Audit 2026-09-09 (#277) — sleep for the REMAINDER of the
+        // target period, not a flat 5 s on top of however long the
+        // cycle took.
+        //
+        // `fetch_all` fans out per node and each task issues three
+        // requests, so a refresh costs 3N requests against a client
+        // rate-limited to 10/s by default. Past about three nodes the
+        // cycle already takes longer than its own interval, and adding
+        // a fixed 5 s on top made the real refresh period grow linearly
+        // with the cluster while the code still asked for 5. Nothing
+        // said so: no staleness signal, no adaptation, and the queued
+        // requests competed with whatever the operator was doing.
+        const TARGET: Duration = Duration::from_secs(5);
         loop {
+            let started = std::time::Instant::now();
             fetch_all(&worker_client, &worker_tx).await;
-            tokio::time::sleep(Duration::from_secs(5)).await;
+            let elapsed = started.elapsed();
+            if elapsed > TARGET {
+                // Cannot keep up. Say so once per cycle rather than
+                // letting the operator infer it from stale numbers.
+                tracing::warn!(
+                    "cluster refresh took {:?}, longer than the {:?} target — data \
+                     will be up to that old. Raise `rate_limit` in the profile, or \
+                     accept the slower cadence on a cluster this size.",
+                    elapsed,
+                    TARGET
+                );
+                let _ = worker_tx.send(DataMsg::RefreshLagging(elapsed)).await;
+            }
+            tokio::time::sleep(TARGET.saturating_sub(elapsed)).await;
         }
     });
 
@@ -657,6 +689,22 @@ pub async fn run(
                         DataMsg::Error(err) => {
                             app::update(&mut state, Action::ErrorOccurred(err));
                         }
+                        // #277 — surface refresh lag as a visible
+                        // condition. Reusing the existing error banner
+                        // rather than adding a status field: the
+                        // operator needs to know the numbers are stale,
+                        // and this is the channel they already read.
+                        DataMsg::RefreshLagging(elapsed) => {
+                            app::update(
+                                &mut state,
+                                Action::ErrorOccurred(format!(
+                                    "cluster refresh is taking {}s — displayed data may be \
+                                     that stale. Raise `rate_limit` in the profile if the \
+                                     cluster can take it.",
+                                    elapsed.as_secs().max(1)
+                                )),
+                            );
+                        }
                         DataMsg::HitlRequested(txn_id, description) => {
                             app::update(&mut state, Action::ApprovalRequested { txn_id, description });
                         }
@@ -802,9 +850,20 @@ async fn fetch_all(client: &Arc<PxClient>, tx: &mpsc::Sender<DataMsg>) {
 
             let mut join_set = tokio::task::JoinSet::new();
 
+            // #277 — bound the fan-out, as the batch path at
+            // cli::common::execute_batch_op_full already does. This loop
+            // runs forever and was the one producer without a gate: on a
+            // large cluster it opened one task per node unconditionally
+            // and relied entirely on the downstream rate limiter to
+            // absorb them.
+            const MAX_INFLIGHT_NODES: usize = 16;
+            let sem = Arc::new(tokio::sync::Semaphore::new(MAX_INFLIGHT_NODES));
+
             for node_name in node_names {
                 let client_cloned = Arc::clone(client);
+                let permit_source = Arc::clone(&sem);
                 join_set.spawn(async move {
+                    let _permit = permit_source.acquire_owned().await;
                     let guests = client_cloned.get_guests(&node_name).await;
                     let storage = client_cloned.get_storage_pools(&node_name).await;
                     (node_name, guests, storage)

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1046,6 +1046,9 @@ async fn dispatch_side_effect(
                 .map(|d| d.as_millis())
                 .unwrap_or(0);
             let txn_id = format!("{action}:{vmid}-{now_ms}");
+            // #250 — the quorum the matched policy demands. `secure_mode`
+            // without a matching policy is the single-approver case.
+            let require = policy_match.map_or(1, |pm| pm.require);
             let desc = format!("Operation {action} on {vmid} requires approval via {channel}");
             let reason = format!("TUI requested {action} on guest {vmid}");
             let action_owned = action.to_string();
@@ -1083,7 +1086,7 @@ async fn dispatch_side_effect(
 
                 let receiver = coord_clone.register(txn_id.clone()).await;
                 if let Err(e) = tg
-                    .request_approval(&action_owned, &target_owned, &reason, &txn_id)
+                    .request_approval(&action_owned, &target_owned, &reason, &txn_id, require)
                     .await
                 {
                     error!("Telegram request_approval failed: {e:#} — denying");

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -248,6 +248,7 @@ async fn run_hitl_poller(
 /// Run the TUI. Returns `Ok(Some(profile_name))` when the user switches
 /// profiles — the caller should re-enter `run()` with the new profile.
 /// Returns `Ok(None)` on normal quit.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub async fn run(
     profile: Option<&str>,
     cli_secret: Option<&str>,
@@ -978,6 +979,7 @@ fn spawn_ssh_open<B: ratatui::backend::Backend>(
 /// passthroughs, MoveDisk/ResizeDisk warn-and-skip) don't, so clippy
 /// flags the function as unused-async on a per-branch basis.
 #[allow(clippy::unused_async)]
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 async fn dispatch_side_effect(
     effect: SideEffect,
     state: &AppState,
@@ -1994,6 +1996,7 @@ const MIN_FRAME_WIDTH: u16 = 40;
 const MIN_FRAME_HEIGHT: u16 = 8;
 
 /// Top-level render dispatcher — routes to the correct view
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn draw(f: &mut Frame, state: &AppState, ssh: &ssh_handler::SshSessionHandler) {
     let area = f.area();
 

--- a/src/tui/views/backup.rs
+++ b/src/tui/views/backup.rs
@@ -10,6 +10,7 @@ use crate::app::AppState;
 use crate::tui::theme::Theme;
 use crate::util::sanitize::sanitize_display;
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/tui/views/guests.rs
+++ b/src/tui/views/guests.rs
@@ -84,6 +84,7 @@ fn draw_title(f: &mut Frame, area: Rect, state: &AppState) {
     );
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn draw_guest_table(f: &mut Frame, area: Rect, state: &AppState) {
     let visible_list = state.visible_guests();
 
@@ -274,6 +275,7 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn draw_guest_detail(f: &mut Frame, area: Rect, state: &AppState, vmid: u32) {
     let guest = state.guests.iter().find(|g| g.vmid == vmid);
 

--- a/src/tui/views/ha_console.rs
+++ b/src/tui/views/ha_console.rs
@@ -139,6 +139,7 @@ fn draw_header(f: &mut Frame, area: Rect, state: &AppState) {
     );
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn draw_ha(f: &mut Frame, area: Rect, state: &AppState) {
     let cols = Layout::default()
         .direction(Direction::Horizontal)

--- a/src/tui/views/nodes.rs
+++ b/src/tui/views/nodes.rs
@@ -46,6 +46,7 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
     draw_node_table(f, chunks[1], state);
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn draw_node_table(f: &mut Frame, area: Rect, state: &AppState) {
     if state.nodes.is_empty() {
         let msg = if state.is_loading {

--- a/src/tui/views/queue.rs
+++ b/src/tui/views/queue.rs
@@ -10,6 +10,7 @@ use crate::app::queue::OpStatus;
 use crate::app::AppState;
 use crate::tui::theme::Theme;
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
     let main_chunks = Layout::default()
         .direction(Direction::Horizontal)

--- a/src/tui/views/storage.rs
+++ b/src/tui/views/storage.rs
@@ -39,6 +39,7 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState) {
     draw_storage_table(f, chunks[1], state);
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn draw_storage_table(f: &mut Frame, area: Rect, state: &AppState) {
     if state.storage.is_empty() {
         let msg = if state.is_loading {

--- a/src/tui/views/timeline.rs
+++ b/src/tui/views/timeline.rs
@@ -91,6 +91,7 @@ fn draw_timeline_slider(f: &mut Frame, area: Rect, state: &AppState) {
     f.render_widget(gauge, area);
 }
 
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn draw_diff_table(f: &mut Frame, area: Rect, state: &AppState) {
     let current_snap = state.timeline_snapshot.as_ref();
     let prev_snap = state.timeline_prev_snapshot.as_ref();

--- a/src/tui/widgets/status_footer.rs
+++ b/src/tui/widgets/status_footer.rs
@@ -88,6 +88,7 @@ const fn mode_label_for(mode: &AppMode) -> &'static str {
 
 /// Returns the `(key, label)` pairs to surface for the current
 /// (view, mode). Pure — testable without rendering.
+#[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
 fn bindings_for(view: &View, mode: &AppMode) -> Vec<(&'static str, &'static str)> {
     if matches!(mode, AppMode::Help) {
         return vec![("any key", "dismiss help")];

--- a/src/util/durable.rs
+++ b/src/util/durable.rs
@@ -1,0 +1,143 @@
+//! Durable rename: make a renamed file survive a power loss.
+//!
+//! Audit 2026-09-09 (#268). Every atomic write in proxxx follows the
+//! same discipline — write a sibling temp file, `sync_all()` it, chmod
+//! it, then `rename` over the target — and that is correct for the
+//! property it was reaching for: a reader sees either the old file or
+//! the complete new one, never a half-written one.
+//!
+//! What it did not do is make the *rename* durable. `rename(2)` updates
+//! the parent directory, and POSIX does not guarantee that update has
+//! reached stable storage until the directory itself is fsynced. Between
+//! the rename returning and that flush, the process has already told the
+//! operator the write succeeded — `proxxx incident freeze` prints that
+//! the fleet is frozen, `proxxx init` reports the config written. After a
+//! power loss the directory may still show the pre-rename state: the
+//! freeze lock absent and the kill-switch off, or a newly generated HITL
+//! HMAC key gone, which makes every audit row signed with it
+//! unverifiable.
+//!
+//! On ext4 with `data=ordered` a rename-over-existing gets an implicit
+//! data flush, so the practical exposure is narrower than the POSIX
+//! guarantee implies — but the directory entry itself is still not
+//! covered, and proxxx also runs on APFS, XFS and ZFS.
+//!
+//! There were four hand-rolled copies of the same pattern; this is the
+//! shared helper they now call.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// `rename` `from` over `to`, then fsync the parent directory so the
+/// rename itself survives a crash.
+///
+/// # Errors
+/// When the rename fails, or when the parent directory cannot be opened
+/// or synced. A failure to sync is reported rather than swallowed: the
+/// caller asked for a durable write and did not get one.
+pub fn rename_durable(from: &Path, to: &Path) -> Result<()> {
+    std::fs::rename(from, to)
+        .with_context(|| format!("rename {} → {}", from.display(), to.display()))?;
+    sync_parent_dir(to)
+}
+
+/// fsync the directory containing `path`.
+///
+/// Opening a directory read-only and syncing it is the portable way to
+/// flush its entries. On platforms where a directory cannot be opened
+/// this way the call is a no-op rather than an error — the rename has
+/// already happened, and failing the operation over an unsupported
+/// durability primitive would be worse than the exposure it closes.
+///
+/// # Errors
+/// When the directory exists and can be opened but the sync fails.
+pub fn sync_parent_dir(path: &Path) -> Result<()> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    // An empty parent means a bare filename in the cwd.
+    let dir = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    match std::fs::File::open(dir) {
+        Ok(handle) => handle
+            .sync_all()
+            .with_context(|| format!("fsync directory {}", dir.display())),
+        // Windows cannot open a directory as a file. Nothing to do.
+        Err(_) => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{rename_durable, sync_parent_dir};
+
+    #[test]
+    fn rename_durable_moves_the_file_and_syncs() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let tmp = dir.path().join("x.tmp");
+        let target = dir.path().join("x");
+        std::fs::write(&tmp, b"payload").expect("write");
+
+        rename_durable(&tmp, &target).expect("durable rename");
+
+        assert!(!tmp.exists(), "the temp file must be gone");
+        assert_eq!(
+            std::fs::read(&target).expect("read back"),
+            b"payload",
+            "the target must hold the new content"
+        );
+    }
+
+    #[test]
+    fn rename_durable_overwrites_an_existing_target() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let tmp = dir.path().join("x.tmp");
+        let target = dir.path().join("x");
+        std::fs::write(&target, b"old").expect("seed");
+        std::fs::write(&tmp, b"new").expect("write");
+
+        rename_durable(&tmp, &target).expect("durable rename");
+        assert_eq!(std::fs::read(&target).expect("read"), b"new");
+    }
+
+    #[test]
+    fn syncing_a_bare_filename_does_not_error() {
+        sync_parent_dir(std::path::Path::new("no-directory-component"))
+            .expect("a bare filename resolves to the cwd, which is syncable");
+    }
+}
+
+#[cfg(test)]
+mod call_site_tests {
+    /// #268 — every atomic write must go through the durable helper.
+    ///
+    /// There were six hand-rolled `fs::rename` sites, each fsyncing the
+    /// temp file and none the directory. A seventh added later would
+    /// inherit the same gap silently, so this asserts the helper is the
+    /// only way a write reaches its final name.
+    #[test]
+    fn no_atomic_write_site_uses_a_bare_rename() {
+        const SITES: &[(&str, &str)] = &[
+            ("cli/init.rs", include_str!("../cli/init.rs")),
+            ("cli/init_wizard.rs", include_str!("../cli/init_wizard.rs")),
+            ("cli/schedule.rs", include_str!("../cli/schedule.rs")),
+            ("config/mod.rs", include_str!("../config/mod.rs")),
+            ("hitl/hmac_key.rs", include_str!("../hitl/hmac_key.rs")),
+            ("incident/mod.rs", include_str!("../incident/mod.rs")),
+        ];
+        for (name, src) in SITES {
+            assert!(
+                !src.contains("std::fs::rename("),
+                "{name} uses a bare std::fs::rename — use util::durable::rename_durable \
+                 so the rename itself survives a power loss (#268)"
+            );
+            assert!(
+                src.contains("rename_durable("),
+                "{name} should reach its final filename through rename_durable"
+            );
+        }
+    }
+}

--- a/src/util/format.rs
+++ b/src/util/format.rs
@@ -5,6 +5,21 @@ use serde_json::Value;
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum OutputFormat {
     Json,
+    /// JSON wrapped in a envelope carrying the producing version
+    /// (audit 2026-09-09, #284).
+    ///
+    /// `--format json` emits the payload verbatim and always has, so a
+    /// script cannot tell from the output which contract produced it.
+    /// The additive-only promise protects a caller that keeps working
+    /// against a newer proxxx; it does not help one that must work
+    /// against several versions at once — a CI fleet mid-rollout, or a
+    /// wrapper supporting the last two releases. Those had to shell out
+    /// to `proxxx --version` and maintain their own mapping.
+    ///
+    /// A separate format rather than a change to `json`, because
+    /// changing the existing one would break every parser that reads it
+    /// today — which is exactly the compatibility problem being solved.
+    JsonEnvelope,
     Table,
     Plain,
 }
@@ -14,6 +29,13 @@ pub fn print(data: &Value, format: OutputFormat) -> Result<()> {
     match format {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(data)?);
+        }
+        OutputFormat::JsonEnvelope => {
+            let enveloped = serde_json::json!({
+                "proxxx": env!("CARGO_PKG_VERSION"),
+                "data": data,
+            });
+            println!("{}", serde_json::to_string_pretty(&enveloped)?);
         }
         OutputFormat::Table => {
             print_table(data);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod durable;
 pub mod format;
 pub mod panic_hook;
 pub mod sanitize;

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -26,7 +26,7 @@ mod tests {
         }))
     }
 
-    async fn mock_client(server: &MockServer) -> PxClient {
+    pub(super) async fn mock_client(server: &MockServer) -> PxClient {
         // Pass the secret via the cli_secret parameter (resolver priority
         // #1) instead of `std::env::set_var`. Env vars are process-global
         // and cargo runs integration tests in parallel — set_var would
@@ -6314,4 +6314,87 @@ fn empty_backup_jobs_array_parses_cleanly() {
     let parsed: ApiResponse<Vec<BackupJob>> =
         serde_json::from_slice(raw).expect("empty BackupJob array must parse");
     assert!(parsed.data.is_empty());
+}
+
+#[cfg(test)]
+mod fast_guest_lookup {
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // Reuse the outer module's fixture rather than a second, subtly
+    // different ProfileConfig literal.
+    use super::tests::mock_client as client;
+
+    /// #276 — locating a vmid must cost ONE cluster-wide request, not a
+    /// per-node walk. The `expect(0)` on `/nodes` is the assertion: the
+    /// old path started there.
+    #[tokio::test]
+    async fn find_guest_uses_cluster_resources_not_a_per_node_walk() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/cluster/resources"))
+            .and(query_param("type", "vm"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    {"id": "lxc/200", "type": "lxc", "node": "pve7", "vmid": 200,
+                     "name": "ct200", "status": "running"}
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // The per-node walk would begin here. It must not run.
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let c = client(&server).await;
+        let (node, guest_type) = proxxx::cli::common::find_guest(&c, 200)
+            .await
+            .expect("guest located");
+        assert_eq!(node, "pve7");
+        assert_eq!(guest_type, proxxx::api::types::GuestType::Lxc);
+    }
+
+    /// If `/cluster/resources` is unavailable, the per-node walk must
+    /// still work — a cluster that does not serve it is not broken.
+    #[tokio::test]
+    async fn falls_back_to_the_per_node_walk() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/cluster/resources"))
+            .respond_with(ResponseTemplate::new(501))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"node": "pve1", "status": "online"}]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes/pve1/qemu"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"vmid": 100, "name": "vm100", "status": "running"}]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes/pve1/lxc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": []
+            })))
+            .mount(&server)
+            .await;
+
+        let c = client(&server).await;
+        let (node, _) = proxxx::cli::common::find_guest(&c, 100)
+            .await
+            .expect("fallback locates the guest");
+        assert_eq!(node, "pve1");
+    }
 }

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -98,6 +98,81 @@ mod tests {
             .expect("stop");
     }
 
+    /// #260 — `/status/current` carries no `type` field, so the client
+    /// must stamp `guest_type` and `node` from the hierarchy that
+    /// answered. Before v0.13.4 every container came back labelled as a
+    /// QEMU VM on node "", and the MCP tool serialised that to its
+    /// caller verbatim.
+    #[tokio::test]
+    async fn get_guest_status_stamps_lxc_type_and_node() {
+        let server = MockServer::start().await;
+        // QEMU probe misses — PVE answers 500 for a vmid in the other
+        // hierarchy.
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes/pve1/qemu/200/status/current"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes/pve1/lxc/200/status/current"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "vmid": 200, "name": "ct200", "status": "running" }
+            })))
+            .mount(&server)
+            .await;
+
+        let c = mock_client(&server).await;
+        let g = c.get_guest_status("pve1", 200).await.expect("status");
+        assert_eq!(
+            g.guest_type,
+            GuestType::Lxc,
+            "a container must not be reported as a QEMU VM"
+        );
+        assert_eq!(g.node, "pve1", "the node must be stamped from the query");
+    }
+
+    #[tokio::test]
+    async fn get_guest_status_stamps_qemu_type_and_node() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes/pve1/qemu/100/status/current"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "vmid": 100, "name": "vm100", "status": "running" }
+            })))
+            .mount(&server)
+            .await;
+        let c = mock_client(&server).await;
+        let g = c.get_guest_status("pve1", 100).await.expect("status");
+        assert_eq!(g.guest_type, GuestType::Qemu);
+        assert_eq!(g.node, "pve1");
+    }
+
+    /// #260 — a 403 on the QEMU probe is not "this is not a VM". It used
+    /// to fall through and surface an LXC 404, naming the wrong
+    /// hierarchy and the wrong cause.
+    #[tokio::test]
+    async fn get_guest_status_propagates_a_403_instead_of_probing_lxc() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api2/json/nodes/pve1/qemu/100/status/current"))
+            .respond_with(ResponseTemplate::new(403))
+            .expect(1)
+            .mount(&server)
+            .await;
+        // No LXC mock at all: reaching it would 404 the request and fail
+        // this test for the right reason.
+        let c = mock_client(&server).await;
+        let err = c
+            .get_guest_status("pve1", 100)
+            .await
+            .expect_err("a 403 must surface, not be swallowed");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("403") || msg.to_lowercase().contains("privile"),
+            "the permission error must survive: {msg}"
+        );
+    }
+
     #[tokio::test]
     async fn lxc_delete_hits_lxc_path() {
         // SPOF 2.3 (Cat. 2 audit): delete now does a pre-flight status
@@ -106,12 +181,14 @@ mod tests {
         Mock::given(method("GET"))
             .and(path("/api2/json/nodes/pve1/lxc/200/status/current"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                // #260: deliberately WITHOUT `type` and `node` — real
+                // PVE `/status/current` does not carry them, and the
+                // client must assign both from the hierarchy it queried.
+                // Injecting them here is what hid the defect.
                 "data": {
                     "vmid": 200,
                     "name": "ct200",
-                    "status": "stopped",
-                    "type": "lxc",
-                    "node": "pve1"
+                    "status": "stopped"
                 }
             })))
             .expect(1)

--- a/tests/fleet_test.rs
+++ b/tests/fleet_test.rs
@@ -121,6 +121,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::too_many_lines)] // audit #272: wide, flat dispatch — see Cargo.toml
     async fn fleet_aggregates_across_clusters_and_degrades_gracefully() {
         // ── alpha: 2 online nodes, 3 guests, shared nfs pool ──
         let alpha = MockServer::start().await;

--- a/tests/hitl_e2e.rs
+++ b/tests/hitl_e2e.rs
@@ -69,7 +69,7 @@ fn callback_query(id: &str, data: &str) -> CallbackQuery {
     // `from`, so we round-trip through JSON.
     let json = serde_json::json!({
         "id": id,
-        "from": { "first_name": "tester" },
+        "from": { "id": TEST_APPROVER, "first_name": "tester" },
         "data": data,
     });
     serde_json::from_value(json).expect("CallbackQuery deserializes")
@@ -81,7 +81,7 @@ fn update(update_id: i64, cb: CallbackQuery) -> Update {
         // the JSON manually.
         serde_json::json!({
             "id": "fallback",
-            "from": { "first_name": "tester" },
+            "from": { "id": TEST_APPROVER, "first_name": "tester" },
             "data": "approve:start:1",
         })
     });
@@ -144,11 +144,196 @@ async fn setup_telegram_mock() -> MockServer {
 
 /// Build a `TelegramGateway` pointed at the wiremock server.
 fn fake_gateway(server: &MockServer) -> TelegramGateway {
+    // Since #249 the daemon refuses any callback unless the sender is on
+    // the approver allowlist, so every fixture gateway installs the test
+    // approver id used by `callback_query` below.
     TelegramGateway::with_base_url(
         "faketoken".to_string(),
         "12345".to_string(),
         format!("{}/bot", server.uri()),
     )
+    .with_allowed_approvers(vec![TEST_APPROVER])
+}
+
+/// Telegram user id every fixture callback is sent from, and the only
+/// id `fake_gateway` authorises.
+const TEST_APPROVER: i64 = 4242;
+
+/// #249 — a correctly-signed callback from a Telegram account that is
+/// NOT on the allowlist must be refused without executing anything.
+#[tokio::test]
+async fn callback_from_unlisted_user_is_refused() {
+    let server = setup_telegram_mock().await;
+    let tg = fake_gateway(&server);
+    let data = signed(tg.hmac_key(), "approve:stop:100");
+    let cb: CallbackQuery = serde_json::from_value(serde_json::json!({
+        "id": "cb-intruder",
+        "from": { "id": 9999_i64, "first_name": "intruder" },
+        "data": data,
+        "message": { "message_id": 1_i64 },
+    }))
+    .expect("CallbackQuery deserializes");
+    let gw = HitlMockGateway::new();
+    let pending = PendingApprovals::new();
+    let out = handle_callback_update(&update(1, cb), &pending, &gw, &tg)
+        .await
+        .expect("handle_callback_update");
+    assert!(
+        matches!(out, CallbackOutcome::UnauthorizedApprover { user_id: 9999 }),
+        "an unlisted sender must be refused, got {out:?}"
+    );
+    assert!(
+        gw.calls_for("shutdown_guest").is_empty(),
+        "refused callback must not reach the gateway, got {:?}",
+        gw.calls_for("shutdown_guest")
+    );
+}
+
+/// #249 — with no `allowed_approvers` configured the daemon refuses
+/// every callback rather than accepting anyone who can see the message.
+#[tokio::test]
+async fn callback_with_no_allowlist_configured_is_refused() {
+    let server = setup_telegram_mock().await;
+    // Deliberately NOT calling `.with_allowed_approvers(..)`.
+    let tg = TelegramGateway::with_base_url(
+        "faketoken".to_string(),
+        "12345".to_string(),
+        format!("{}/bot", server.uri()),
+    );
+    let data = signed(tg.hmac_key(), "approve:stop:100");
+    let cb = callback_query("cb-noallowlist", &data);
+    let gw = HitlMockGateway::new();
+    let pending = PendingApprovals::new();
+    let out = handle_callback_update(&update(1, cb), &pending, &gw, &tg)
+        .await
+        .expect("handle_callback_update");
+    assert!(
+        matches!(out, CallbackOutcome::UnauthorizedApprover { .. }),
+        "an unconfigured allowlist must fail closed, got {out:?}"
+    );
+    assert!(
+        gw.calls_for("shutdown_guest").is_empty(),
+        "nothing may execute"
+    );
+}
+
+/// #249 — a keyboard forwarded into a different chat cannot drive the
+/// daemon even when the sender is an authorised approver.
+#[tokio::test]
+async fn callback_from_another_chat_is_refused() {
+    let server = setup_telegram_mock().await;
+    let tg = fake_gateway(&server); // configured chat_id = "12345"
+    let data = signed(tg.hmac_key(), "approve:stop:100");
+    let cb: CallbackQuery = serde_json::from_value(serde_json::json!({
+        "id": "cb-forwarded",
+        "from": { "id": TEST_APPROVER, "first_name": "tester" },
+        "data": data,
+        "message": { "message_id": 1_i64, "chat": { "id": 999_i64 } },
+    }))
+    .expect("CallbackQuery deserializes");
+    let gw = HitlMockGateway::new();
+    let pending = PendingApprovals::new();
+    let out = handle_callback_update(&update(1, cb), &pending, &gw, &tg)
+        .await
+        .expect("handle_callback_update");
+    assert!(
+        matches!(out, CallbackOutcome::WrongChat { chat_id: 999 }),
+        "a forwarded keyboard must be refused, got {out:?}"
+    );
+    assert!(
+        gw.calls_for("shutdown_guest").is_empty(),
+        "nothing may execute"
+    );
+}
+
+/// #250 — a policy with `require = 2` must not execute on the first
+/// approval, and must execute once a SECOND distinct approver votes.
+#[tokio::test]
+async fn quorum_of_two_needs_two_distinct_approvers() {
+    const SECOND: i64 = 5150;
+    let server = setup_telegram_mock().await;
+    let tg = fake_gateway(&server).with_allowed_approvers(vec![TEST_APPROVER, SECOND]);
+    // Payload as `request_approval` mints it for `require = 2`.
+    let data = signed(tg.hmac_key(), "approve:stop:100:r2");
+    let gw = HitlMockGateway::new().with_node_and_guest("pve1", guest(100, "vm-quorum"));
+    let pending = PendingApprovals::new();
+
+    let first = handle_callback_update(
+        &update(1, callback_query("cb-q1", &data)),
+        &pending,
+        &gw,
+        &tg,
+    )
+    .await
+    .expect("first vote");
+    assert!(
+        matches!(
+            first,
+            CallbackOutcome::AwaitingApprovals { have: 1, need: 2 }
+        ),
+        "first approval must not execute, got {first:?}"
+    );
+    assert!(
+        gw.calls_for("shutdown_guest").is_empty(),
+        "nothing may execute on a single vote"
+    );
+
+    // The SAME approver pressing again must not complete the quorum.
+    let again = handle_callback_update(
+        &update(2, callback_query("cb-q1b", &data)),
+        &pending,
+        &gw,
+        &tg,
+    )
+    .await
+    .expect("duplicate vote");
+    assert!(
+        matches!(
+            again,
+            CallbackOutcome::AwaitingApprovals { have: 1, need: 2 }
+        ),
+        "the same approver must not satisfy a 2-of-N quorum, got {again:?}"
+    );
+    assert!(gw.calls_for("shutdown_guest").is_empty());
+
+    // A second, distinct approver completes it.
+    let cb2: CallbackQuery = serde_json::from_value(serde_json::json!({
+        "id": "cb-q2",
+        "from": { "id": SECOND, "first_name": "second" },
+        "data": data,
+        "message": { "message_id": 1_i64 },
+    }))
+    .expect("CallbackQuery deserializes");
+    let done = handle_callback_update(&update(3, cb2), &pending, &gw, &tg)
+        .await
+        .expect("second vote");
+    assert!(
+        matches!(done, CallbackOutcome::Executed { .. }),
+        "the second distinct approver must complete the quorum, got {done:?}"
+    );
+}
+
+/// #250 — a keyboard minted before the quorum segment existed (three
+/// payload segments, no `r<N>`) still means one approver.
+#[tokio::test]
+async fn legacy_payload_without_quorum_segment_means_one() {
+    let server = setup_telegram_mock().await;
+    let tg = fake_gateway(&server);
+    let data = signed(tg.hmac_key(), "approve:stop:100");
+    let gw = HitlMockGateway::new().with_node_and_guest("pve1", guest(100, "vm-quorum"));
+    let pending = PendingApprovals::new();
+    let out = handle_callback_update(
+        &update(1, callback_query("cb-legacy", &data)),
+        &pending,
+        &gw,
+        &tg,
+    )
+    .await
+    .expect("legacy payload");
+    assert!(
+        matches!(out, CallbackOutcome::Executed { .. }),
+        "a 3-segment payload must behave as require=1, got {out:?}"
+    );
 }
 
 /// Helper to build a Node by name.
@@ -1384,6 +1569,7 @@ async fn secure_mode_forces_request_approval_for_destructive() {
                 &vmid.to_string(),
                 "test",
                 &format!("{action}:{vmid}"),
+                1,
             )
             .await
             .expect("request_approval");
@@ -1486,7 +1672,7 @@ async fn fast_op_skips_intermediate_executing_edit() {
     let data = signed(tg.hmac_key(), "approve:restart:100");
     let cb_json = serde_json::json!({
         "id": "cb-fast",
-        "from": { "first_name": "tester" },
+        "from": { "id": TEST_APPROVER, "first_name": "tester" },
         "data": data,
         "message": { "message_id": 42 },
     });
@@ -1517,6 +1703,7 @@ async fn fast_op_skips_intermediate_executing_edit() {
 #[serial_test::serial] // env vars are process-global
 async fn env_var_beats_inline_bot_token() {
     let cfg = proxxx::config::TelegramConfig {
+        allowed_approvers: None,
         bot_token: Some(proxxx::util::secret::SecretString::from("inline-loser")),
         bot_token_file: None,
         chat_id: "12345".to_string(),
@@ -1550,6 +1737,7 @@ async fn bot_token_file_with_lax_permissions_is_refused() {
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("chmod");
 
     let cfg = proxxx::config::TelegramConfig {
+        allowed_approvers: None,
         bot_token: None,
         bot_token_file: Some(path.to_string_lossy().to_string()),
         chat_id: "12345".to_string(),

--- a/tests/live/test_pbs_backup_restore.sh
+++ b/tests/live/test_pbs_backup_restore.sh
@@ -240,7 +240,7 @@ log "[step 7] proxxx backup-verify (expect $VMID pass; retries for content-listi
 verify_ok=0
 for attempt in 1 2 3 4 5; do
     out=$("${PX[@]}" backup-verify 2>&1)
-    if echo "$out" | grep -E "^$VMID[[:space:]]" | grep -q "pass"; then
+    if echo "$out" | grep -E "^${VMID}[[:space:]]" | grep -q "pass"; then
         verify_ok=1
         break
     fi

--- a/tests/logging_surface_test.rs
+++ b/tests/logging_surface_test.rs
@@ -1,0 +1,88 @@
+//! #270 — where log records actually go, asserted by running the binary.
+//!
+//! The defect this guards against is structural and easy to reintroduce:
+//! the subscriber was wired to a rotating file appender and nothing else,
+//! so a daemon under the recommended systemd unit produced a journald
+//! stream with its start and stop lines and nothing in between. Every
+//! diagnostic that mattered — the write kill-switch disengaging, TLS
+//! pinning silently off — went to a file the operator had not been told
+//! about.
+//!
+//! These run the real binary rather than inspecting source, because what
+//! matters is the observable stream, not how it is constructed.
+
+#![allow(clippy::expect_used)]
+
+use std::process::Command;
+
+fn run(args: &[&str], rust_log: Option<&str>) -> (String, String) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_proxxx"));
+    cmd.args(args);
+    match rust_log {
+        Some(v) => {
+            cmd.env("RUST_LOG", v);
+        }
+        None => {
+            cmd.env_remove("RUST_LOG");
+        }
+    }
+    // Point the config somewhere empty so the run fails fast and
+    // deterministically instead of touching a developer's real cluster.
+    cmd.env("PROXXX_CONFIG", "/nonexistent/proxxx-logging-test.toml");
+    let out = cmd.output().expect("binary runs");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// A CLI invocation must put its log records on stderr, where journald
+/// and a log shipper can see them.
+#[test]
+fn cli_mode_logs_to_stderr() {
+    let (_out, err) = run(&["ls", "nodes"], None);
+    assert!(
+        err.contains("proxxx v") && err.contains("starting"),
+        "the startup record must reach stderr, got: {err:?}"
+    );
+}
+
+/// …and must not put them on stdout, which carries `--format json` and
+/// `state export` output that pipelines parse.
+#[test]
+fn log_records_never_contaminate_stdout() {
+    let (out, _err) = run(&["--format", "json", "ls", "nodes"], None);
+    assert!(
+        !out.contains("INFO") && !out.contains("proxxx v"),
+        "stdout must stay machine-readable, got: {out:?}"
+    );
+}
+
+/// `RUST_LOG` must be honoured. It was previously ignored in favour of a
+/// compile-time literal, so an operator who set it believed they had
+/// changed something and had not.
+#[test]
+fn rust_log_controls_the_level() {
+    let (_out, default_err) = run(&["ls", "nodes"], None);
+    assert!(
+        default_err.contains("INFO"),
+        "the default filter must emit info records, got: {default_err:?}"
+    );
+
+    let (_out, quiet_err) = run(&["ls", "nodes"], Some("error"));
+    assert!(
+        !quiet_err.contains("INFO"),
+        "RUST_LOG=error must suppress info records, got: {quiet_err:?}"
+    );
+}
+
+/// The operator is told where the file copy lives, so the rotating log
+/// is discoverable rather than a path they have to know already.
+#[test]
+fn startup_names_the_log_file_location() {
+    let (_out, err) = run(&["ls", "nodes"], None);
+    assert!(
+        err.contains("log file:"),
+        "startup must name the log file path, got: {err:?}"
+    );
+}

--- a/tests/proxmox_map_coverage.rs
+++ b/tests/proxmox_map_coverage.rs
@@ -149,6 +149,15 @@ struct ClientPath {
 /// endpoints from the map's perspective.
 const KIND_PLACEHOLDERS: &[&str] = &["{kind}", "{type_str}"];
 
+/// Everything before the first `#[cfg(test)]` in a source file.
+///
+/// Crude but exactly right for this file: client.rs keeps its unit tests
+/// at the bottom, and a path literal that only exists inside a test is
+/// not an endpoint the client calls.
+fn production_source(src: &str) -> &str {
+    src.find("#[cfg(test)]").map_or(src, |i| &src[..i])
+}
+
 /// Extract every API path string the client constructs. Heuristic:
 /// scan source for string literals starting with `/nodes`, `/cluster`,
 /// `/access`, `/storage`, `/pools`, `/version`. Also handles
@@ -156,7 +165,12 @@ const KIND_PLACEHOLDERS: &[&str] = &["{kind}", "{type_str}"];
 /// and the disk-resize site).
 fn parse_client_paths() -> Vec<ClientPath> {
     let mut paths = BTreeSet::new();
-    for s in extract_string_literals(CLIENT_RS) {
+    // Only the production half of client.rs describes real endpoints.
+    // `#[cfg(test)]` modules in that file contain deliberately malformed
+    // fixture paths (traversal probes for the #253 guard, for one), and
+    // counting those as "endpoints proxxx calls" is nonsense that shows
+    // up as phantom drift.
+    for s in extract_string_literals(production_source(CLIENT_RS)) {
         if !is_pve_path(&s) {
             continue;
         }

--- a/tests/rbac_e2e.rs
+++ b/tests/rbac_e2e.rs
@@ -702,10 +702,15 @@ async fn operator_get_guest_status_on_unowned_returns_typed_forbidden() {
         .expect(1)
         .mount(&server)
         .await;
+    // #260 — a 403 on the QEMU probe means "you may not look", not
+    // "this is not a VM", so it must surface immediately. Expecting ZERO
+    // calls here is the assertion: before v0.13.4 the permission error
+    // was swallowed and a second, pointless request went to the other
+    // hierarchy, whose 404/403 is what the operator finally saw.
     Mock::given(method("GET"))
         .and(path("/api2/json/nodes/pve1/lxc/100/status/current"))
         .respond_with(pve_403("Permission check failed (/vms/100, VM.Audit)"))
-        .expect(1)
+        .expect(0)
         .mount(&server)
         .await;
 
@@ -941,10 +946,15 @@ async fn blind_get_guest_status_on_other_vmid_returns_typed_forbidden() {
         .expect(1)
         .mount(&server)
         .await;
+    // #260 — a 403 on the QEMU probe means "you may not look", not
+    // "this is not a VM", so it must surface immediately. Expecting ZERO
+    // calls here is the assertion: before v0.13.4 the permission error
+    // was swallowed and a second, pointless request went to the other
+    // hierarchy, whose 404/403 is what the operator finally saw.
     Mock::given(method("GET"))
         .and(path("/api2/json/nodes/pve1/lxc/100/status/current"))
         .respond_with(pve_403("Permission check failed (/vms/100, VM.Audit)"))
-        .expect(1)
+        .expect(0)
         .mount(&server)
         .await;
 

--- a/tests/rbac_live.rs
+++ b/tests/rbac_live.rs
@@ -628,7 +628,8 @@ async fn hitl_callback_replay_rejected_under_live_pve() {
         "1".to_string(),
         format!("{}/bot", server.uri()),
         zero_key.clone(),
-    );
+    )
+    .with_allowed_approvers(vec![7_i64]);
 
     // Real operator client against the live PVE cluster.
     let client = env.operator().await.expect("operator client");
@@ -645,7 +646,7 @@ async fn hitl_callback_replay_rejected_under_live_pve() {
         "update_id": 1_i64,
         "callback_query": {
             "id": "live-replay-1",
-            "from": { "first_name": "live-replay-tester" },
+            "from": { "id": 7_i64, "first_name": "live-replay-tester" },
             "data": callback_data,
             "message": { "message_id": 1_i64 },
         }

--- a/tests/resilience_chaos_e2e.rs
+++ b/tests/resilience_chaos_e2e.rs
@@ -506,17 +506,50 @@ mod proxmox_quirks {
     /// message. We attest the lock-detection state field.
     #[test]
     fn guest_lock_detection_blocks_duplicate_migration_intent() {
-        // The contract surface is `Guest::lock`. When `lock` is
-        // set on a guest (PVE sets it during in-flight ops), the
-        // CLI/TUI's pre-flight refuses any new mutation against
-        // that vmid without `--allow-risk`.
+        // Audit #273 — this test used to construct two local
+        // `Option<String>` values and assert on those, touching neither
+        // `Guest` nor the pre-flight gate. It passed with lock detection
+        // deleted, and its comment misdescribed `Guest::lock` as an
+        // `Option<String>` (it is a plain `String`) — an error it could
+        // not catch precisely because it never referenced the type.
         //
-        // We pin the structural contract: the `lock` field is
-        // `Option<String>` on the Guest type.
-        let g_clean: Option<String> = None;
-        let g_locked: Option<String> = Some("migrate".to_string());
-        assert!(g_clean.is_none());
-        assert_eq!(g_locked.as_deref(), Some("migrate"));
+        // What the row actually claims: a guest PVE has locked mid-op
+        // must be refused a further mutation. So exercise the gate.
+        use proxxx::api::types::Guest;
+        use proxxx::app::preflight::{assess, Op, Risk, RiskLevel};
+
+        let mut locked = Guest {
+            vmid: 100,
+            node: "pve1".into(),
+            ..Default::default()
+        };
+        locked.lock = "migrate".into();
+        assert!(locked.is_locked(), "a non-empty lock means PVE holds it");
+
+        let risks = assess(Op::Migrate, &locked);
+        assert!(
+            risks
+                .iter()
+                .any(|(r, l)| matches!(r, Risk::Locked { .. }) && *l == RiskLevel::Severe),
+            "a locked guest must raise Locked at Severe, so the mutation is \
+             refused without --allow-risk; got {risks:?}"
+        );
+
+        // The control case: the same guest without the lock must not
+        // raise it, or the assertion above would pass for the wrong
+        // reason.
+        let clean = Guest {
+            vmid: 100,
+            node: "pve1".into(),
+            ..Default::default()
+        };
+        assert!(!clean.is_locked());
+        assert!(
+            !assess(Op::Migrate, &clean)
+                .iter()
+                .any(|(r, _)| matches!(r, Risk::Locked { .. })),
+            "an unlocked guest must not raise Locked"
+        );
     }
 }
 
@@ -533,16 +566,22 @@ mod logging {
     /// and `max_log_files(14)`. We pin the const independently.
     #[test]
     fn tracing_appender_rotation_capped_at_14_files() {
-        // The 04-row's contract is "max 14 daily-rotated files".
-        // We pin via the same builder configuration proxxx uses.
-        let _builder = tracing_appender::rolling::Builder::new()
-            .rotation(tracing_appender::rolling::Rotation::DAILY)
-            .max_log_files(14)
-            .filename_prefix("proxxx-test")
-            .filename_suffix("log");
-        // The builder accepts our config (compile-time + runtime).
-        // Real file-rollover behaviour is tested by tracing_appender's
-        // own suite; we attest the proxxx-side wiring.
+        // Audit #273 — this used to build a `tracing_appender` builder
+        // with the same settings, bind it to `_builder`, and assert
+        // nothing about proxxx. It tested the library.
+        //
+        // The claim is about proxxx's own wiring, so assert against
+        // proxxx's own source: the cap must be present, daily, and 14.
+        const MAIN: &str = include_str!("../src/main.rs");
+        assert!(
+            MAIN.contains(".max_log_files(14)"),
+            "main.rs must cap the rotating log at 14 files — without it a daemon \
+             on a flapping network fills the disk"
+        );
+        assert!(
+            MAIN.contains("Rotation::DAILY"),
+            "the cap is 14 DAILY files; another rotation unit changes what 14 means"
+        );
         const MAX_LOG_FILES: usize = 14;
         assert_eq!(MAX_LOG_FILES, 14);
     }


### PR DESCRIPTION
Closes the remediation milestone from the 2026-09-09 full-repo audit: **36 of 36 findings**, in 8 fix commits plus the release bump.

The audit scored `32e10020` at **59/100**, capped by one confirmed high finding — the HITL approver was never authenticated. That one is fixed here, along with the other 35 that had a concrete, bounded fix.

## Read this before merging

Four **behavioural breaks**, each with its migration in the changelog:

| Change | Migration |
|---|---|
| HITL daemon refuses every callback without `allowed_approvers` | Add the approving Telegram **numeric** user ids to `[telegram]` |
| `verify_tls` defaults to `true` | Homelab clusters need an explicit `verify_tls = false`, or `tls_pin_mode = "tofu"` |
| Unrecognised `auth` / `tls_pin_mode` no longer starts | Fix the typo; the error names the key and its accepted values |
| `Policy.require` is enforced | None if you used `require = 1`; otherwise the quorum now applies |

Hence **minor, not patch**. CLI commands and exit codes are unchanged — the project's contract treats those as strictly SemVer — but a config that used to start and now does not is not a patch.

## What is in it

Grouped by what a reviewer would care about; issue numbers link the detail.

**Security** — approver authentication and a real N-of-M quorum (#249, #250); an unreadable freeze lock now refuses instead of silently disarming the write kill-switch (#252); path segments percent-encoded across all 111 sites plus a traversal guard at the transport (#253); MCP string parameters constrained and the constraint published in `tools/list` (#254); audit actor anchored on `getuid()` rather than `$USER` (#256); MCP auth as a router layer (#258); `--token-secret-file` so the credential stays out of `ps` (#283); the audit key is rotatable without invalidating history, and `doctor` actually verifies the chain (#281).

**Correctness** — a state family the document never mentions is no longer read as "delete everything in it" (#259); unknown fields rejected (#262); duplicate identities refused (#261); `schema_version` on the state document (#263); `get_guest_status` stops labelling every container as a QEMU VM (#260); the daemon supervises its pillars instead of running on with a dead one (#264); an interrupted converge leaves an audit record (#265); a per-node listing failure is reported as indeterminate rather than "Guest not found" (#266); atomic writes fsync the parent directory (#268).

**Operability** — logs reach `journalctl` and `RUST_LOG` works (#270); `proxxx_daemon_component_up` (#271); guest lookup is one request instead of 1+2N (#276); the TUI refresh adapts and says when it is lagging (#277); `describe` says which sections it could not read (#278).

**Verification** — `clippy -D warnings` armed, with no backlog (#272); ruff, shellcheck and gitleaks gates (#274); a coverage job and an on-demand live-tier workflow (#275); npm watched and gated (#280); two tests that could not fail now can (#273).

**Contract and docs** — reproducible release tarballs (#279); the library API declared as a supported surface (#284); ARCHITECTURE.md corrected (#282); upgrade/rollback/backup added to the production checklist (#269).

## Verification

All green locally on the head commit:

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | 0 errors |
| `cargo test --all-targets` | **1283 passed**, 0 failed |
| `ruff check .` | clean |
| `shellcheck -S error` | clean |
| `npm audit --audit-level=high` | 0 vulnerabilities |
| `cargo deny check` | advisories ok, bans ok, licenses ok, sources ok |
| `cargo audit --deny warnings` | clean |

~60 new tests. Where a fix could only be asserted structurally (the daemon's `select!`, the router layer) the test says so and explains why, rather than pretending to be behavioural.

## Three things worth knowing

1. **The audit's own recommendation for #253 would have broken production.** It said "wrap every path segment in `urlenc()`". Applied literally that percent-encodes `:` and `@`, which are legal inside a path segment (RFC 3986 `pchar`) and appear in every UPID — the wiremock suite caught it immediately. The fix uses a more permissive `urlenc_segment`, with `urlenc` kept for query values.

2. **#262 makes part of #259 redundant.** With `deny_unknown_fields`, a mistyped section header is a parse error and never reaches the diff. The `declared_families` work still matters for the different case: a family legitimately omitted, e.g. dropped in a branch merge.

3. **Two judgement calls that differ from the audit's suggested fix.** For #257 the audit offered "correct the docs or the code"; I corrected the docs and added a warning when both secret sources are set — inverting the precedence would silently change which credential a live deployment authenticates with, which is worse than the bug. For #272 the audit assumed "a handful" of functions over the line limit; there are 44, and all 44 now carry an explicit per-function `#[allow]` rather than a global silence.

## Also included

`der` 0.8.0 → 0.8.2 and `wnaf` 0.14.0 → 0.14.1, both yanked upstream and reached transitively through russh. Pre-existing drift — both were already in `Cargo.lock` at `32e10020` and the lockfile was otherwise untouched by this branch — but it had `cargo deny` red, so it is fixed here.

## Not included

The audit produced 72 findings; 36 had a fix concrete enough to act on and are all here. The rest were observations without a bounded change (measurements, limitations, and dimension reasoning) and were not filed as issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
