### PR TITLE
security: build the docs on a hosted runner, not a self-hosted one

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,13 @@ concurrency:
 jobs:
   build:
     name: Build VitePress
-    runs-on: [self-hosted, Linux, X64]
+    # Hosted, deliberately. This job builds on `pull_request`, proxxx is
+    # a public repo, and `[self-hosted, Linux, X64]` names no
+    # distinguishing label — so it matched *any* runner attached to the
+    # repo, and a fork PR touching `docs/**` could reach whichever
+    # machine that happened to be. Nothing here needs a private host:
+    # `npm ci` + `npx vitepress build` run identically on ubuntu-latest.
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -98,7 +104,9 @@ jobs:
     # Push to main only — PRs build but don't deploy.
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: build
-    runs-on: [self-hosted, Linux, X64]
+    # Hosted for the same reason as `build`, and this job additionally
+    # holds the github-pages deployment credential.
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ SemVer contract:
 
 ## [Unreleased]
 
+### Security
+
+- **The docs workflow moved off the self-hosted runner.** `docs.yml`
+  declared `runs-on: [self-hosted, Linux, X64]` — labels that name no
+  particular machine, so the job matched *any* self-hosted runner
+  attached to the repo. It builds on `pull_request`, and proxxx is
+  public, so a fork PR touching `docs/**` could execute on whichever
+  runner happened to be registered. Both jobs now run on
+  `ubuntu-latest`; `npm ci` + `npx vitepress build` never needed a
+  private host, and the deploy job additionally holds the `github-pages`
+  credential.
+
+
 ### Changed
 
 - **The live tier moved off GitHub Actions and onto a LAN-only box.**


### PR DESCRIPTION
Follow-up to #287, from auditing where self-hosted runners are actually used.

## The problem

`docs.yml` declared:

```yaml
runs-on: [self-hosted, Linux, X64]
```

Those labels name no particular machine. The job matched **any** self-hosted runner attached to this repo — and it builds on `pull_request`, on a **public** repo. So the fork-PR approval policy (`first_time_contributors`) was the only thing between a fork PR touching `docs/**` and code execution on whichever runner happened to be registered.

That included, for the few hours it existed, the box holding live PVE cluster credentials that #287 removed. The generic labels are why #287's reasoning was incomplete: I checked that nothing requested the `proxxx-live` label, but `docs.yml` never needed that label to land there.

## The fix

Both jobs move to `ubuntu-latest`. Nothing in them needs a private host — `npm ci`, `npm audit --audit-level=high`, `npx vitepress build`, `actions/deploy-pages`. The deploy job additionally carries the `github-pages` deployment credential, which is not something to hand to a shared machine.

With this merged, **no proxxx workflow requests a self-hosted runner**, so `runner-02-homelab` can be detached from the repo entirely — which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)